### PR TITLE
mkfs.xfs uses -f instead of -F flag

### DIFF
--- a/system/filesystem.py
+++ b/system/filesystem.py
@@ -97,7 +97,7 @@ def main():
         cmd = None
         if fstype in ['ext2', 'ext3', 'ext4', 'ext4dev']:
           force_flag="-F"
-        elif fstype in ['btrfs']:
+        elif fstype in ['xfs', 'btrfs']:
           force_flag="-f"
         else:
           force_flag=""


### PR DESCRIPTION
mkfs.xfs uses the -f instead of -F flag to force creating a filesystem on a devices that have an existing filesystem
