### PR TITLE
Clear rabbitmq_user pw when none is specified

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -162,7 +162,11 @@ class RabbitMqUser(object):
         return dict()
 
     def add(self):
-        self._exec(['add_user', self.username, self.password])
+        if self.password is not None:
+            self._exec(['add_user', self.username, self.password])
+        else
+            self._exec(['add_user', self.username, ''])
+            self._exec(['clear_password', self.username])
 
     def delete(self):
         self._exec(['delete_user', self.username])


### PR DESCRIPTION
Fixes #83. I have not tested this thoroughly, but I thought I might as well send a PR for this.
