### PR TITLE
removed useless domain parameter to Slack module

### DIFF
--- a/notification/slack.py
+++ b/notification/slack.py
@@ -22,18 +22,14 @@ DOCUMENTATION = """
 module: slack
 short_description: Send Slack notifications
 description:
-    - The M(slack) module sends notifications to U(http://slack.com) via the Incoming WebHook integration
+    - The M(slack) module sends notifications to U(http://slack.com) via the Incoming WebHook integration.
+
 version_added: 1.6
 author: Ramon de la Fuente <ramon@delafuente.nl>
 options:
-  domain:
-    description:
-      - Slack (sub)domain for your environment without protocol.
-        (i.e. C(future500.slack.com))
-    required: true
   token:
     description:
-      - Slack integration token
+      - The token part of the Webhook URL, i.e. https://hooks.slack.com/services/C(thetoken/generated/byslack)
     required: true
   msg:
     description:
@@ -81,21 +77,26 @@ options:
     choices:
       - 'yes'
       - 'no'
+
+notes:
+  - Due to a change in the Slack API, the C(domain) parameter for this module was removed.
 """
 
 EXAMPLES = """
+
+The token can be found in the SlackHQ interface when configuring an Incoming WebHook.
+https://hooks.slack.com/services/`thetoken/generated/byslack`
+
 - name: Send notification message via Slack
   local_action:
     module: slack
-    domain: future500.slack.com
-    token: thetokengeneratedbyslack
+    token: thetoken/generated/byslack
     msg: "{{ inventory_hostname }} completed"
 
 - name: Send notification message via Slack all options
   local_action:
     module: slack
-    domain: future500.slack.com
-    token: thetokengeneratedbyslack
+    token: thetoken/generated/byslack
     msg: "{{ inventory_hostname }} completed"
     channel: "#ansible"
     username: "Ansible on {{ inventory_hostname }}"
@@ -126,7 +127,7 @@ def build_payload_for_slack(module, text, channel, username, icon_url, icon_emoj
     payload="payload=" + module.jsonify(payload)
     return payload
 
-def do_notify_slack(module, domain, token, payload):
+def do_notify_slack(module, token, payload):
     slack_incoming_webhook = SLACK_INCOMING_WEBHOOK % (token)
 
     response, info = fetch_url(module, slack_incoming_webhook, data=payload)
@@ -137,7 +138,6 @@ def do_notify_slack(module, domain, token, payload):
 def main():
     module = AnsibleModule(
         argument_spec = dict(
-            domain      = dict(type='str', required=True),
             token       = dict(type='str', required=True),
             msg         = dict(type='str', required=True),
             channel     = dict(type='str', default=None),
@@ -151,7 +151,6 @@ def main():
         )
     )
 
-    domain = module.params['domain']
     token = module.params['token']
     text = module.params['msg']
     channel = module.params['channel']
@@ -162,7 +161,7 @@ def main():
     parse = module.params['parse']
 
     payload = build_payload_for_slack(module, text, channel, username, icon_url, icon_emoji, link_names, parse)
-    do_notify_slack(module, domain, token, payload)
+    do_notify_slack(module, token, payload)
 
     module.exit_json(msg="OK")
 


### PR DESCRIPTION
The Slack module was updated due to a change in the Slack API. 

https://github.com/ansible/ansible-modules-extras/commit/513eadbd9289c013127b562a61274f56a768edd4#diff-bd8d05bbd5b603181d453fa3bb1ec879

This change left the `domain` parameter as a required parameter - but the parameter was never used.

For 1.9, I propose to remove the parameter and update the documentation accordingly.
