### PR TITLE
rename list to list_ to avoid shadowing in github_hooks module

### DIFF
--- a/source_control/github_hooks.py
+++ b/source_control/github_hooks.py
@@ -69,7 +69,7 @@ EXAMPLES = '''
 - local_action: github_hooks action=cleanall user={{ gituser }} oauthkey={{ oauthkey }} repo={{ repo }}
 '''
 
-def list(module, hookurl, oauthkey, repo, user):
+def list_(module, hookurl, oauthkey, repo, user):
     url = "%s/hooks" % repo
     auth = base64.encodestring('%s:%s' % (user, oauthkey)).replace('\n', '')
     headers = {
@@ -82,7 +82,7 @@ def list(module, hookurl, oauthkey, repo, user):
         return False, response.read()
 
 def clean504(module, hookurl, oauthkey, repo, user):
-    current_hooks = list(hookurl, oauthkey, repo, user)[1]
+    current_hooks = list_(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
     for hook in decoded:
@@ -94,7 +94,7 @@ def clean504(module, hookurl, oauthkey, repo, user):
     return 0, current_hooks
 
 def cleanall(module, hookurl, oauthkey, repo, user):
-    current_hooks = list(hookurl, oauthkey, repo, user)[1]
+    current_hooks = list_(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
     for hook in decoded:
@@ -154,7 +154,7 @@ def main():
     user = module.params['user']
 
     if action == "list":
-        (rc, out) = list(module, hookurl, oauthkey, repo, user)
+        (rc, out) = list_(module, hookurl, oauthkey, repo, user)
 
     if action == "clean504":
         (rc, out) = clean504(module, hookurl, oauthkey, repo, user)


### PR DESCRIPTION
The definition was leaking into ansible.module_utils.basic and causing
type checking to fail when running module as script.  Not entirely clear
why this should be the case.
