### PR TITLE
Patch multiple versions rpm zypper

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -95,11 +95,11 @@ def zypper_version(module):
         return rc, stderr
 
 # Function used for getting versions of currently installed packages.
-def get_current_version( packages):
+def get_current_version(m, packages):
     cmd = ['/bin/rpm', '-q', '--qf', '%{NAME} %{VERSION}-%{RELEASE}\n']
     cmd.extend(packages)
 
-    stdout = subprocess.check_output(cmd)
+    rc, stdout, stderr = m.run_command(cmd, check_rc=False)
 
     current_version = {}
     rpmoutput_re = re.compile('^(\S+) (\S+)$')

--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -141,7 +141,7 @@ def get_package_state(m, packages):
             installed_state[package] = False
 
     for package in packages:
-	if package not in installed_state:
+        if package not in installed_state:
             print package + ' was not returned by rpm \n'
             return None
 


### PR DESCRIPTION
Fix bug in ansible get_package_state and get_current_version that breaks when there are multiple versions of a package installed and there is a list of packages to install.
The previous implementation used 'zip' to match requested names to installed names which fails, because rpm outputs multiple lines per package when there are multiple versions.

Testcase: Install opensuse, install multiple kernel versions (happens by update)
Before patch a playbook like the following fails:
zypper: state=present for name={{item}} 
with_items: 
- kernel-desktop
- git

After the patch ansible performs as expected and makes sure both packages are present.
Also the last version number is used for further update information in this version (before if only one package name was given (to not trigger the bug) the oldest version number was used instead of the current).
