### PR TITLE
Allow disabling of autorefresh for zypper repositories

### DIFF
--- a/packaging/os/zypper_repository.py
+++ b/packaging/os/zypper_repository.py
@@ -63,7 +63,7 @@ options:
        description:
            - Enable autorefresh of the repository.
         required: false
-        default: "no"
+        default: "yes"
         choices: [ "yes", "no" ]
         aliases: []
 notes: []


### PR DESCRIPTION
In case of release repositories or other special cases you might not
need the autorefreshing of the repos. This patch adds a configure
option instead of hard enabling this.

Signed-off-by: Justin Lecher jlec@gentoo.org
