### PR TITLE
Add Elasticsearch plugin module

### DIFF
--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -50,8 +50,9 @@ options:
         default: None
     timeout:
         description:
-            - Timeout setting: 30s, 1m, 1h... (1m by default)
+            - Timeout setting: 30s, 1m, 1h...
         required: False
+        default: 1m
     plugin_bin:
         description:
             - Location of the plugin binary

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -3,8 +3,6 @@
 
 import os
 
-from ansible.module_utils.basic import *
-
 """
 Ansible module to manage elasticsearch plugins
 (c) 2015, Mathew Davies <thepixeldeveloper@googlemail.com>
@@ -158,5 +156,6 @@ def main():
 
     module.exit_json(changed=True, cmd=cmd, name=name, state=state, url=url, timeout=timeout, stdout=out, stderr=err)
 
-if __name__ == "__main__":
-    main()
+from ansible.module_utils.basic import *
+
+main()

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -130,8 +130,6 @@ def main():
     version = module.params["version"]
 
     present = is_plugin_present(parse_plugin_repo(name), plugin_dir)
-    
-    print state
 
     # skip if the state is correct
     if (present and state == "present") or (state == "absent" and not present):

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -1,0 +1,160 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import os
+
+from ansible.module_utils.basic import *
+
+"""
+Ansible module to manage elasticsearch plugins
+(c) 2015, Mathew Davies <thepixeldeveloper@googlemail.com>
+
+This file is part of Ansible
+
+Ansible is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Ansible is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+DOCUMENTATION = '''
+---
+module: elasticsearch_plugin
+short_description: Manage Elasticsearch plugins
+description:
+    - Manages Elasticsearch plugins.
+version_added: ""
+author: Mathew Davies (@ThePixelDeveloper)
+options:
+    name:
+        description:
+            - Name of the plugin to install
+        required: True
+    state:
+        description:
+            - Desired state of a plugin.
+        required: False
+        choices: [present, absent]
+        default: present
+    url:
+        description:
+            - Set exact URL to download the plugin from
+        required: False
+    timeout:
+        description:
+            - Timeout setting: 30s, 1m, 1h... (1m by default)
+        required: False
+    plugin_bin:
+        description:
+            - Location of the plugin binary
+        required: False
+        default: /usr/share/elasticsearch/bin/plugin
+    plugin_dir:
+        description:
+            - Your configured plugin directory specified in Elasticsearch
+        required: False
+        default: /usr/share/elasticsearch/plugins/
+    version:
+        description: 
+            - Version of the plugin to be installed.
+'''
+
+EXAMPLES = '''
+# Install Elasticsearch head plugin
+- elasticsearch_plugin: state=present name="mobz/elasticsearch-head"
+'''
+
+
+def parse_plugin_repo(string):
+    elements = string.split("/")
+
+    # We first consider the simplest form: pluginname
+    repo = elements[0]
+
+    # We consider the form: username/pluginname
+    if len(elements) > 1:
+        repo = elements[1]
+
+    # remove elasticsearch- prefix
+    # remove es- prefix
+    for string in ("elasticsearch-", "es-"):
+        if repo.startswith(string):
+            return repo[len(string):]
+
+    return repo
+
+
+def is_plugin_present(plugin_dir, working_dir):
+    return os.path.isdir(os.path.join(working_dir, plugin_dir))
+
+
+def parse_error(string):
+    reason = "reason: "
+    return string[string.index(reason) + len(reason):].strip()
+
+
+def main():
+
+    package_state_map = dict(
+        present="--install",
+        absent="--remove"
+    )
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(required=True),
+            state=dict(default="present", choices=package_state_map.keys()),
+            url=dict(default=None),
+            timeout=dict(default="1m"),
+            plugin_bin=dict(default="/usr/share/elasticsearch/bin/plugin"),
+            plugin_dir=dict(default="/usr/share/elasticsearch/plugins/"),
+            version=dict(default=None)
+        )
+    )
+
+    plugin_bin = module.params["plugin_bin"]
+    plugin_dir = module.params["plugin_dir"]
+    name = module.params["name"]
+    state = module.params["state"]
+    url = module.params["url"]
+    timeout = module.params["timeout"]
+    version = module.params["version"]
+
+    present = is_plugin_present(parse_plugin_repo(name), plugin_dir)
+    
+    print state
+
+    # skip if the state is correct
+    if (present and state == "present") or (state == "absent" and not present):
+        module.exit_json(changed=False, name=name)
+        
+    if (version):
+       name = name + '/' + version
+
+    cmd_args = [plugin_bin, package_state_map[state], name]
+
+    if url:
+        cmd_args.append("--url %s" % url)
+
+    if timeout:
+        cmd_args.append("--timeout %s" % timeout)
+
+    cmd = " ".join(cmd_args)
+
+    rc, out, err = module.run_command(cmd)
+
+    if rc != 0:
+        reason = parse_error(out)
+        module.fail_json(msg=reason)
+
+    module.exit_json(changed=True, cmd=cmd, name=name, state=state, url=url, timeout=timeout, stdout=out, stderr=err)
+
+if __name__ == "__main__":
+    main()

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -63,7 +63,8 @@ options:
         default: /usr/share/elasticsearch/plugins/
     version:
         description: 
-            - Version of the plugin to be installed.
+            - Version of the plugin to be installed.  
+              If plugin exists with previous version, it will NOT be updated
         required: False
         default: None
 '''

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -72,6 +72,12 @@ options:
 EXAMPLES = '''
 # Install Elasticsearch head plugin
 - elasticsearch_plugin: state=present name="mobz/elasticsearch-head"
+
+# Install specific version of a plugin
+- elasticsearch_plugin: state=present name="com.github.kzwang/elasticsearch-image" version="1.2.0"
+
+# Uninstall Elasticsearch head plugin
+- elasticsearch_plugin: state=absent name="mobz/elasticsearch-head"
 '''
 
 

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -65,6 +65,7 @@ options:
     version:
         description: 
             - Version of the plugin to be installed.
+        required: False
         default: None
 '''
 

--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -47,6 +47,7 @@ options:
         description:
             - Set exact URL to download the plugin from
         required: False
+        default: None
     timeout:
         description:
             - Timeout setting: 30s, 1m, 1h... (1m by default)
@@ -64,6 +65,7 @@ options:
     version:
         description: 
             - Version of the plugin to be installed.
+        default: None
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
First time really playing with Python and Ansible modules.

This manages elasticsearch plugins and will allow you to add and remove them easily. This has been a bit of issue with the elasticsearch playbooks out there as none of them support existential checks as well as removal. Main reason for that being the [name -> directory transformation](https://github.com/elasticsearch/elasticsearch/blob/master/src/main/java/org/elasticsearch/plugins/PluginManager.java#L657-L689)

Conforms to pep8.

Suggestions appreciated.
