### PR TITLE
Fix some logical issues with enabling/disabling a server on the A10.

### DIFF
--- a/network/a10/a10_server.py
+++ b/network/a10/a10_server.py
@@ -251,9 +251,7 @@ def main():
             # - in case ports are missing from the ones specified by the user
             # - in case ports are missing from those on the device
             # - in case we are change the status of a server
-            if port_needs_update(defined_ports, slb_server_ports)
-              or port_needs_update(slb_server_ports, defined_ports)
-              or status_needs_update(current_status, axapi_enabled_disabled(slb_server_status)):
+            if port_needs_update(defined_ports, slb_server_ports) or port_needs_update(slb_server_ports, defined_ports) or status_needs_update(current_status, axapi_enabled_disabled(slb_server_status)):
                 result = axapi_call(module, session_url + '&method=slb.server.update', json.dumps(json_post))
                 if axapi_failure(result):
                     module.fail_json(msg="failed to update the server: %s" % result['response']['err']['msg'])

--- a/network/a10/a10_server.py
+++ b/network/a10/a10_server.py
@@ -183,28 +183,35 @@ def main():
 
     json_post = {
         'server': {
-            'name': slb_server, 
-            'host': slb_server_ip, 
-            'status': axapi_enabled_disabled(slb_server_status),
-            'port_list': slb_server_ports,
+            'name': slb_server,
         }
     }
+
+    # add optional module parameters
+    if slb_server_ip:
+        json_post['server']['host'] = slb_server_ip
+
+    if slb_server_ports:
+        json_post['server']['port_list'] = slb_server_ports
+
+    if slb_server_status:
+        json_post['server']['status'] = axapi_enabled_disabled(slb_server_status)
 
     slb_server_data = axapi_call(module, session_url + '&method=slb.server.search', json.dumps({'name': slb_server}))
     slb_server_exists = not axapi_failure(slb_server_data)
 
     changed = False
     if state == 'present':
-        if not slb_server_ip:
-            module.fail_json(msg='you must specify an IP address when creating a server')
-
         if not slb_server_exists:
+            if not slb_server_ip:
+                module.fail_json(msg='you must specify an IP address when creating a server')
+
             result = axapi_call(module, session_url + '&method=slb.server.create', json.dumps(json_post))
             if axapi_failure(result):
                 module.fail_json(msg="failed to create the server: %s" % result['response']['err']['msg'])
             changed = True
         else:
-            def needs_update(src_ports, dst_ports):
+            def port_needs_update(src_ports, dst_ports):
                 '''
                 Checks to determine if the port definitions of the src_ports
                 array are in or different from those in dst_ports. If there is
@@ -227,12 +234,26 @@ def main():
                 # every port from the src exists in the dst, and none of them were different
                 return False
 
-            defined_ports = slb_server_data.get('server', {}).get('port_list', [])
+            def status_needs_update(current_status, new_status):
+                '''
+                Check to determine if we want to change the status of a server.
+                If there is a difference between the current status of the server and
+                the desired status, return true, otherwise false.
+                '''
+                if current_status != new_status:
+                    return True
+                return False
 
-            # we check for a needed update both ways, in case ports
-            # are missing from either the ones specified by the user
-            # or from those on the device
-            if needs_update(defined_ports, slb_server_ports) or needs_update(slb_server_ports, defined_ports):
+            defined_ports = slb_server_data.get('server', {}).get('port_list', [])
+            current_status = slb_server_data.get('server', {}).get('status')
+
+            # we check for a needed update several ways
+            # - in case ports are missing from the ones specified by the user
+            # - in case ports are missing from those on the device
+            # - in case we are change the status of a server
+            if port_needs_update(defined_ports, slb_server_ports)
+              or port_needs_update(slb_server_ports, defined_ports)
+              or status_needs_update(current_status, axapi_enabled_disabled(slb_server_status)):
                 result = axapi_call(module, session_url + '&method=slb.server.update', json.dumps(json_post))
                 if axapi_failure(result):
                     module.fail_json(msg="failed to update the server: %s" % result['response']['err']['msg'])
@@ -249,10 +270,10 @@ def main():
             result = axapi_call(module, session_url + '&method=slb.server.delete', json.dumps({'name': slb_server}))
             changed = True
         else:
-            result = dict(msg="the  server was not present")
+            result = dict(msg="the server was not present")
 
-    # if the config has changed, save the config unless otherwise requested
-    if changed and write_config:
+    # if the config has changed, or we want to force a save, save the config unless otherwise requested
+    if changed or write_config:
         write_result = axapi_call(module, session_url + '&method=system.action.write_memory')
         if axapi_failure(write_result):
             module.fail_json(msg="failed to save the configuration: %s" % write_result['response']['err']['msg'])


### PR DESCRIPTION
Hello,

I tried testing the A10 module and ran into a few issues.  I'm hoping perhaps these changes will get accepted.  Specifically the problems I ran into were
- When trying to enable/disable a server on the A10, both the server name and IP address had to be specified.  If the IP address was not specified in the playbook, the code would fail thinking you were trying to "create a server" and this was required. If you only want to enable/disable a server, which is a pretty simple thing that happens a LOT, this code will make it easier to do that.  See lines 198-200.
- Add a new function to determine if the status of a server needs to be updated.  See additional lines 237-246.
- Only add optional parameters to the json_post array if they were specified in the module as parameters.  My AXAPI calls were including a ports parameter when they didn't need one.  See additional lines 190-199.
- The a10_server.py code is looking for a module parameter called "write_config", but the documentation doesn't mention that.  Make that an optional parameter, or perhaps just update the documentation.  Either way, this code allows you to be more flexible.  See lines 254-255.

Hope this helps others!

Jason
