### PR TITLE
Fix composer module checkmode

### DIFF
--- a/packaging/language/composer.py
+++ b/packaging/language/composer.py
@@ -138,6 +138,7 @@ def main():
 
     if module.check_mode:
         options.add("--dry-run")
+        del module.params['CHECKMODE']
 
     # Get composer command with fallback to default  
     command = module.params['command']


### PR DESCRIPTION
Hi,

While writing and testing playbooks using the composer module, I ran into two issues:
- check mode didn't work, even if it seems supported
- the changed status detection test was not valid

I propose this simple pull request to address those issues.

I've rewritten the way options are parsed and handled to be more consistent with the way other modules work (gem for example), since it was this origin of the check mode problem. I hope it's more appropriate now.

Note: original request was https://github.com/ansible/ansible/pull/8304
