### PR TITLE
Fixed small typo in zabbix group docs

### DIFF
--- a/monitoring/zabbix_group.py
+++ b/monitoring/zabbix_group.py
@@ -36,7 +36,7 @@ options:
         choices: [ 'present', 'absent' ]
     host_group:
         description:
-            - Name of the host groupto be added or removed.
+            - Name of the host group to be added or removed.
         required: true
         default: null
         aliases: [ ]


### PR DESCRIPTION
This pr fixes a small typo in the zabbix group documentation
