### PR TITLE
Facter module should return custom facts

### DIFF
--- a/system/facter.py
+++ b/system/facter.py
@@ -45,7 +45,7 @@ def main():
         argument_spec = dict()
     )
 
-    cmd = ["/usr/bin/env", "facter", "--json"]
+    cmd = ["/usr/bin/env", "facter", "--puppet", "--json"]
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))
 


### PR DESCRIPTION
The Ansible facter module should return puppet's custom facts by default.

Ansible already autoloads puppet's custom facts via the [core setup module](https://github.com/ansible/ansible-modules-core/blob/devel/system/setup.py#L94) during the fact gathering task.
The Facter module should reflect this behaviour.
