### PR TITLE
win_acl Module

### DIFF
--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -30,8 +30,8 @@ $result = New-Object psobject @{
 If ($params.src) {
     $src = $params.src.toString()
 
-    If (-Not (Test-Path -Path $src -PathType Leaf -Or Test-Path -Path $src -PathType Container)) {
-        Fail-Json $result "$src is not a valid file or directory on the host"
+    If (-Not (Test-Path -Path $src)) {
+        Fail-Json $result "$src file or directory does not exist on the host"
     }
 }
 Else {

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -1,0 +1,146 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2014, Phil Schwartz <schwartzmx@gmail.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+# win_acl module (File/Resources Permission Additions/Removal)
+$params = Parse-Args $args;
+
+$result = New-Object psobject @{
+    win_acl = New-Object psobject
+    changed = $false
+}
+
+If ($params.src) {
+    $src = $params.src.toString()
+
+    If (-Not (Test-Path -Path $src -PathType Leaf -Or Test-Path -Path $src -PathType Container)) {
+        Fail-Json $result "$src is not a valid file or directory on the host"
+    }
+}
+Else {
+    Fail-Json $result "missing required argument: src"
+}
+
+If ($params.user) {
+    $user = $params.user.toString()
+
+    # Test that the user/group exists on the local machine
+    $localComputer = [ADSI]("WinNT://"+[System.Net.Dns]::GetHostName())
+    $list = ($localComputer.psbase.children | Where-Object { (($_.psBase.schemaClassName -eq "User") -Or ($_.psBase.schemaClassName -eq "Group"))} | Select-Object -expand Name)
+    If (-Not ($list -contains "$user")) {
+        Fail-Json $result "$user is not a valid user or group on the host machine"
+    }
+}
+Else {
+    Fail-Json $result "missing required argument: user.  specify the user or group to apply permission changes."
+}
+
+If ($params.type -eq "allow") {
+    $type = $true
+}
+ElseIf ($params.type -eq "deny") {
+    $type = $false
+}
+Else {
+    Fail-Json $result "missing required argument: type. specify whether to allow or deny the specified rights."
+}
+
+If ($params.inherit) {
+    # If it's a file then no flags can be set or an exception will be thrown
+    If (Test-Path -Path $src -PathType Leaf) {
+        $inherit = "None"
+    }
+    Else {
+        $inherit = $params.inherit.toString()
+    }
+}
+Else {
+    # If it's a file then no flags can be set or an exception will be thrown
+    If (Test-Path -Path $src -PathType Leaf) {
+        $inherit = "None"
+    }
+    Else {
+        $inherit = "ContainerInherit, ObjectInherit"
+    }
+}
+
+If ($params.propagation) {
+    $propagation = $params.propagation.toString()
+}
+Else {
+    $propagation = "None"
+}
+
+If ($params.rights) {
+    $rights = $params.rights.toString()
+}
+Else {
+    Fail-Json $result "missing required argument: rights"
+}
+
+If ($params.state -eq "absent") {
+    $state = "remove"
+}
+Else {
+    $state = "add"
+}
+
+Try {
+    $colRights = [System.Security.AccessControl.FileSystemRights]$rights
+    $InheritanceFlag = [System.Security.AccessControl.InheritanceFlags]$inherit
+    $PropagationFlag = [System.Security.AccessControl.PropagationFlags]$propagation
+
+    If ($type) {
+        $objType =[System.Security.AccessControl.AccessControlType]::Allow
+    }
+    Else {
+        $objType =[System.Security.AccessControl.AccessControlType]::Deny
+    }
+
+    $objUser = New-Object System.Security.Principal.NTAccount($user)
+    $objACE = New-Object System.Security.AccessControl.FileSystemAccessRule ($objUser, $colRights, $InheritanceFlag, $PropagationFlag, $objType)
+    $objACL = Get-ACL $src
+
+    If ($state -eq "add") {
+        Try {
+            $objACL.AddAccessRule($objACE)
+        }
+        Catch {
+            Fail-Json $result "an exception occured when adding the specified rule.  it may already exist."
+        }
+    }
+    Else {
+        Try {
+            $objACL.RemoveAccessRule($objACE)
+        }
+        Catch {
+            Fail-Json $result "an exception occured when removing the specified rule.  it may not exist."
+        }
+    }
+
+    Set-ACL $src $objACL
+
+    $result.changed = $true
+}
+Catch {
+    Fail-Json $result "an error occured when attempting to $state $rights permission(s) on $src for $user"
+}
+
+Exit-Json $result

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -88,15 +88,15 @@ $result = New-Object psobject @{
     changed = $false
 }
  
-If ($params.src) {
-    $src = $params.src.toString()
+If ($params.path) {
+    $path = $params.path.toString()
  
-    If (-Not (Test-Path -Path $src)) {
-        Fail-Json $result "$src file or directory does not exist on the host"
+    If (-Not (Test-Path -Path $path)) {
+        Fail-Json $result "$path file or directory does not exist on the host"
     }
 }
 Else {
-    Fail-Json $result "missing required argument: src"
+    Fail-Json $result "missing required argument: path"
 }
  
 If ($params.user) {
@@ -124,7 +124,7 @@ Else {
  
 If ($params.inherit) {
     # If it's a file then no flags can be set or an exception will be thrown
-    If (Test-Path -Path $src -PathType Leaf) {
+    If (Test-Path -Path $path -PathType Leaf) {
         $inherit = "None"
     }
     Else {
@@ -133,7 +133,7 @@ If ($params.inherit) {
 }
 Else {
     # If it's a file then no flags can be set or an exception will be thrown
-    If (Test-Path -Path $src -PathType Leaf) {
+    If (Test-Path -Path $path -PathType Leaf) {
         $inherit = "None"
     }
     Else {
@@ -176,7 +176,7 @@ Try {
  
     $objUser = New-Object System.Security.Principal.NTAccount($user)
     $objACE = New-Object System.Security.AccessControl.FileSystemAccessRule ($objUser, $colRights, $InheritanceFlag, $PropagationFlag, $objType)
-    $objACL = Get-ACL $src
+    $objACL = Get-ACL $path
  
     # Check if the ACE exists already in the objects ACL list
     $match = $false
@@ -190,7 +190,7 @@ Try {
     If ($state -eq "add" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
-            Set-ACL $src $objACL
+            Set-ACL $path $objACL
             $result.changed = $true
         }
         Catch {
@@ -200,7 +200,7 @@ Try {
     ElseIf ($state -eq "remove" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
-            Set-ACL $src $objACL
+            Set-ACL $path $objACL
             $result.changed = $true
         }
         Catch {
@@ -219,7 +219,7 @@ Try {
     }
 }
 Catch {
-    Fail-Json $result "an error occured when attempting to $state $rights permission(s) on $src for $user"
+    Fail-Json $result "an error occured when attempting to $state $rights permission(s) on $path for $user"
 }
  
 Exit-Json $result

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_acl
-version_added: ""
+version_added: "2.0"
 short_description: Set file/directory permissions for a system user or group.
 description:
      - Add or remove rights/permissions for a given user or group for the specified src file or folder.
@@ -107,7 +107,7 @@ options:
       - InheritOnly
     default: "None"
     aliases: []
-author: Phil Schwartz
+author: Phil Schwartz, Trond Hindenes
 '''
 
 EXAMPLES = '''

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -29,18 +29,15 @@ short_description: Set file/directory permissions for a system user or group.
 description:
      - Add or remove rights/permissions for a given user or group for the specified src file or folder.
 options:
-  src:
+  path:
     description:
       - File or Directory
     required: yes
-    default: none
-    aliases: []
   user:
     description:
       - User or Group to add specified rights to act on src file/folder
     required: yes
     default: none
-    aliases: []
   state:
     description:
       - Specify whether to add (present) or remove (absent) the specified access rule
@@ -49,7 +46,6 @@ options:
       - present
       - absent
     default: present
-    aliases: []
   type:
     description:
       - Specify whether to allow or deny the rights specified
@@ -58,7 +54,6 @@ options:
       - allow
       - deny
     default: none
-    aliases: []
   rights:
     description:
       - The rights/permissions that are to be allowed/denyed for the specified user or group for the given src file or directory.  Can be entered as a comma separated list (Ex. "Modify, Delete, ExecuteFile").  For more information on the choices see MSDN FileSystemRights Enumeration.
@@ -86,7 +81,6 @@ options:
       - WriteData
       - WriteExtendedAttributes
     default: none
-    aliases: []
   inherit:
     description:
       - Inherit flags on the ACL rules.  Can be specified as a comma separated list (Ex. "ContainerInherit, ObjectInherit").  For more information on the choices see MSDN InheritanceFlags Enumeration.
@@ -96,7 +90,6 @@ options:
       - ObjectInherit
       - None
     default: For Leaf File: None; For Directory: ContainerInherit, ObjectInherit;
-    aliases: []
   propagation:
     description:
       - Propagation flag on the ACL rules.  For more information on the choices see MSDN PropagationFlags Enumeration.
@@ -106,7 +99,6 @@ options:
       - NoPropagateInherit
       - InheritOnly
     default: "None"
-    aliases: []
 author: Phil Schwartz, Trond Hindenes
 '''
 

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -99,19 +99,19 @@ options:
       - NoPropagateInherit
       - InheritOnly
     default: "None"
-author: Phil Schwartz, Trond Hindenes
+author: Phil Schwartz (@schwartzmx), Trond Hindenes (@trondhindenes)
 '''
 
 EXAMPLES = '''
 # Restrict write,execute access to User Fed-Phil
-$ ansible -i hosts -m win_acl -a "user=Fed-Phil src=C:\Important\Executable.exe type=deny rights='ExecuteFile,Write'" all
+$ ansible -i hosts -m win_acl -a "user=Fed-Phil path=C:\Important\Executable.exe type=deny rights='ExecuteFile,Write'" all
 
 # Playbook example
 # Add access rule to allow IIS_IUSRS FullControl to MySite
 ---
 - name: Add IIS_IUSRS allow rights
   win_acl:
-    src: 'C:\inetpub\wwwroot\MySite'
+    path: 'C:\inetpub\wwwroot\MySite'
     user: 'IIS_IUSRS'
     rights: 'FullControl'
     type: 'allow'
@@ -121,7 +121,7 @@ $ ansible -i hosts -m win_acl -a "user=Fed-Phil src=C:\Important\Executable.exe 
 
 # Remove previously added rule for IIS_IUSRS
 - name: Remove FullControl AccessRule for IIS_IUSRS
-    src: 'C:\inetpub\wwwroot\MySite'
+    path: 'C:\inetpub\wwwroot\MySite'
     user: 'IIS_IUSRS'
     rights: 'FullControl'
     type: 'allow'
@@ -131,7 +131,7 @@ $ ansible -i hosts -m win_acl -a "user=Fed-Phil src=C:\Important\Executable.exe 
 
 # Deny Intern
 - name: Deny Deny
-    src: 'C:\Administrator\Documents'
+    path: 'C:\Administrator\Documents'
     user: 'Intern'
     rights: 'Read,Write,Modify,FullControl,Delete'
     type: 'deny'

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -1,0 +1,147 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Phil Schwartz <schwartzmx@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_acl
+version_added: ""
+short_description: Set file/directory permissions for a system user or group.
+description:
+     - Add or remove rights/permissions for a given user or group for the specified src file or folder.
+options:
+  src:
+    description:
+      - File or Directory
+    required: yes
+    default: none
+    aliases: []
+  user:
+    description:
+      - User or Group to add specified rights to act on src file/folder
+    required: yes
+    default: none
+    aliases: []
+  state:
+    description:
+      - Specify whether to add (present) or remove (absent) the specified access rule
+    required: no
+    choices:
+      - present
+      - absent
+    default: present
+    aliases: []
+  type:
+    description:
+      - Specify whether to allow or deny the rights specified
+    required: yes
+    choices:
+      - allow
+      - deny
+    default: none
+    aliases: []
+  rights:
+    description:
+      - The rights/permissions that are to be allowed/denyed for the specified user or group for the given src file or directory.  Can be entered as a comma separated list (Ex. "Modify, Delete, ExecuteFile").  For more information on the choices see MSDN FileSystemRights Enumeration.
+    required: yes
+    choices:
+      - AppendData
+      - ChangePermissions
+      - Delete
+      - DeleteSubdirectoriesAndFiles
+      - ExecuteFile
+      - FullControl
+      - ListDirectory
+      - Modify
+      - Read
+      - ReadAndExecute
+      - ReadAttributes
+      - ReadData
+      - ReadExtendedAttributes
+      - ReadPermissions
+      - Synchronize
+      - TakeOwnership
+      - Traverse
+      - Write
+      - WriteAttributes
+      - WriteData
+      - WriteExtendedAttributes
+    default: none
+    aliases: []
+  inherit:
+    description:
+      - Inherit flags on the ACL rules.  Can be specified as a comma separated list (Ex. "ContainerInherit, ObjectInherit").  For more information on the choices see MSDN InheritanceFlags Enumeration.
+    required: no
+    choices:
+      - ContainerInherit
+      - ObjectInherit
+      - None
+    default: For Leaf File: None; For Directory: ContainerInherit, ObjectInherit;
+    aliases: []
+  propagation:
+    description:
+      - Propagation flag on the ACL rules.  For more information on the choices see MSDN PropagationFlags Enumeration.
+    required: no
+    choices:
+      - None
+      - NoPropagateInherit
+      - InheritOnly
+    default: "None"
+    aliases: []
+author: Phil Schwartz
+'''
+
+EXAMPLES = '''
+# Restrict write,execute access to User Fed-Phil
+$ ansible -i hosts -m win_acl -a "user=Fed-Phil src=C:\Important\Executable.exe type=deny rights='ExecuteFile,Write'" all
+
+# Playbook example
+# Add access rule to allow IIS_IUSRS FullControl to MySite
+---
+- name: Add IIS_IUSRS allow rights
+  win_acl:
+    src: 'C:\inetpub\wwwroot\MySite'
+    user: 'IIS_IUSRS'
+    rights: 'FullControl'
+    type: 'allow'
+    state: 'present'
+    inherit: 'ContainerInherit, ObjectInherit'
+    propagation: 'None'
+
+# Remove previously added rule for IIS_IUSRS
+- name: Remove FullControl AccessRule for IIS_IUSRS
+    src: 'C:\inetpub\wwwroot\MySite'
+    user: 'IIS_IUSRS'
+    rights: 'FullControl'
+    type: 'allow'
+    state: 'absent'
+    inherit: 'ContainerInherit, ObjectInherit'
+    propagation: 'None'
+
+# Deny Intern
+- name: Deny Deny
+    src: 'C:\Administrator\Documents'
+    user: 'Intern'
+    rights: 'Read,Write,Modify,FullControl,Delete'
+    type: 'deny'
+    state: 'present'
+'''

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2014, Phil Schwartz <schwartzmx@gmail.com>
+# (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
 #
 # This file is part of Ansible
 #


### PR DESCRIPTION
module `win_acl`:  **Access Control**
- Module allows for adding or removing `Allow`/`Deny` rules (permissions) on files and/or directories on Windows hosts.

See `win_acl.py` for documentation on `params`.

Suggestions, concerns, comments, anything? Let me know please.

Phil
