### PR TITLE
make it possible to configure the content type of a github webhook

### DIFF
--- a/source_control/github_hooks.py
+++ b/source_control/github_hooks.py
@@ -57,6 +57,12 @@ options:
     required: false
     default: 'yes'
     choices: ['yes', 'no']
+  content_type:
+    description:
+      - Content type to use for requests made to the webhook
+    required: false
+    default: 'json'
+    choices: ['json', 'form']
 
 author: Phillip Gentry, CX Inc
 '''
@@ -105,14 +111,14 @@ def cleanall(module, hookurl, oauthkey, repo, user):
             
     return 0, current_hooks
 
-def create(module, hookurl, oauthkey, repo, user):
+def create(module, hookurl, oauthkey, repo, user, content_type):
     url = "%s/hooks" % repo
     values = {
         "active": True,
         "name": "web",
         "config": {
             "url": "%s" % hookurl,
-            "content_type": "json"
+            "content_type": "%s" % content_type
             }
         }
     data = json.dumps(values)
@@ -144,6 +150,7 @@ def main():
         repo=dict(required=True),
         user=dict(required=True),
         validate_certs=dict(default='yes', type='bool'),
+        content_type=dict(default='json', choices=['json', 'form']),
         )
     )
 
@@ -152,6 +159,7 @@ def main():
     oauthkey = module.params['oauthkey']
     repo = module.params['repo']
     user = module.params['user']
+    content_type = module.params['content_type']
 
     if action == "list":
         (rc, out) = list_(module, hookurl, oauthkey, repo, user)
@@ -163,7 +171,7 @@ def main():
         (rc, out) = cleanall(module, hookurl, oauthkey, repo, user)
 
     if action == "create":
-        (rc, out) = create(module, hookurl, oauthkey, repo, user)
+        (rc, out) = create(module, hookurl, oauthkey, repo, user, content_type)
 
     if rc != 0:
         module.fail_json(msg="failed", result=out)

--- a/source_control/github_hooks.py
+++ b/source_control/github_hooks.py
@@ -75,7 +75,7 @@ EXAMPLES = '''
 - local_action: github_hooks action=cleanall user={{ gituser }} oauthkey={{ oauthkey }} repo={{ repo }}
 '''
 
-def list_(module, hookurl, oauthkey, repo, user):
+def _list(module, hookurl, oauthkey, repo, user):
     url = "%s/hooks" % repo
     auth = base64.encodestring('%s:%s' % (user, oauthkey)).replace('\n', '')
     headers = {
@@ -88,7 +88,7 @@ def list_(module, hookurl, oauthkey, repo, user):
         return False, response.read()
 
 def clean504(module, hookurl, oauthkey, repo, user):
-    current_hooks = list_(hookurl, oauthkey, repo, user)[1]
+    current_hooks = _list(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
     for hook in decoded:
@@ -100,7 +100,7 @@ def clean504(module, hookurl, oauthkey, repo, user):
     return 0, current_hooks
 
 def cleanall(module, hookurl, oauthkey, repo, user):
-    current_hooks = list_(hookurl, oauthkey, repo, user)[1]
+    current_hooks = _list(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
     for hook in decoded:
@@ -162,7 +162,7 @@ def main():
     content_type = module.params['content_type']
 
     if action == "list":
-        (rc, out) = list_(module, hookurl, oauthkey, repo, user)
+        (rc, out) = _list(module, hookurl, oauthkey, repo, user)
 
     if action == "clean504":
         (rc, out) = clean504(module, hookurl, oauthkey, repo, user)

--- a/source_control/github_hooks.py
+++ b/source_control/github_hooks.py
@@ -69,7 +69,7 @@ EXAMPLES = '''
 - local_action: github_hooks action=cleanall user={{ gituser }} oauthkey={{ oauthkey }} repo={{ repo }}
 '''
 
-def list(module, hookurl, oauthkey, repo, user):
+def list_(module, hookurl, oauthkey, repo, user):
     url = "%s/hooks" % repo
     auth = base64.encodestring('%s:%s' % (user, oauthkey)).replace('\n', '')
     headers = {
@@ -82,7 +82,7 @@ def list(module, hookurl, oauthkey, repo, user):
         return False, response.read()
 
 def clean504(module, hookurl, oauthkey, repo, user):
-    current_hooks = list(hookurl, oauthkey, repo, user)[1]
+    current_hooks = list_(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
     for hook in decoded:
@@ -94,7 +94,7 @@ def clean504(module, hookurl, oauthkey, repo, user):
     return 0, current_hooks
 
 def cleanall(module, hookurl, oauthkey, repo, user):
-    current_hooks = list(hookurl, oauthkey, repo, user)[1]
+    current_hooks = list_(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
     for hook in decoded:
@@ -154,7 +154,7 @@ def main():
     user = module.params['user']
 
     if action == "list":
-        (rc, out) = list(module, hookurl, oauthkey, repo, user)
+        (rc, out) = list_(module, hookurl, oauthkey, repo, user)
 
     if action == "clean504":
         (rc, out) = clean504(module, hookurl, oauthkey, repo, user)

--- a/source_control/github_hooks.py
+++ b/source_control/github_hooks.py
@@ -87,7 +87,7 @@ def _list(module, hookurl, oauthkey, repo, user):
     else:
         return False, response.read()
 
-def clean504(module, hookurl, oauthkey, repo, user):
+def _clean504(module, hookurl, oauthkey, repo, user):
     current_hooks = _list(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
@@ -95,11 +95,11 @@ def clean504(module, hookurl, oauthkey, repo, user):
         if hook['last_response']['code'] == 504:
             # print "Last response was an ERROR for hook:"
             # print hook['id']
-            delete(module, hookurl, oauthkey, repo, user, hook['id'])
+            _delete(module, hookurl, oauthkey, repo, user, hook['id'])
             
     return 0, current_hooks
 
-def cleanall(module, hookurl, oauthkey, repo, user):
+def _cleanall(module, hookurl, oauthkey, repo, user):
     current_hooks = _list(hookurl, oauthkey, repo, user)[1]
     decoded = json.loads(current_hooks)
 
@@ -107,11 +107,11 @@ def cleanall(module, hookurl, oauthkey, repo, user):
         if hook['last_response']['code'] != 200:
             # print "Last response was an ERROR for hook:"
             # print hook['id']
-            delete(module, hookurl, oauthkey, repo, user, hook['id'])
+            _delete(module, hookurl, oauthkey, repo, user, hook['id'])
             
     return 0, current_hooks
 
-def create(module, hookurl, oauthkey, repo, user, content_type):
+def _create(module, hookurl, oauthkey, repo, user, content_type):
     url = "%s/hooks" % repo
     values = {
         "active": True,
@@ -132,7 +132,7 @@ def create(module, hookurl, oauthkey, repo, user, content_type):
     else:
         return 0, response.read()
 
-def delete(module, hookurl, oauthkey, repo, user, hookid):
+def _delete(module, hookurl, oauthkey, repo, user, hookid):
     url = "%s/hooks/%s" % (repo, hookid)
     auth = base64.encodestring('%s:%s' % (user, oauthkey)).replace('\n', '')
     headers = {
@@ -165,13 +165,13 @@ def main():
         (rc, out) = _list(module, hookurl, oauthkey, repo, user)
 
     if action == "clean504":
-        (rc, out) = clean504(module, hookurl, oauthkey, repo, user)
+        (rc, out) = _clean504(module, hookurl, oauthkey, repo, user)
 
     if action == "cleanall":
-        (rc, out) = cleanall(module, hookurl, oauthkey, repo, user)
+        (rc, out) = _cleanall(module, hookurl, oauthkey, repo, user)
 
     if action == "create":
-        (rc, out) = create(module, hookurl, oauthkey, repo, user, content_type)
+        (rc, out) = _create(module, hookurl, oauthkey, repo, user, content_type)
 
     if rc != 0:
         module.fail_json(msg="failed", result=out)


### PR DESCRIPTION
(Depends on (and includes) https://github.com/ansible/ansible-modules-extras/pull/8 as I wasn't able to test it without fixing shadowing imports first)

Adds `content_type` argument to `github_hooks` module to allow user to choose between json and form encoding for requests from github.  Default is kept as json so it should not break backwards compatibility.

The patch changes the signature of `create` so that it no longer matches the other commands in the module.  I also haven't spent too much thought about argument ordering.  I'm happy to try to make things match if you are unhappy with the style.
