### PR TITLE
Fix rabbitmq_plugin.py: broken prefix path

### DIFF
--- a/messaging/rabbitmq_plugin.py
+++ b/messaging/rabbitmq_plugin.py
@@ -59,12 +59,23 @@ EXAMPLES = '''
 - rabbitmq_plugin: names=rabbitmq_management state=enabled
 '''
 
+import os
+
 class RabbitMqPlugins(object):
     def __init__(self, module):
         self.module = module
 
         if module.params['prefix']:
-            self._rabbitmq_plugins = module.params['prefix'] + "/sbin/rabbitmq-plugins"
+            if os.path.isdir(os.path.join(module.params['prefix'], 'bin')):
+                bin_path = os.path.join(module.params['prefix'], 'bin')
+            elif os.path.isdir(os.path.join(module.params['prefix'], 'sbin')):
+                bin_path = os.path.join(module.params['prefix'], 'sbin')
+            else:
+                # No such path exists.
+                raise Exception("No binary folder in RabbitMQ prefix")
+
+            self._rabbitmq_plugins = bin_path + "/rabbitmq-plugins"
+
         else:
             self._rabbitmq_plugins = module.get_bin_path('rabbitmq-plugins', True)
 

--- a/messaging/rabbitmq_plugin.py
+++ b/messaging/rabbitmq_plugin.py
@@ -72,7 +72,8 @@ class RabbitMqPlugins(object):
                 bin_path = os.path.join(module.params['prefix'], 'sbin')
             else:
                 # No such path exists.
-                raise Exception("No binary folder in RabbitMQ prefix")
+                raise Exception("No binary folder in prefix %s" %
+                        module.params['prefix'])
 
             self._rabbitmq_plugins = bin_path + "/rabbitmq-plugins"
 


### PR DESCRIPTION
Old code only looks for /sbin while many current distros use /bin in the generic location.
Adding $prefix/bin so that it can find these binaries
