### PR TITLE
Ansible is verbose when MySQLdb library import fails

### DIFF
--- a/database/mysql_replication.py
+++ b/database/mysql_replication.py
@@ -123,10 +123,10 @@ import warnings
 
 try:
     import MySQLdb
-except ImportError:
-    mysqldb_found = False
+except ImportError, e:
+    mysqldb_import_error = e
 else:
-    mysqldb_found = True
+    mysqldb_import_error = None
 
 
 def get_master_status(cursor):
@@ -268,8 +268,8 @@ def main():
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
 
-    if not mysqldb_found:
-        module.fail_json(msg="the python mysqldb module is required")
+    if mysqldb_import_error is not None:
+        module.fail_json(msg="the python mysqldb module failed to import: %s" % mysqldb_import_error)
     else:
         warnings.filterwarnings('error', category=MySQLdb.Warning)
 


### PR DESCRIPTION
Ansible displays error message from mysqldb library imports, thus correctly indicating what kind of issue mysqldb library has - i.e. missing, invalid version, link error, etc.
