### PR TITLE
fix lvol module to properly query the size of logical volumes

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -153,7 +153,7 @@ def main():
         unit = size_unit
 
     rc, current_lvs, err = module.run_command(
-        "lvs --noheadings -o lv_name,size --units %s --separator ';' %s" % (unit, vg))
+        "lvs --noheadings --nosuffix -o lv_name,size --units %s --separator ';' %s" % (unit, vg))
 
     if rc != 0:
         if state == 'absent':


### PR DESCRIPTION
The command to get a list of existing logical volumes -- lvs, needs additional parameter **nosuffix** to remove the unit indicator from the output. Without this parameter an attempt to create a new logical volume the module may fail (if logical volumes already exists on the target volume group) with this exception:

```
Traceback (most recent call last):
  File "/x/.ansible/tmp/ansible-tmp-1420450957.48-276008732087388/lvol", line 1800, in <module>
    main()
  File "/x/.ansible/tmp/ansible-tmp-1420450957.48-276008732087388/lvol", line 166, in main
    lvs = parse_lvs(current_lvs)
  File "/x/.ansible/tmp/ansible-tmp-1420450957.48-276008732087388/lvol", line 93, in parse_lvs
    'size': int(decimal_point.split(parts[1])[0]),
ValueError: invalid literal for int() with base 10: '8992587776B'
```

The function _parse_lvs()_ expects only digits in the second column of the output, so when the unit letter is present the conversion to int fails.

To reproduce the problem try to create new logical volume in volume group that already has at least one logical volume. If the volume group is empty the problem will not manifest itself because the output of the command is empty.
