### PR TITLE
Add a note about debconf passwords always being recorded as changed

### DIFF
--- a/system/debconf.py
+++ b/system/debconf.py
@@ -34,6 +34,7 @@ notes:
     - A number of questions have to be answered (depending on the package).
       Use 'debconf-show <package>' on any Debian or derivative with the package
       installed to see questions/settings available.
+    - Some distros will always record tasks involving the setting of passwords as changed. This is due to debconf-get-selections masking passwords.
 requirements: [ debconf, debconf-utils ]
 options:
   name:


### PR DESCRIPTION
Replaces https://github.com/ansible/ansible/pull/6808,, which was raised before ansible-modules-extra was created
