### PR TITLE
gtid_replication parameter added 

### DIFF
--- a/database/mysql/mysql_replication.py
+++ b/database/mysql/mysql_replication.py
@@ -106,7 +106,6 @@ options:
     master_auto_position:
         descrtiption:
             - does the host uses GTID based replication or not
-        possible values: 0,1
 '''
 
 EXAMPLES = '''
@@ -235,7 +234,7 @@ def main():
             login_host=dict(default="localhost"),
             login_unix_socket=dict(default=None),
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave"]),
-            master_auto_position=dict(default=None, choices=['0', '1']),
+            master_auto_position=dict(default=False, type='bool'),
             master_host=dict(default=None),
             master_user=dict(default=None),
             master_password=dict(default=None),

--- a/database/mysql/mysql_replication.py
+++ b/database/mysql/mysql_replication.py
@@ -103,7 +103,7 @@ options:
     master_ssl_cipher:
         description:
             - same as mysql variable
-    gtid_replication:
+    master_auto_position:
         descrtiption:
             - does the host uses GTID based replication or not
         possible values: 0,1
@@ -235,7 +235,7 @@ def main():
             login_host=dict(default="localhost"),
             login_unix_socket=dict(default=None),
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave"]),
-            gtid_replication=dict(default=None, choices=['0', '1']),
+            master_auto_position=dict(default=None, choices=['0', '1']),
             master_host=dict(default=None),
             master_user=dict(default=None),
             master_password=dict(default=None),
@@ -272,7 +272,7 @@ def main():
     master_ssl_cert = module.params["master_ssl_cert"]
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
-    gtid_replication = module.params["gtid_replication"]
+    master_auto_position = module.params["master_auto_position"]
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -369,7 +369,7 @@ def main():
         if master_ssl_cipher:
             chm.append("MASTER_SSL_CIPHER=%(master_ssl_cipher)s")
             chm_params['master_ssl_cipher'] = master_ssl_cipher
-        if gtid_replication:
+        if master_auto_position:
             chm.append("MASTER_AUTO_POSITION = 1")
         changemaster(cursor, chm, chm_params)
         module.exit_json(changed=True)

--- a/database/mysql/mysql_replication.py
+++ b/database/mysql/mysql_replication.py
@@ -103,7 +103,10 @@ options:
     master_ssl_cipher:
         description:
             - same as mysql variable
-
+    gtid_replication:
+        descrtiption:
+            - does the host uses GTID based replication or not
+        possible values: 0,1
 '''
 
 EXAMPLES = '''
@@ -232,6 +235,7 @@ def main():
             login_host=dict(default="localhost"),
             login_unix_socket=dict(default=None),
             mode=dict(default="getslave", choices=["getmaster", "getslave", "changemaster", "stopslave", "startslave"]),
+            gtid_replication=dict(default=None, choices=['0', '1']),
             master_host=dict(default=None),
             master_user=dict(default=None),
             master_password=dict(default=None),
@@ -268,6 +272,7 @@ def main():
     master_ssl_cert = module.params["master_ssl_cert"]
     master_ssl_key = module.params["master_ssl_key"]
     master_ssl_cipher = module.params["master_ssl_cipher"]
+    gtid_replication = module.params["gtid_replication"]
 
     if not mysqldb_found:
         module.fail_json(msg="the python mysqldb module is required")
@@ -364,6 +369,8 @@ def main():
         if master_ssl_cipher:
             chm.append("MASTER_SSL_CIPHER=%(master_ssl_cipher)s")
             chm_params['master_ssl_cipher'] = master_ssl_cipher
+        if gtid_replication:
+            chm.append("MASTER_AUTO_POSITION = 1")
         changemaster(cursor, chm, chm_params)
         module.exit_json(changed=True)
     elif mode in "startslave":


### PR DESCRIPTION
Environments where MySQL uses GTID replication cannot managed with the original module, because there is a 'MASTER_AUTO_POSITION = 1' switch in all the CHANGE MASTER TO ... commands. 
