### PR TITLE
Bugfix PR for lvol: Cast size(LogicalVolumeSize) to lower .

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -132,8 +132,8 @@ def main():
 
         # LVCREATE(8) -L --size option unit
         elif size[-1].isalpha():
-            if size[-1] in 'bBsSkKmMgGtTpPeE':
-                size_unit = size[-1]
+            if size[-1].lower() in 'bskmgtpe':
+                size_unit = size[-1].lower()
                 if size[0:-1].isdigit():
                     size = int(size[0:-1])
                 else:


### PR DESCRIPTION
#### Issue Type:

Bugfix Pull Request
#### Ansible Version:

ansible 1.9 (devel 1a44d98916) last updated 2015/01/08 11:24:51 (GMT +200)
#### Environment:

SLES 11 SP3
#### Summary:

In front of the module splitting the PR was closed:
https://github.com/ansible/ansible/pull/8284

So I have recreated the commit to fix that issue, which is still present :( 

Please review and give feedback
