### PR TITLE
win_unzip Module

### DIFF
--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -33,7 +33,7 @@ If ($params.src) {
         Fail-Json $result "src file: $src does not exist."
     }
 
-    $ext = [System.IO.Path]::GetExtension($dest)
+    $ext = [System.IO.Path]::GetExtension($src)
 }
 Else {
     Fail-Json $result "missing required argument: src"
@@ -93,7 +93,7 @@ Else {
     If (-Not ($list -match "PSCX")) {
         # Try install with chocolatey
         Try {
-            cinst -force PSCX
+            cinst -force PSCX -y
             $choco = $true
         }
         Catch {
@@ -109,9 +109,7 @@ Else {
                 Fail-Json $result "Error downloading PSCX from $url and saving as $dest"
             }
             Try {
-                msiexec.exe /i $msi /qb
-                # Give it a chance to install, so that it can be imported
-                sleep 10
+                Start-Process -FilePath msiexec.exe -ArgumentList "/i $msi /qb" -Verb Runas -PassThru -Wait | out-null
             }
             Catch {
                 Fail-Json $result "Error installing $msi"
@@ -127,7 +125,12 @@ Else {
     # Import
     Try {
         If ($installed) {
-            Import-Module 'C:\Program Files (x86)\Powershell Community Extensions\pscx3\pscx\pscx.psd1'
+            Try {
+                Import-Module 'C:\Program Files (x86)\Powershell Community Extensions\pscx3\pscx\pscx.psd1'
+            }
+            Catch {
+                Import-Module PSCX
+            }
         }
         Else {
             Import-Module PSCX

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -1,7 +1,7 @@
 #!powershell
 # This file is part of Ansible
 #
-# Copyright 2014, Phil Schwartz <schwartzmx@gmail.com>
+# Copyright 2015, Phil Schwartz <schwartzmx@gmail.com>
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -80,43 +80,13 @@ If ($ext -eq ".zip" -And $recurse -eq $false) {
         Fail-Json $result "Error unzipping $src to $dest"
     }
 }
-# Need PSCX
+# Requires PSCX
 Else {
-    # Requires PSCX, will be installed if it isn't found
-    # Pscx-3.2.0.msi
-    $url = "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=pscx&DownloadId=923562&FileTime=130585918034470000&Build=20959"
-    $msi = "C:\Pscx-3.2.0.msi"
-
     # Check if PSCX is installed
     $list = Get-Module -ListAvailable
-    # If not download it and install
+
     If (-Not ($list -match "PSCX")) {
-        # Try install with chocolatey
-        Try {
-            cinst -force PSCX -y
-            $choco = $true
-        }
-        Catch {
-            $choco = $false
-        }
-        # install from downloaded msi if choco failed or is not present
-        If ($choco -eq $false) {
-            Try {
-                $client = New-Object System.Net.WebClient
-                $client.DownloadFile($url, $msi)
-            }
-            Catch {
-                Fail-Json $result "Error downloading PSCX from $url and saving as $dest"
-            }
-            Try {
-                Start-Process -FilePath msiexec.exe -ArgumentList "/i $msi /qb" -Verb Runas -PassThru -Wait | out-null
-            }
-            Catch {
-                Fail-Json $result "Error installing $msi"
-            }
-        }
-        Set-Attr $result.win_zip "pscx_status" "pscx was installed"
-        $installed = $true
+        Fail-Json "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for non-'.zip' compressed archive types."
     }
     Else {
         Set-Attr $result.win_zip "pscx_status" "present"
@@ -124,17 +94,7 @@ Else {
 
     # Import
     Try {
-        If ($installed) {
-            Try {
-                Import-Module 'C:\Program Files (x86)\Powershell Community Extensions\pscx3\pscx\pscx.psd1'
-            }
-            Catch {
-                Import-Module PSCX
-            }
-        }
-        Else {
-            Import-Module PSCX
-        }
+        Import-Module PSCX
     }
     Catch {
         Fail-Json $result "Error importing module PSCX"

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -26,15 +26,17 @@ $result = New-Object psobject @{
     changed = $false
 }
 
-If ($params.zip) {
-    $zip = $params.zip.toString()
+If ($params.src) {
+    $src = $params.src.toString()
 
-    If (-Not (Test-Path -path $zip)){
-        Fail-Json $result "zip file: $zip does not exist."
+    If (-Not (Test-Path -path $src)){
+        Fail-Json $result "src file: $src does not exist."
     }
+
+    $ext = [System.IO.Path]::GetExtension($dest)
 }
 Else {
-    Fail-Json $result "missing required argument: zip"
+    Fail-Json $result "missing required argument: src"
 }
 
 If (-Not($params.dest -eq $null)) {
@@ -53,22 +55,120 @@ Else {
     Fail-Json $result "missing required argument: dest"
 }
 
-Try {
-    $shell = New-Object -ComObject Shell.Application
-    $shell.NameSpace($dest).copyhere(($shell.NameSpace($zip)).items(), 20)
-    $result.changed = $true
+If ($params.recurse -eq "true" -Or $params.recurse -eq "yes") {
+    $recurse = $true
 }
-Catch {
-    # Used to allow reboot after exe hotfix extraction (Windows 2008 R2 SP1)
-    # This will have no effect in most cases.
-    If (-Not ([System.IO.Path]::GetExtension($zip) -match ".exe")){
-        $result.changed = $false
-        Fail-Json $result "Error unzipping $zip to $dest"
-    }
+Else {
+    $recurse = $false
 }
 
 If ($params.rm -eq "true" -Or $params.rm -eq "yes"){
-    Remove-Item $zip -Recurse -Force
+    $rm = $true
+    Set-Attr $result.win_unzip "rm" "true"
+}
+Else {
+    $rm = $false
+}
+
+If ($ext -eq ".zip" -And $recurse -eq $false) {
+    Try {
+        $shell = New-Object -ComObject Shell.Application
+        $shell.NameSpace($dest).copyhere(($shell.NameSpace($src)).items(), 20)
+        $result.changed = $true
+    }
+    Catch {
+        Fail-Json $result "Error unzipping $src to $dest"
+    }
+}
+# Need PSCX
+Else {
+    # Requires PSCX, will be installed if it isn't found
+    # Pscx-3.2.0.msi
+    $url = "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=pscx&DownloadId=923562&FileTime=130585918034470000&Build=20959"
+    $msi = "C:\Pscx-3.2.0.msi"
+
+    # Check if PSCX is installed
+    $list = Get-Module -ListAvailable
+    # If not download it and install
+    If (-Not ($list -match "PSCX")) {
+        # Try install with chocolatey
+        Try {
+            cinst -force PSCX
+            $choco = $true
+        }
+        Catch {
+            $choco = $false
+        }
+        # install from downloaded msi if choco failed or is not present
+        If ($choco -eq $false) {
+            Try {
+                $client = New-Object System.Net.WebClient
+                $client.DownloadFile($url, $msi)
+            }
+            Catch {
+                Fail-Json $result "Error downloading PSCX from $url and saving as $dest"
+            }
+            Try {
+                msiexec.exe /i $msi /qb
+                # Give it a chance to install, so that it can be imported
+                sleep 10
+            }
+            Catch {
+                Fail-Json $result "Error installing $msi"
+            }
+        }
+        Set-Attr $result.win_zip "pscx_status" "pscx was installed"
+        $installed = $true
+    }
+    Else {
+        Set-Attr $result.win_zip "pscx_status" "present"
+    }
+
+    # Import
+    Try {
+        If ($installed) {
+            Import-Module 'C:\Program Files (x86)\Powershell Community Extensions\pscx3\pscx\pscx.psd1'
+        }
+        Else {
+            Import-Module PSCX
+        }
+    }
+    Catch {
+        Fail-Json $result "Error importing module PSCX"
+    }
+
+    Try {
+        If ($recurse) {
+            Expand-Archive -Path $src -OutputPath $dest -Force
+
+            If ($rm) {
+                Get-ChildItem $dest -recurse | Where {$_.extension -eq ".gz" -Or $_.extension -eq ".zip" -Or $_.extension -eq ".bz2" -Or $_.extension -eq ".tar" -Or $_.extension -eq ".msu"} | % {
+                    Expand-Archive $_.FullName -OutputPath $dest  -Force
+                    Remove-Item $_.FullName -Force
+                }
+            }
+            Else {
+                Get-ChildItem $dest -recurse | Where {$_.extension -eq ".gz" -Or $_.extension -eq ".zip" -Or $_.extension -eq ".bz2" -Or $_.extension -eq ".tar" -Or $_.extension -eq ".msu"} | % {
+                    Expand-Archive $_.FullName -OutputPath $dest  -Force
+                }
+            }
+        }
+        Else {
+            Expand-Archive -Path $src -OutputPath $dest -Force
+        }
+    }
+    Catch {
+        If ($recurse) {
+            Fail-Json "Error recursively expanding $src to $dest"
+        }
+        Else {
+            Fail-Json "Error expanding $src to $dest"
+        }
+    }
+}
+
+If ($rm -eq $true){
+    Remove-Item $src -Recurse -Force
     Set-Attr $result.win_unzip "rm" "true"
 }
 
@@ -77,8 +177,17 @@ If ($params.restart -eq "true" -Or $params.restart -eq "yes") {
     Set-Attr $result.win_unzip "restart" "true"
 }
 
-
-Set-Attr $result.win_unzip "zip" $zip.toString()
+# Fixes a fail error message (when the task actually succeeds) for a "Convert-ToJson: The converted JSON string is in bad format"
+# This happens when JSON is parsing a string that ends with a "\", which is possible when specifying a directory to download to.
+# This catches that possible error, before assigning the JSON $result
+If ($src[$src.length-1] -eq "\") {
+    $src = $src.Substring(0, $src.length-1)
+}
+If ($dest[$dest.length-1] -eq "\") {
+    $dest = $dest.Substring(0, $dest.length-1)
+}
+Set-Attr $result.win_unzip "src" $src.toString()
 Set-Attr $result.win_unzip "dest" $dest.toString()
+Set-Attr $result.win_unzip "recurse" $recurse.toString()
 
 Exit-Json $result;

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -26,6 +26,13 @@ $result = New-Object psobject @{
     changed = $false
 }
 
+If ($params.creates) {
+    If (Test-Path $params.creates) {
+        Exit-Json $result "The 'creates' file or directory already exists."
+    }
+
+}
+
 If ($params.src) {
     $src = $params.src.toString()
 
@@ -86,7 +93,7 @@ Else {
     $list = Get-Module -ListAvailable
 
     If (-Not ($list -match "PSCX")) {
-        Fail-Json "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for non-'.zip' compressed archive types."
+        Fail-Json $result "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for non-'.zip' compressed archive types."
     }
     Else {
         Set-Attr $result.win_unzip "pscx_status" "present"
@@ -122,10 +129,10 @@ Else {
     }
     Catch {
         If ($recurse) {
-            Fail-Json "Error recursively expanding $src to $dest"
+            Fail-Json $result "Error recursively expanding $src to $dest"
         }
         Else {
-            Fail-Json "Error expanding $src to $dest"
+            Fail-Json $result "Error expanding $src to $dest"
         }
     }
 }
@@ -133,11 +140,6 @@ Else {
 If ($rm -eq $true){
     Remove-Item $src -Recurse -Force
     Set-Attr $result.win_unzip "rm" "true"
-}
-
-If ($params.restart -eq "true" -Or $params.restart -eq "yes") {
-    Restart-Computer -Force
-    Set-Attr $result.win_unzip "restart" "true"
 }
 
 # Fixes a fail error message (when the task actually succeeds) for a "Convert-ToJson: The converted JSON string is in bad format"

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -1,0 +1,83 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2014, Phil Schwartz <schwartzmx@gmail.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+
+$result = New-Object psobject @{
+    win_unzip = New-Object psobject
+    changed = $false
+}
+
+If ($params.zip) {
+    $zip = $params.zip.toString()
+
+    If (-Not (Test-Path -path $zip)){
+        Fail-Json $result "zip file: $zip does not exist."
+    }
+}
+Else {
+    Fail-Json $result "missing required argument: zip"
+}
+
+If (-Not($params.dest -eq $null)) {
+    $dest = $params.dest.toString()
+
+    If (-Not (Test-Path $dest -PathType Container)){
+        New-Item -itemtype directory -path $dest
+    }
+}
+Else {
+    Fail-Json $result "missing required argument: dest"
+}
+
+Try {
+    cd C:\
+    $shell = New-Object -ComObject Shell.Application
+    $shell.NameSpace($dest).copyhere(($shell.NameSpace($zip)).items(), 20)
+    $result.changed = $true
+}
+Catch {
+    $sp = $zip.split(".")
+    $ext = $sp[$sp.length-1]
+
+    # Used to allow reboot after exe hotfix extraction (Windows 2008 R2 SP1)
+    # This will have no effect in most cases.
+    If (-Not ($ext -eq "exe")){
+        $result.changed = $false
+        Fail-Json $result "Error unzipping $zip to $dest"
+    }
+}
+
+If ($params.rm -eq "true"){
+    Remove-Item $zip -Recurse -Force
+    Set-Attr $result.win_unzip "rm" "true"
+}
+
+If ($params.restart -eq "true") {
+    Restart-Computer -Force
+    Set-Attr $result.win_unzip "restart" "true"
+}
+
+
+Set-Attr $result.win_unzip "zip" $zip.toString()
+Set-Attr $result.win_unzip "dest" $dest.toString()
+
+Exit-Json $result;

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -62,19 +62,18 @@ Else {
     Fail-Json $result "missing required argument: dest"
 }
 
-If ($params.recurse -eq "true" -Or $params.recurse -eq "yes") {
-    $recurse = $true
+If ($params.recurse) {
+   $recurse = ConvertTo-Bool ($params.recurse)
 }
 Else {
     $recurse = $false
 }
 
-If ($params.rm -eq "true" -Or $params.rm -eq "yes"){
-    $rm = $true
-    Set-Attr $result.win_unzip "rm" "true"
-}
-Else {
-    $rm = $false
+If ($params.rm) { 
+    $rm = ConvertTo-Bool ($params.rm) 
+} 
+Else { 
+    $rm = $false 
 }
 
 If ($ext -eq ".zip" -And $recurse -eq $false) {
@@ -111,7 +110,7 @@ Else {
         If ($recurse) {
             Expand-Archive -Path $src -OutputPath $dest -Force
 
-            If ($rm) {
+            If ($rm -eq $true) {
                 Get-ChildItem $dest -recurse | Where {$_.extension -eq ".gz" -Or $_.extension -eq ".zip" -Or $_.extension -eq ".bz2" -Or $_.extension -eq ".tar" -Or $_.extension -eq ".msu"} | % {
                     Expand-Archive $_.FullName -OutputPath $dest  -Force
                     Remove-Item $_.FullName -Force

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -67,12 +67,12 @@ Catch {
     }
 }
 
-If ($params.rm -eq "true"){
+If ($params.rm -eq "true" -Or $params.rm -eq "yes"){
     Remove-Item $zip -Recurse -Force
     Set-Attr $result.win_unzip "rm" "true"
 }
 
-If ($params.restart -eq "true") {
+If ($params.restart -eq "true" -Or $params.restart -eq "yes") {
     Restart-Computer -Force
     Set-Attr $result.win_unzip "restart" "true"
 }

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -41,7 +41,12 @@ If (-Not($params.dest -eq $null)) {
     $dest = $params.dest.toString()
 
     If (-Not (Test-Path $dest -PathType Container)){
-        New-Item -itemtype directory -path $dest
+        Try{  
+            New-Item -itemtype directory -path $dest
+        }
+        Catch {
+            Fail-Json $result "Error creating $dest directory"
+        }
     }
 }
 Else {

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -89,7 +89,7 @@ Else {
         Fail-Json "PowerShellCommunityExtensions PowerShell Module (PSCX) is required for non-'.zip' compressed archive types."
     }
     Else {
-        Set-Attr $result.win_zip "pscx_status" "present"
+        Set-Attr $result.win_unzip "pscx_status" "present"
     }
 
     # Import

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -41,7 +41,7 @@ If (-Not($params.dest -eq $null)) {
     $dest = $params.dest.toString()
 
     If (-Not (Test-Path $dest -PathType Container)){
-        Try{  
+        Try{
             New-Item -itemtype directory -path $dest
         }
         Catch {
@@ -54,18 +54,14 @@ Else {
 }
 
 Try {
-    cd C:\
     $shell = New-Object -ComObject Shell.Application
     $shell.NameSpace($dest).copyhere(($shell.NameSpace($zip)).items(), 20)
     $result.changed = $true
 }
 Catch {
-    $sp = $zip.split(".")
-    $ext = $sp[$sp.length-1]
-
     # Used to allow reboot after exe hotfix extraction (Windows 2008 R2 SP1)
     # This will have no effect in most cases.
-    If (-Not ($ext -eq "exe")){
+    If (-Not ([System.IO.Path]::GetExtension($zip) -match ".exe")){
         $result.changed = $false
         Fail-Json $result "Error unzipping $zip to $dest"
     }

--- a/windows/win_unzip.py
+++ b/windows/win_unzip.py
@@ -1,0 +1,90 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Phil Schwartz <schwartzmx@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_unzip
+version_added: ""
+short_description: Unzips compressed files on the Windows node
+description:
+     - Unzips compressed files, and can force reboot (if needed, i.e. such as hotfixes).
+options:
+  zip:
+    description:
+      - Zip file to be unzipped (provide absolute path)
+    required: true
+    default: null
+    aliases: []
+  dest:
+    description:
+      - Destination of zip file (provide absolute path of directory)
+    required: true
+    default: null
+    aliases: []
+  rm:
+    description:
+      - Remove the zip file, after unzipping
+    required: no
+    default: false
+    aliases: []
+  restart:
+    description:
+      - Restarts the computer after unzip, can be useful for hotfixes such as http://support.microsoft.com/kb/2842230 (Restarts will have to be accounted for with wait_for module)
+    choices:
+      - true
+      - false
+    required: false
+    default: false
+    aliases: []
+author: Phil Schwartz
+'''
+
+EXAMPLES = '''
+# This unzips hotfix http://support.microsoft.com/kb/2842230 and forces reboot (for hotfix to take effect)
+$ ansible -i hosts -m win_unzip -a "zip=C:\\463984_intl_x64_zip.exe dest=C:\\Hotfix restart=true" all
+# This unzips a library that was downloaded with win_get_url, and removes the file after extraction
+$ ansible -i hosts -m win_unzip -a "zip=C:\\LibraryToUnzip.zip dest=C:\\Lib rm=true" all
+# Playbook example
+---
+- name: Install WinRM PowerShell Hotfix for Windows Server 2008 SP1
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: Grab Hotfix from URL
+    win_get_url:
+      url: 'http://hotfixv4.microsoft.com/Windows%207/Windows%20Server2008%20R2%20SP1/sp2/Fix467402/7600/free/463984_intl_x64_zip.exe'
+      dest: 'C:\\463984_intl_x64_zip.exe'
+  - name: Unzip hotfix
+    win_unzip:
+      zip: "C:\\463984_intl_x64_zip.exe"
+      dest: "C:\\Hotfix"
+      restart: true
+  - name: Wait for server reboot...
+  local_action:
+    module: wait_for
+      host={{ inventory_hostname }}
+      port={{ansible_ssh_port|default(5986)}}
+      delay=15
+      timeout=600
+      state=started
+'''

--- a/windows/win_unzip.py
+++ b/windows/win_unzip.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2014, Phil Schwartz <schwartzmx@gmail.com>
+# (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
 #
 # This file is part of Ansible
 #
@@ -74,7 +74,7 @@ options:
     required: false
     default: false
     aliases: []
-author: Phil Schwartz
+author: Phil Schwartz 
 '''
 
 EXAMPLES = '''
@@ -126,4 +126,17 @@ $ ansible -i hosts -m win_unzip -a "src=C:\\LibraryToUnzip.zip dest=C:\\Lib rm=t
       delay=15
       timeout=600
       state=started
+
+# Install PSCX to use for extracting a gz file
+  - name: Grab PSCX msi
+    win_get_url:
+      url: 'http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=pscx&DownloadId=923562&FileTime=130585918034470000&Build=20959'
+      dest: 'C:\\pscx.msi'
+  - name: Install PSCX
+    win_msi:
+      path: 'C:\\pscx.msi'
+  - name: Unzip gz log
+    win_unzip:
+      src: "C:\\Logs\\application-error-logs.gz"
+      dest: "C:\\ExtractedLogs\\application-error-logs"
 '''

--- a/windows/win_unzip.py
+++ b/windows/win_unzip.py
@@ -27,7 +27,7 @@ module: win_unzip
 version_added: ""
 short_description: Unzips compressed files on the Windows node
 description:
-     - Unzips compressed files, and can force reboot (if needed, i.e. such as hotfixes).
+     - Unzips compressed files, and can force reboot (if needed, i.e. such as hotfixes). If the destination directory does not exist, it will be created before unzipping the file. Specifying rm parameter will allow removal of the zip file after extraction.
 options:
   zip:
     description:
@@ -37,7 +37,7 @@ options:
     aliases: []
   dest:
     description:
-      - Destination of zip file (provide absolute path of directory)
+      - Destination of zip file (provide absolute path of directory). If it does not exist, the directory will be created.
     required: true
     default: null
     aliases: []

--- a/windows/win_unzip.py
+++ b/windows/win_unzip.py
@@ -63,16 +63,11 @@ options:
       - yes
       - no
     aliases: []
-  restart:
+  creates:
     description:
-      - Restarts the computer after unzip, can be useful for hotfixes such as http://support.microsoft.com/kb/2842230 (Restarts will have to be accounted for with wait_for module)
-    choices:
-      - true
-      - false
-      - yes
-      - no
-    required: false
-    default: false
+      - If this file or directory exists the specified src will not be extracted.
+    required: no
+    default: null
     aliases: []
 author: Phil Schwartz 
 '''
@@ -88,6 +83,7 @@ $ ansible -i hosts -m win_unzip -a "src=C:\\LibraryToUnzip.zip dest=C:\\Lib rm=t
   win_unzip:
     src: "C:\Users\Phil\Logs.bz2"
     dest: "C:\Users\Phil\OldLogs"
+    creates: "C:\Users\Phil\OldLogs"
 
 # This playbook example unzips a .zip file and recursively decompresses the contained .gz files and removes all unneeded compressed files after completion.
 ---
@@ -101,31 +97,6 @@ $ ansible -i hosts -m win_unzip -a "src=C:\\LibraryToUnzip.zip dest=C:\\Lib rm=t
         dest: C:\Application\Logs
         recurse: yes
         rm: true
-
-# Install hotfix (self-extracting .exe)
----
-- name: Install WinRM PowerShell Hotfix for Windows Server 2008 SP1
-  hosts: all
-  gather_facts: false
-  tasks:
-  - name: Grab Hotfix from URL
-    win_get_url:
-      url: 'http://hotfixv4.microsoft.com/Windows%207/Windows%20Server2008%20R2%20SP1/sp2/Fix467402/7600/free/463984_intl_x64_zip.exe'
-      dest: 'C:\\463984_intl_x64_zip.exe'
-  - name: Unzip hotfix
-    win_unzip:
-      src: "C:\\463984_intl_x64_zip.exe"
-      dest: "C:\\Hotfix"
-      recurse: true
-      restart: true
-  - name: Wait for server reboot...
-  local_action:
-    module: wait_for
-      host={{ inventory_hostname }}
-      port={{ansible_ssh_port|default(5986)}}
-      delay=15
-      timeout=600
-      state=started
 
 # Install PSCX to use for extracting a gz file
   - name: Grab PSCX msi


### PR DESCRIPTION
`win_unzip` module:
- Can be useful for extracting libraries or needed sources.
- Also for unzipping self-extracting `.exe`'s for hot fixes such as http://support.microsoft.com/kb/2842230.
- Would most likely be used in conjunction with `win_get_url` to first grab the file.
- All paths specified must be on windows node machine.  Absolute path required.

Initial need for this module was for extracting gzip files that were being pulled down from s3 using AWS and also remotely installing hot fix for initialization of Windows 2008 R2 Servers.

**Updates 1/11**:
- Renamed `zip` param to `src` to be consistent across modules.
- Added `recurse` param to allow for recursive decompression.
  - For example, provided `C:\Example.zip` as a `src`, which contains many `.gz` files.  Specifying `recurse=true` will carry out a recursive decompression of all files within the decompressed `Example.zip` (step 1) to be decompressed as well (step 2).  Further, specifying `rm = true` will remove all compressed files after decompression is complete.
- Added ability to unzip `tar`, `gzip`, and `bzip` files to coincide with added functionality to `win_zip` module: [#177 commit:fc4d2c0d34e321d929b9c751add8c8cd38cfad9c](https://github.com/schwartzmx/ansible-modules-extras/commit/fc4d2c0d34e321d929b9c751add8c8cd38cfad9c)
  - `.msu` files will also be extracted when dealing with self-extracting `.exe` files such as with the hotfix previously mentioned.
- If a `.zip` file is specified and `recurse=false`, then the module will use PowerShell's built-in methods to extract the `.zip` file.  **Otherwise** `PSCX` will be installed, first by attempting a `chocolatey` install, if failure, then install from `.msi`.  This is also a requirement of `win_zip`: [#177](https://github.com/ansible/ansible-modules-extras/pull/177) 

Questions, comments, or suggestions for additions please let me know.

Phil
