### PR TITLE
Make sure portage doesn't ask for confirmation

### DIFF
--- a/packaging/os/portage.py
+++ b/packaging/os/portage.py
@@ -335,6 +335,7 @@ def cleanup_packages(module, packages):
 def run_emerge(module, packages, *args):
     args = list(args)
 
+    args.append('--ask=n')
     if module.check_mode:
         args.append('--pretend')
 


### PR DESCRIPTION
If EMERGE_DEFAULT_OPTS in make.conf(5) contains '--ask' then the portage
module doesn't work correctly, this commit fixes that.
