### PR TITLE
Hipchat v2 + legacy v1 support

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -83,6 +83,7 @@ EXAMPLES = '''
 
 V1_MSG_URI = "https://api.hipchat.com/v1/rooms/message"
 
+
 def msg_uri(version, room="notify"):
     ''''message uri based on version'''
     if version == "2":
@@ -95,26 +96,29 @@ def send_msg(module, token, room, msg_from, msg, msg_format='text',
     '''sending message to hipchat'''
 
     params = {}
-    if version == "1":
-        params['room_id'] = room
-        params['from'] = msg_from[:15]  # max length is 15
-        params['api'] = api
     params['message'] = msg
     params['message_format'] = msg_format
     params['color'] = color
 
-    if notify:
-        params['notify'] = 1
-    else:
-        params['notify'] = 0
+    if version == "1":
+        params['room_id'] = room
+        params['api'] = api
+        params['from'] = msg_from[:15]  # max length is 15
+        if notify:
+            params['notify'] = 1
+        else:
+            params['notify'] = 0
 
     url = api + "?auth_token=%s" % (token)
     data = urllib.urlencode(params)
-    response, info = fetch_url(module, url, data=data)
+
+    headers = {'content-type': 'application/x-www-form-urlencoded'}
+
+    response, info = fetch_url(module, url, data=data, headers=headers, method='POST')
     if info['status'] == 200:
         return response.read()
     else:
-        module.fail_json(msg="failed to send message, return status=%s" % str(info))
+        module.fail_json(msg="failed to send message, return status=%s" % str(params))
 
 
 # ===========================================


### PR DESCRIPTION
I updated the hipchat module to work with v2, as well as v1. There is a new module parameter, `version` which can be set to `1` or `2`.

I no longer have a v1 account so I am not able to test if this will still work for v1. If not, it should be minor fixes.

I did not get `notify` to work with the v2 API. It defaults to false.  The API specifies it wants a boolean value but does not accept anything. I tested it in with numeric, string, and boolean values from the plugin code, as well as tested with postman (chrome app).  All values I tested generate a bad request error stating the valid type should be boolean. `notify` will be ignored right now when `version` is set to 2.

The API changes are as follows:
- base changed from: `https://api.hipchat.com/v1` to `https://api.hipchat.com/v2`
- path changed from: `rooms/message` to `room/id_or_name/notification`
- method changed from `POST` or `GET` to `POST` only
- `room_id` is no longer a parameter since it is defined in the path
- `from` is no longer a parameter. This is now the user who owns the token, or the notification label setup with the token.
- `format` is no longer a parameter (not to be confused with `message_format`, which is still valid

V1: https://www.hipchat.com/docs/api/method/rooms/message
V2: https://www.hipchat.com/docs/apiv2/method/send_room_notification
