### PR TITLE
composer: Fix `changed` status that always returns False

### DIFF
--- a/packaging/composer.py
+++ b/packaging/composer.py
@@ -101,7 +101,10 @@ def parse_out(string):
     return re.sub("\s+", " ", string).strip()
 
 def has_changed(string):
-    return (re.match("Nothing to install or update", string) != None)
+    if "Nothing to install or update" in string:
+        return False
+    else:
+        return True
 
 def composer_install(module, command, options):
     php_path      = module.get_bin_path("php", True, ["/usr/local/bin"])


### PR DESCRIPTION
re.match in has_changed function never worked properly, because match
requires searched sequence to be present exactly at a start of processed
string, which is not the case here:

```
 "msg": "Loading composer repositories with package information Installing dependencies from lock file Nothing to install or update Generating optimized autoload files"
```
