### PR TITLE
Removed references to slack domain (no longer relevant)

### DIFF
--- a/notification/slack.py
+++ b/notification/slack.py
@@ -33,7 +33,7 @@ options:
     required: false    
   token:
     description:
-      - Slack integration token
+      - The token part of the Webhook URL, i.e. https://hooks.slack.com/services/C(thetoken/generated/byslack)
     required: true
   msg:
     description:
@@ -81,19 +81,24 @@ options:
     choices:
       - 'yes'
       - 'no'
+notes:
+  - Due to a change in the Slack API, the C(domain) parameter for this module was deprecated.
 """
 
 EXAMPLES = """
+The token can be found in the SlackHQ interface when configuring an Incoming WebHook.
+https://hooks.slack.com/services/`thetoken/generated/byslack`
+
 - name: Send notification message via Slack
   local_action:
     module: slack
-    token: thetokengeneratedbyslack
+    token: thetoken/generated/byslack
     msg: "{{ inventory_hostname }} completed"
 
 - name: Send notification message via Slack all options
   local_action:
     module: slack
-    token: thetokengeneratedbyslack
+    token: thetoken/generated/byslack
     msg: "{{ inventory_hostname }} completed"
     channel: "#ansible"
     username: "Ansible on {{ inventory_hostname }}"

--- a/notification/slack.py
+++ b/notification/slack.py
@@ -26,11 +26,6 @@ description:
 version_added: 1.6
 author: Ramon de la Fuente <ramon@delafuente.nl>
 options:
-  domain:
-    description:
-      - Slack (sub)domain for your environment without protocol.
-        (i.e. C(future500.slack.com))
-    required: true
   token:
     description:
       - Slack integration token
@@ -87,14 +82,12 @@ EXAMPLES = """
 - name: Send notification message via Slack
   local_action:
     module: slack
-    domain: future500.slack.com
     token: thetokengeneratedbyslack
     msg: "{{ inventory_hostname }} completed"
 
 - name: Send notification message via Slack all options
   local_action:
-    module: slack
-    domain: future500.slack.com
+    module: slackdo
     token: thetokengeneratedbyslack
     msg: "{{ inventory_hostname }} completed"
     channel: "#ansible"
@@ -126,7 +119,7 @@ def build_payload_for_slack(module, text, channel, username, icon_url, icon_emoj
     payload="payload=" + module.jsonify(payload)
     return payload
 
-def do_notify_slack(module, domain, token, payload):
+def do_notify_slack(module, token, payload):
     slack_incoming_webhook = SLACK_INCOMING_WEBHOOK % (token)
 
     response, info = fetch_url(module, slack_incoming_webhook, data=payload)
@@ -137,7 +130,6 @@ def do_notify_slack(module, domain, token, payload):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            domain      = dict(type='str', required=True),
             token       = dict(type='str', required=True),
             msg         = dict(type='str', required=True),
             channel     = dict(type='str', default=None),
@@ -151,7 +143,6 @@ def main():
         )
     )
 
-    domain = module.params['domain']
     token = module.params['token']
     text = module.params['msg']
     channel = module.params['channel']
@@ -162,7 +153,7 @@ def main():
     parse = module.params['parse']
 
     payload = build_payload_for_slack(module, text, channel, username, icon_url, icon_emoji, link_names, parse)
-    do_notify_slack(module, domain, token, payload)
+    do_notify_slack(module, token, payload)
 
     module.exit_json(msg="OK")
 

--- a/notification/slack.py
+++ b/notification/slack.py
@@ -26,6 +26,11 @@ description:
 version_added: 1.6
 author: Ramon de la Fuente <ramon@delafuente.nl>
 options:
+  domain:
+    description:
+      - DEPRECATED. Slack (sub)domain for your environment without protocol.
+        (i.e. C(future500.slack.com))
+    required: false    
   token:
     description:
       - Slack integration token
@@ -131,6 +136,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             token       = dict(type='str', required=True),
+            domain      = dict(type='str', default=''),
             msg         = dict(type='str', required=True),
             channel     = dict(type='str', default=None),
             username    = dict(type='str', default='Ansible'),
@@ -144,6 +150,7 @@ def main():
     )
 
     token = module.params['token']
+    domain = module.params['domain']
     text = module.params['msg']
     channel = module.params['channel']
     username = module.params['username']
@@ -155,7 +162,10 @@ def main():
     payload = build_payload_for_slack(module, text, channel, username, icon_url, icon_emoji, link_names, parse)
     do_notify_slack(module, token, payload)
 
-    module.exit_json(msg="OK")
+    if domain:
+        module.exit_json(msg="OK. Warning: The domain parameter has been deprecated and will be removed in a future Ansible version. Please remove it from this task.")
+    else:
+        module.exit_json(msg="OK.")
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/notification/slack.py
+++ b/notification/slack.py
@@ -87,7 +87,7 @@ EXAMPLES = """
 
 - name: Send notification message via Slack all options
   local_action:
-    module: slackdo
+    module: slack
     token: thetokengeneratedbyslack
     msg: "{{ inventory_hostname }} completed"
     channel: "#ansible"


### PR DESCRIPTION
Slack webhooks now use `hooks.slack.com`, so the domain parameter is irrelevant, but it's still listed as required in the module. This pull request fixes that.
