### PR TITLE
win_zip Module

### DIFF
--- a/windows/win_zip.ps1
+++ b/windows/win_zip.ps1
@@ -95,7 +95,7 @@ If ($params.dest) {
     }
 
 
-    If (-Not ([System.IO.Path]::GetExtension($dest) -match ".zip")) {
+    If (-Not ([System.IO.Path]::GetExtension($dest) -eq ".zip")) {
         $dest = $dest + ".zip"
     }
 
@@ -105,7 +105,7 @@ Else {
 }
 
 #RM
-If ($params.rm){
+If ($params.rm -eq "true" -Or $params.rm -eq "yes"){
     $rm = $true
 }
 Else {

--- a/windows/win_zip.ps1
+++ b/windows/win_zip.ps1
@@ -141,6 +141,7 @@ Catch {
 
 Set-Attr $result.win_zip "src" $src.toString()
 Set-Attr $result.win_zip "dest" $dest.toString()
+Set-Attr $result.win_zip "rm" $rm.toString()
 
 Exit-Json $result;
 

--- a/windows/win_zip.ps1
+++ b/windows/win_zip.ps1
@@ -39,20 +39,32 @@ $isContainer = $false
 $list = Get-Module -ListAvailable
 # If not download it and install
 If (-Not ($list -match "PSCX")) {
+    # Try install with chocolatey
     Try {
-        $client = New-Object System.Net.WebClient
-        $client.DownloadFile($url, $dest)
+        cinst -force PSCX -y
+        $choco = $true
     }
     Catch {
-        Fail-Json $result "Error downloading PSCX from $url and saving as $dest"
+        $choco = $false
     }
-    Try {
-        msiexec.exe /i $dest /qb
-    }
-    Catch {
-        Fail-Json $result "Error installing $dest"
+    # install from downloaded msi if choco failed or is not present
+    If ($choco -eq $false) {
+        Try {
+            $client = New-Object System.Net.WebClient
+            $client.DownloadFile($url, $dest)
+        }
+        Catch {
+            Fail-Json $result "Error downloading PSCX from $url and saving as $dest"
+        }
+        Try {
+            Start-Process -FilePath msiexec.exe -ArgumentList "/i $dest /qb" -Verb Runas -PassThru -Wait | out-null
+        }
+        Catch {
+            Fail-Json $result "Error installing $dest"
+        }
     }
     Set-Attr $result.win_zip "pscx_status" "pscx was installed"
+    $installed = $true
 }
 Else {
     Set-Attr $result.win_zip "pscx_status" "present"
@@ -60,13 +72,23 @@ Else {
 
 # Import
 Try {
-    Import-Module PSCX
+    If ($installed) {
+        Try {
+            Import-Module 'C:\Program Files (x86)\Powershell Community Extensions\pscx3\pscx\pscx.psd1'
+        }
+        Catch {
+            Import-Module PSCX
+        }
+    }
+    Else {
+        Import-Module PSCX
+    }
 }
 Catch {
     Fail-Json $result "Error importing module PSCX"
 }
 
-# Get Params (SRC, DEST, RM)
+# Get Params (SRC, DEST, TYPE, RM)
 # SRC
 If ($params.src) {
     $src = $params.src.toString()
@@ -75,6 +97,16 @@ If ($params.src) {
         $isLeaf = $true
     }
     ElseIf (Test-Path $src -PathType Container) {
+        $lastchar = $src[$src.length-1]
+        If (-Not ($lastchar -eq "/" -Or $lastchar -eq "\")) {
+            # figure out type of path delimiter provided
+            If ($src.split("\").length -eq 1) {
+                $src = $src + "/"
+            }
+            Else {
+                $src = $src + "\"
+            }
+        }
         $isContainer = $true
     }
     Else {
@@ -86,23 +118,6 @@ Else {
     Fail-Json $result "missing required argument: src"
 }
 
-# DEST
-If ($params.dest) {
-    $dest = $params.dest.toString()
-
-    If (Test-Path $dest -PathType Container) {
-        Fail-Json $result "Error in dest arg. Please provide the desired zip file name at the end of the path. (C:\Users\Path\Ex.zip)"
-    }
-
-
-    If (-Not ([System.IO.Path]::GetExtension($dest) -eq ".zip")) {
-        $dest = $dest + ".zip"
-    }
-
-}
-Else {
-    Fail-Json $result "missing required argument: dest"
-}
 
 #RM
 If ($params.rm -eq "true" -Or $params.rm -eq "yes"){
@@ -112,12 +127,85 @@ Else {
     $rm = $false
 }
 
-# Zip
+#TYPE
+If ($params.type -eq "bzip" -Or $params.type -eq "tar" -Or $params.type -eq "gzip") {
+    $type = $params.type.toString()
+}
+Else {
+    $type = "zip"
+}
+
+# DEST
+If ($params.dest) {
+    $dest = $params.dest.toString()
+
+    If ((Test-Path $dest -PathType Container) -And ($type -eq "zip" -Or $type -eq "tar")) {
+        Fail-Json $result "Error in dest arg. Please provide the desired zip/tar file name at the end of the path. (C:\Users\Path\Ex.zip)"
+    }
+
+    $ext = [System.IO.Path]::GetExtension($dest)
+    If (-Not ( $ext -eq ".zip" -Or $ext -eq ".tar")) {
+        If ($type -eq "tar") {
+            $dest = $dest + ".tar"
+        }
+        ElseIf ($type -eq "zip") {
+            $dest = $dest + ".zip"
+        }
+    }
+    ElseIf ($isLeaf -And -Not(Test-Path $dest -PathType Container) -And ($type -eq "bzip" -Or $type -eq "gzip")){
+        If ($type -eq "bzip" -And $ext -ne ".bz2") {
+            $dest = $dest + ".bz"
+        }
+        ElseIf ($type -eq "gzip" -And $ext -ne ".gz") {
+            $dest = $dest + ".gz"
+        }
+
+    }
+
+}
+Else {
+    Fail-Json $result "missing required argument: dest"
+}
+
+# Compress
 Try {
-    # On success Write-Zip writes to std-out. This is the reason for piping to out-null (And also b/c their -Quiet switch won't work).
-    # This allows for the try-catch to still catch errors, but not fail on success output.
-    Write-Zip -Path $src -OutputPath $dest -Level 9 -IncludeEmptyDirectories | out-null
-    $result.changed = $true
+    If ($type -eq "zip") {
+        # On success Write-Zip writes to std-out. This is the reason for piping to out-null (And also b/c their -Quiet switch won't work).
+        # This allows for the try-catch to still catch errors, but not fail on success output.
+        Write-Zip -Path $src -OutputPath $dest -Level 9 -IncludeEmptyDirectories | out-null
+        $result.changed = $true
+    }
+    ElseIf ($type -eq "bzip") {
+        If ($isLeaf) {
+            Write-BZip2 -Path $src | out-null
+            Move-Item -Path $src".bz2" -Destination $dest
+        }
+        ElseIf ($isContainer) {
+            Get-ChildItem $src -Recurse | Write-BZip2 | out-null
+            Get-ChildItem $src"*.bz2" -Recurse | Move-Item -Destination $dest
+        }
+
+        $result.changed = $true
+    }
+    ElseIf ($type -eq "tar") {
+        Write-Tar -Path $src -OutputPath $dest | out-null
+        $result.changed = $true
+    }
+    ElseIf ($type -eq "gzip") {
+        If ($isLeaf) {
+            Write-GZip -Path $src | out-null
+            Move-Item -Path $src".gz" -Destination $dest
+        }
+        ElseIf ($isContainer) {
+            Get-ChildItem $src -Recurse | Write-Gzip | out-null
+            Get-ChildItem $src"*.gz" -Recurse | Move-Item -Destination $dest
+        }
+
+        $result.changed = $true
+    }
+    Else {
+        Fail-Json $result "An error occured when checking param: type for compression creation"
+    }
 
     If ($rm){
         Try {
@@ -135,13 +223,23 @@ Catch {
         Fail-Json $result "Directory: $directory does not exist in the dest provided."
     }
     Else {
-        Fail-Json $result "Error zipping $src to $dest."
+        Fail-Json $result "Error compressing $src to $dest."
     }
 }
 
+# Fixes a fail error message (when the task actually succeeds) for a "Convert-ToJson: The converted JSON string is in bad format"
+# This happens when JSON is parsing a string that ends with a "\", which is possible when specifying a directory to download to.
+# This catches that possible error, before assigning the JSON $result
+If ($src[$src.length-1] -eq "\") {
+    $src = $src.Substring(0, $src.length-1)
+}
+If ($dest[$dest.length-1] -eq "\") {
+    $dest = $dest.Substring(0, $dest.length-1)
+}
 Set-Attr $result.win_zip "src" $src.toString()
 Set-Attr $result.win_zip "dest" $dest.toString()
 Set-Attr $result.win_zip "rm" $rm.toString()
+Set-Attr $result.win_zip "type" $type.toString()
 
 Exit-Json $result;
 

--- a/windows/win_zip.ps1
+++ b/windows/win_zip.ps1
@@ -1,0 +1,147 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2014, Phil Schwartz <schwartzmx@gmail.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+
+$result = New-Object psobject @{
+    win_zip = New-Object psobject
+    changed = $false
+}
+
+# Requires PSCX, will be installed if it isn't found
+# Pscx-3.2.0.msi
+$url = "http://download-codeplex.sec.s-msft.com/Download/Release?ProjectName=pscx&DownloadId=923562&FileTime=130585918034470000&Build=20959"
+$dest = "C:\Pscx-3.2.0.msi"
+
+# Global flags
+$isLeaf = $false
+$isContainer = $false
+
+# Check if PSCX is installed
+$list = Get-Module -ListAvailable
+# If not download it and install
+If (-Not ($list -match "PSCX")) {
+    Try {
+        $client = New-Object System.Net.WebClient
+        $client.DownloadFile($url, $dest)
+    }
+    Catch {
+        Fail-Json $result "Error downloading PSCX from $url and saving as $dest"
+    }
+    Try {
+        msiexec.exe /i $dest /qb
+    }
+    Catch {
+        Fail-Json $result "Error installing $dest"
+    }
+    Set-Attr $result.win_zip "pscx_status" "pscx was installed"
+}
+Else {
+    Set-Attr $result.win_zip "pscx_status" "present"
+}
+
+# Import
+Try {
+    Import-Module PSCX
+}
+Catch {
+    Fail-Json $result "Error importing module PSCX"
+}
+
+# Get Params (SRC, DEST, RM)
+# SRC
+If ($params.src) {
+    $src = $params.src.toString()
+
+    If(Test-Path $src -PathType Leaf) {
+        $isLeaf = $true
+    }
+    ElseIf (Test-Path $src -PathType Container) {
+        $isContainer = $true
+    }
+    Else {
+        Fail-Json $result "Specified src: $src is not a valid file or directory"
+    }
+
+}
+Else {
+    Fail-Json $result "missing required argument: src"
+}
+
+# DEST
+If ($params.dest) {
+    $dest = $params.dest.toString()
+
+    If (Test-Path $dest -PathType Container) {
+        Fail-Json $result "Error in dest arg. Please provide the desired zip file name at the end of the path. (C:\Users\Path\Ex.zip)"
+    }
+
+
+    If (-Not ([System.IO.Path]::GetExtension($dest) -match ".zip")) {
+        $dest = $dest + ".zip"
+    }
+
+}
+Else {
+    Fail-Json $result "missing required argument: dest"
+}
+
+#RM
+If ($params.rm){
+    $rm = $true
+}
+Else {
+    $rm = $false
+}
+
+# Zip
+Try {
+    # On success Write-Zip writes to std-out. This is the reason for piping to out-null (And also b/c their -Quiet switch won't work).
+    # This allows for the try-catch to still catch errors, but not fail on success output.
+    Write-Zip -Path $src -OutputPath $dest -Level 9 -IncludeEmptyDirectories | out-null
+    $result.changed = $true
+
+    If ($rm){
+        Try {
+            Remove-Item -Path $src -Force -Recurse
+            Set-Attr $result.win_zip "rm" "removed $src"
+        }
+        Catch {
+            Fail-Json $result "Error removing $src"
+        }
+    }
+}
+Catch {
+    $directory = [System.IO.Path]::GetDirectoryName($dest)
+    If (-Not (Test-Path -Path $directory -PathType Container)) {
+        Fail-Json $result "Directory: $directory does not exist in the dest provided."
+    }
+    Else {
+        Fail-Json $result "Error zipping $src to $dest."
+    }
+}
+
+Set-Attr $result.win_zip "src" $src.toString()
+Set-Attr $result.win_zip "dest" $dest.toString()
+
+Exit-Json $result;
+
+

--- a/windows/win_zip.ps1
+++ b/windows/win_zip.ps1
@@ -52,10 +52,11 @@ Else {
 Try {
     If ($pscxPresent) {
         Try {
-            Import-Module 'C:\Program Files (x86)\Powershell Community Extensions\pscx3\pscx\pscx.psd1'
+            Import-Module PSCX
         }
         Catch {
-            Import-Module PSCX
+            $ex = $_.Exception
+            Fail-Json $result "Error importing module PSCX.  Exception: $ex.Message"
         }
     }
 }

--- a/windows/win_zip.py
+++ b/windows/win_zip.py
@@ -1,0 +1,74 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Phil Schwartz <schwartzmx@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_zip
+version_added: ""
+short_description: Zips file or directory on the Windows node
+description:
+     - Zips the specified local file or directory on the Windows node. Depends on PSCX (PowerShell Community Extensions).  PSCX is downloaded and installed if it is not found.  If found it imports the module and continues. For information on PSCX visit https://pscx.codeplex.com/.
+options:
+  src:
+    description:
+      - Local file or directory (provide absolute path)
+    required: true
+    default: null
+    aliases: []
+  dest:
+    description:
+      - Destination of compressed zip file (provide absolute path) and name of desired output file.  If a .zip extension is not present, it will be detected and added automatically. The path specified must exist, the basename doesn't need to exist.
+    required: true
+    default: null
+    aliases: []
+  rm:
+    description:
+      - Remove the (unzipped) src file, after zipping
+    required: no
+    choices:
+      - true
+      - false
+      - yes
+      - no
+    default: false
+    aliases: []
+author: Phil Schwartz
+'''
+
+EXAMPLES = '''
+# Zips directory on Windows Host and saves as SRC.zip
+$ ansible -i hosts -m win_zip -a "src=C:\\Users\Administrator\SRC dest=C:\\Users\Administrator\SRC.zip rm=true" all
+# Zips a file on Windows Host and saves as test.txt.zip
+$ ansible -i hosts -m win_zip -a "src=C:\\Users\Phil\xfile.txt dest=C:\\xfile" all
+# Playbook example
+---
+- name: Zip Logs
+  hosts: all
+  gather_facts: false
+  tasks:
+  - name: win_zip the inet log directory and then remove the src directory after completion
+    win_zip:
+      src: 'C:\\inetpub\wwwroot\Logs'
+      dest: 'C:\\Logs\1-1-15.ServerLogs.zip'
+      rm: true
+'''

--- a/windows/win_zip.py
+++ b/windows/win_zip.py
@@ -52,6 +52,11 @@ options:
       - tar
       - gzip
     aliases: []
+  creates:
+    description:
+      - If the specified file or directory exists then no changes will be made.
+    required: false
+    aliases: []
   rm:
     description:
       - Remove the (unzipped) src file, after zipping
@@ -68,11 +73,11 @@ author: Phil Schwartz
 
 EXAMPLES = '''
 # Zips directory on Windows Host and saves as SRC.zip
-$ ansible -i hosts -m win_zip -a "src=C:\\Users\Administrator\SRC dest=C:\\Users\Administrator\SRC.zip rm=true" all
+$ ansible -i hosts -m win_zip -a "src=C:\\Users\\Administrator\\SRC dest=C:\\Users\\Administrator\\SRC.zip rm=true" all
 # Zips a file on Windows Host and saves as xfile.txt.zip
-$ ansible -i hosts -m win_zip -a "src=C:\\Users\Phil\xfile.txt dest=C:\\xfile.txt" all
+$ ansible -i hosts -m win_zip -a "src=C:\\Users\\Phil\\xfile.txt dest=C:\\xfile.txt" all
 # BZip all files in a directory, and move them all into a new directory, and removes all files within the src folder
-$ ansible -i hosts -m win_zip -a "src=C:\\Logs\ dest=C:\\UploadFolder type=bzip rm=true"
+$ ansible -i hosts -m win_zip -a "src=C:\\Logs\\ dest=C:\\UploadFolder type=bzip rm=true"
 # Playbook example
 ---
 - name: Zip Logs
@@ -81,7 +86,7 @@ $ ansible -i hosts -m win_zip -a "src=C:\\Logs\ dest=C:\\UploadFolder type=bzip 
   tasks:
   - name: win_zip the inet log directory and then remove the src directory after completion
     win_zip:
-      src: 'C:\\inetpub\wwwroot\Logs'
+      src: 'C:\\inetpub\\wwwroot\\Logs'
       dest: 'C:\\Logs\1-1-15.ServerLogs.zip'
       rm: true
 
@@ -92,13 +97,14 @@ $ ansible -i hosts -m win_zip -a "src=C:\\Logs\ dest=C:\\UploadFolder type=bzip 
   tasks:
     - name: Tar folder
       win_zip:
-        src: C:\\folder\\to\\tar
-        dest: C:\\TA.tar
+        src: 'C:\\folder\\to\\tar'
+        dest: 'C:\\TA.tar'
         type: tar
+        creates: 'C:\\TA.tar'
 
     - name: GZip Tatar
       win_zip:
-        src: C:\\TA.tar
-        dest: C:\\Totz.gz
+        src: 'C:\\TA.tar'
+        dest: 'C:\\Totz.gz'
         type: gzip
 '''

--- a/windows/win_zip.py
+++ b/windows/win_zip.py
@@ -41,6 +41,17 @@ options:
     required: true
     default: null
     aliases: []
+  type:
+    description:
+      - Type of compression method to use.
+    required: false
+    default: zip
+    choices:
+      - zip
+      - bzip
+      - tar
+      - gzip
+    aliases: []
   rm:
     description:
       - Remove the (unzipped) src file, after zipping
@@ -58,8 +69,10 @@ author: Phil Schwartz
 EXAMPLES = '''
 # Zips directory on Windows Host and saves as SRC.zip
 $ ansible -i hosts -m win_zip -a "src=C:\\Users\Administrator\SRC dest=C:\\Users\Administrator\SRC.zip rm=true" all
-# Zips a file on Windows Host and saves as test.txt.zip
-$ ansible -i hosts -m win_zip -a "src=C:\\Users\Phil\xfile.txt dest=C:\\xfile" all
+# Zips a file on Windows Host and saves as xfile.txt.zip
+$ ansible -i hosts -m win_zip -a "src=C:\\Users\Phil\xfile.txt dest=C:\\xfile.txt" all
+# BZip all files in a directory, and move them all into a new directory, and removes all files within the src folder
+$ ansible -i hosts -m win_zip -a "src=C:\\Logs\ dest=C:\\UploadFolder type=bzip rm=true"
 # Playbook example
 ---
 - name: Zip Logs
@@ -71,4 +84,21 @@ $ ansible -i hosts -m win_zip -a "src=C:\\Users\Phil\xfile.txt dest=C:\\xfile" a
       src: 'C:\\inetpub\wwwroot\Logs'
       dest: 'C:\\Logs\1-1-15.ServerLogs.zip'
       rm: true
+
+
+---
+- name: Tar a folder, and then GZip the Tar
+  hosts: all
+  tasks:
+    - name: Tar folder
+      win_zip:
+        src: C:\\folder\\to\\tar
+        dest: C:\\TA.tar
+        type: tar
+
+    - name: GZip Tatar
+      win_zip:
+        src: C:\\TA.tar
+        dest: C:\\Totz.gz
+        type: gzip
 '''


### PR DESCRIPTION
`win_zip` module:
- Uses PowerShell Community Extensions' (PSCX) `Write-Zip` cmdlet to zip the specified file or directory.
  - The reason for this, is implementing zipping of files/directories in PowerShell natively is ugly. Files are sometimes skipped and other weird anomalies have been noted of happening.
  - PSCX `Write-Zip` uses 7zip as the core library, and is much more reliable.
- If PSCX is not detected on the machine, it will be downloaded and installed, then imported for the script. 
- Also takes a `rm` argument, for specifying whether to remove the `src` file after compression is completed.
- The `dest` argument's path must exist, but the basename does not need to exist.
  - The script detects whether the `.zip` extension for `dest` was supplied, and adds it if need be.
- I've tried to make exception handling and the resultant error messages as specific and helpful as possible.

**Updates 1/11**:
- Added `tar`, `gzip`, `bzip` functionality.
  - Added param `type` to take care of this.
    - Ex: `type: gzip`
- Fixes to `PSCX` import problems after installation
- Updated docs
- Also added attempt to install `PSCX` with `chocolatey` if present on the machine, if not continue with the `.msi` installation.
- Updates to `win_unzip` module PR: [#174](https://github.com/ansible/ansible-modules-extras/pull/174) have been made to coincide with the changes here.

Questions, comments, or suggestions for additions please let me know.

Phil
