### PR TITLE
An Ansible module to manage github keys

### DIFF
--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -159,7 +159,11 @@ def check_required_fields(module):
   present_fields = ['title', 'key', 'password']
   absent_fields = ['key_id', 'password']
 
-  fields = present_fields if module.params['state'] == 'present' else absent_fields
+  if module.params['state'] == 'present':
+    fields = present_fields
+  else:
+    fields = absent_fields
+
   for field in fields:
     if module.params[field] is None:
       raise ValueError(field + " cannot be null for state [" + module.params['state'] + "]")

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -20,13 +20,12 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
-import requests
-from ansible.module_utils.basic import *
+import base64
 
 DOCUMENTATION = '''
 ---
 module: gh_keys
-version_added: n/a
+version_added: 1.9 
 short_description: Manages github ssh keys.
 description:
     - The module manages the ssh key for a specific user through Github API v3.
@@ -34,54 +33,37 @@ options:
   action:
     description: This tells the gh_keys module what you want it to do.
     required: true
-    choices: 
-      list_keys:
-        description: lists keys for authenticated or non-authenticated user. If the passwd field is informed, the module returns all keys and all data about its (In this case, the module will send the authentication data in request). Otherwise, the module returns only some data about the ssh keys of non-authenticated user.
-        required_fields: [user | user & passwd]
-      get_key:
-        description: gets a specific key by github ssh-key-id
-        required_fields: [user & passwd & key_id]
-      add_key:
-        description: adds a new public ssh key
-        required_fields: [user & passwd & title & key]
-      remove_key:
-        description: removes a specific key by github ssh-key-id
-        required_fields: [user & passwd & key_id]
+    choices: [ list_keys, get_key, add_key, remove_key ]
   user:
     description: Github username.
     required: true
-  passwd:
-    description: Github password. If 2FA is enabled for your account, you should generate a new personal access token. 
-    required: for actions: list_keys (your), get_key, add_key, remove_key
+  password:
+    description: Github password. If 2FA is enabled for your account, you should generate a new personal access token. Required for get_key, add_key and remove_key 
+    required: false 
   title:
-    description: Title of the new ssh key
-    required: for add_key action
+    description: Title of the new ssh key. Required for add_key
+    required: false
   key:
-    description: The path of file that contains the public key
-    required: for add_key action
+    description: The path of file that contains the public key. Required for add_key
+    required: false
   key_id:
-    description: The key id provided by Github
-    required: for get_key and remove_key actions
+    description: The key id provided by Github. Required for get_key and remove_key
+    required: false
 author: Leonardo Comelli
 '''
 
 EXAMPLES = '''
 # Example from Ansible Playbooks
-
 # Lists limit informations about all keys of non-authenticated user
 - gh_keys: action=list_keys user=leocomelli
-
 # Lists all informations about all keys of authenticated user
-- gh_keys: action=list_keys user=leocomelli passwd=secret
-
+- gh_keys: action=list_keys user=leocomelli password=secret
 # Gets a single public key (authetication required)
-- gh_keys: action=get_key user=leocomelli passwd=secret key_id=8767854
-
+- gh_keys: action=get_key user=leocomelli password=secret key_id=8767854
 # Adds a new public key (authentication required)
-- gh_keys: action=add_key user=leocomelli passwd=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
-
+- gh_keys: action=add_key user=leocomelli password=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
 # Removes an existing ssh key
-- gh_keys: action=remove_key user=leocomelli passwd=secret key_id=8767854
+- gh_keys: action=remove_key user=leocomelli password=secret key_id=8767854
 '''
 
 GH_API_URL = "https://api.github.com/%s"
@@ -89,14 +71,15 @@ GH_API_URL = "https://api.github.com/%s"
 class GHKeys(object):
 
   def __init__(self, module):
+    self.module = module
     self.action = module.params['action']
     self.user   = module.params['user']
-    self.passwd = module.params['passwd']
+    self.password = module.params['password']
     self.title  = module.params['title']
     self.key    = module.params['key']
     self.key_id = module.params['key_id']
   
-  def work(self):
+  def perform_by_action(self):
     return {
       'list_keys'  : self.list_keys,
       'get_key'    : self.get_key,
@@ -105,73 +88,89 @@ class GHKeys(object):
     }[self.action]()
 
   def list_keys(self):
-    if self.passwd is None:
+    if self.password is None:
       url = GH_API_URL % "users/%s/keys" % self.user
-      response = requests.get(url)  
+      response, info = fetch_url(self.module, url)
     else:
       url = GH_API_URL % "user/keys"
-      response = requests.get(url, auth=(self.user, self.passwd))  
-
-    return response.text
-
+      headers = self.get_auth_header(self.user, self.password)
+      response, info = fetch_url(self.module, url, headers=headers)
+    
+    return self.handle_response(response, info)
+ 
   def get_key(self):
-    self.validate_fileds('get_key', ['key_id', 'passwd'])    
+    self.validate_fields('get_key', ['key_id', 'password'])    
 
     url = GH_API_URL %  "user/keys/%s" % self.key_id
-    response = requests.get(url, auth=(self.user, self.passwd)) 
+    headers = self.get_auth_header(self.user, self.password)
+    response, info = fetch_url(self.module, url, headers=headers)
 
-    return response.text
+    return self.handle_response(response, info)
 
   def add_key(self):
-    self.validate_fileds('add_key', ['title', 'key', 'passwd'])
+    self.validate_fields('add_key', ['title', 'key', 'password'])
 
-    with open(self.key, 'r') as content_file:
-      content = content_file.read()
-
+    f = open(self.key, 'r')
+    try:
+      content = f.readline()
+    finally:
+      f.close()
+    
     url = GH_API_URL %  "user/keys"
+    headers = self.get_auth_header(self.user, self.password)
     data = json.dumps({ 'title' : self.title, 'key' : content })
-    response = requests.post(url, auth = (self.user, self.passwd), data = data) 
-
-    return response.text
+    response, info = fetch_url(self.module, url, headers=headers, data=data, method='POST')
+      
+    return self.handle_response(response, info)
 
   def remove_key(self):
-    self.validate_fileds('remove_key', ['key_id', 'passwd'])
+    self.validate_fields('remove_key', ['key_id', 'password'])
 
     url = GH_API_URL %  "user/keys/%s" % self.key_id
-    response = requests.delete(url, auth=(self.user, self.passwd)) 
+    headers = self.get_auth_header(self.user, self.password)
+    response, info = fetch_url(self.module, url, headers=headers, method='DELETE')
 
-    return response.text
+    return self.handle_response(response, info)
 
-  def validate_fileds(self, action, fields):
+  def get_auth_header(self, user, password):
+    auth = base64.encodestring('%s:%s' % (user, password)).replace('\n', '')
+    headers = {
+      'Authorization': 'Basic %s' % auth,
+    }
+    return headers
+
+  def validate_fields(self, action, fields):
     for field in fields:
       if getattr(self, field) is None:
         raise ValueError(field + " cannot be null for action [" + action + "]")
 
-
-def convert_bool_to_str(value):
-  return value.replace('true', '"true"').replace('false', '"false"')
+  def handle_response(self, response, info):
+    if info['status'] == 200:
+      return response.read()
+    else:
+      raise RuntimeError(info['msg']) 
 
 def main():
   module = AnsibleModule(
     argument_spec = dict(
-      passwd = dict(),
-      title  = dict(),
-      key    = dict(),
-      key_id = dict(),
-      user   = dict(required=True),
-      action = dict(required=True, choices=['list_keys', 'get_key', 'add_key', 'remove_key']),
+      password = dict(),
+      title    = dict(),
+      key      = dict(),
+      key_id   = dict(),
+      user     = dict(required=True),
+      action   = dict(required=True, choices=['list_keys', 'get_key', 'add_key', 'remove_key']),
     )
   )  
 
   gh_keys = GHKeys(module)
   try:
-    result = gh_keys.work()
-    if 'message' in result:
-      raise RuntimeError(result)
-
-    module.exit_json(changed=True, stdout=result)
-  except (RuntimeError, ValueError) as err:
+    response = gh_keys.perform_by_action()
+    module.exit_json(changed=True, result=response)
+  except (RuntimeError, ValueError), err:
     module.fail_json(msg=err.args)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
 
 if __name__ == '__main__':
   main()

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -22,7 +22,7 @@
 DOCUMENTATION = '''
 ---
 module: gh_keys
-version_added: 1.9 
+version_added: 2.0 
 short_description: Manages github ssh keys.
 description:
     - The module manages the ssh key for a specific user through Github API v3.
@@ -38,21 +38,25 @@ options:
 
   password:
     description: Github password. If 2FA is enabled for your account, you should generate a new personal access token. Required for get_key, add_key and remove_key 
-    required: false 
+    required: false
+    default: none
 
   title:
     description: Title of the new ssh key. Required for add_key
     required: false
+    default: none
 
   key:
     description: The path of file that contains the public key. Required for add_key
     required: false
+    default: none
 
   key_id:
     description: The key id provided by Github. Required for get_key and remove_key
     required: false
+    default: none
 
-author: Leonardo Comelli
+author: Leonardo Comelli (@leocomelli)
 '''
 
 EXAMPLES = '''

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -22,37 +22,44 @@
 DOCUMENTATION = '''
 ---
 module: gh_keys
-version_added: 2.1 
-short_description: Manages github ssh keys.
+version_added: "2.1" 
+short_description: Manages GitHub ssh keys.
 description:
-    - The module manages the ssh key for a specific user through Github API v3.
+  - The module manages the ssh key for a specific user through Github API v3.
 
 options:
-  action:
-    description: This tells the gh_keys module what you want it to do.
+  state:
+    description: 
+      - This tells the gh_keys module what you want it to do.
     choices: [ present, absent ]
+    default: present
 
   user:
-    description: Github username.
+    description: 
+      - Github username.
     required: true
 
   password:
-    description: Github password. If 2FA is enabled for your account, you should generate a new personal access token. Required for get_key, add_key and remove_key 
-    required: false
+    description: 
+      - Github password. If 2FA is enabled for your account, you should generate a new personal access token.
+    required: true
     default: none
 
   title:
-    description: Title of the new ssh key. Required for add_key
+    description: 
+      - Title of the new ssh key. Required for the present state
     required: false
     default: none
 
   key:
-    description: The path of file that contains the public key. Required for add_key
+    description: 
+      - The path of file that contains the public key. Required for the present state
     required: false
     default: none
 
   key_id:
-    description: The key id provided by Github. Required for get_key and remove_key
+    description: 
+      - The key id provided by Github. Required for the absent state
     required: false
     default: none
 
@@ -62,34 +69,27 @@ author: Leonardo Comelli (@leocomelli)
 EXAMPLES = '''
 # Example from Ansible Playbooks
 
-# Lists limit informations about all keys of non-authenticated user
-- gh_keys: user=leocomelli
+# Adds a new public key
+- gh_keys: state=present user=leocomelli password=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
 
-# Lists all informations about all keys of authenticated user
-- gh_keys: user=leocomelli password=secret
-
-# Gets a single public key (authetication required)
-- gh_keys: user=leocomelli password=secret key_id=8767854
-
-# Adds a new public key (authentication required)
-- gh_keys: action=present user=leocomelli password=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
-
-# Removes an existing ssh key (authentication required)
-- gh_keys: action=absent user=leocomelli password=secret key_id=8767854
+# Removes an existing ssh key
+- gh_keys: state=absent user=leocomelli password=secret key_id=8767854
 '''
 
 RETURN = '''
 output:
-  description: the data returned by Github according to the action performed
+  description: the data returned by Github according to the state
   returned: success
   type: dict
   sample: 
     {
-      "id":9999999991,
-      "key":"ssh-rsa AAA2...",
-      "url":"https://api.github.com/user/keys/9999999991",
-      "title":"my-new-pkey",
-      "verified":true
+        "created_at": "2016-03-25T17:08:51Z", 
+        "id": 12345678, 
+        "key": "ssh-rsa AAAA...", 
+        "read_only": false, 
+        "title": "devel", 
+        "url": "https://api.github.com/user/keys/12345678", 
+        "verified": true
     }
 '''
 
@@ -105,45 +105,20 @@ class GHKeys(object):
 
   def __init__(self, module):
     self.module = module
-    self.action = module.params['action']
+    self.state = module.params['state']
     self.user   = module.params['user']
     self.password = module.params['password']
     self.title  = module.params['title']
     self.key    = module.params['key']
     self.key_id = module.params['key_id']
   
-  def perform_by_action(self):
-    print self.action
+  def handle_state(self):
     return {
-      'list_keys'  : self.list_keys,
-      'get_key'    : self.get_key,
-      'present'    : self.add_key,
-      'absent' : self.remove_key
-    }[self.action]()
-
-  def list_keys(self):
-    if self.password is None:
-      url = GH_API_URL % "users/%s/keys" % self.user
-      response, info = fetch_url(self.module, url)
-    else:
-      url = GH_API_URL % "user/keys"
-      headers = self.get_auth_header(self.user, self.password)
-      response, info = fetch_url(self.module, url, headers=headers)
-    
-    return self.handle_response(response, info)
- 
-  def get_key(self):
-    self.validate_fields('get_key', ['key_id', 'password'])    
-
-    url = GH_API_URL %  "user/keys/%s" % self.key_id
-    headers = self.get_auth_header(self.user, self.password)
-    response, info = fetch_url(self.module, url, headers=headers)
-
-    return self.handle_response(response, info)
+      'present' : self.add_key,
+      'absent'  : self.remove_key
+    }[self.state]()
 
   def add_key(self):
-    self.validate_fields('add_key', ['title', 'key', 'password'])
-
     f = open(self.key, 'r')
     try:
       content = f.readline()
@@ -158,8 +133,6 @@ class GHKeys(object):
     return self.handle_response(response, info)
 
   def remove_key(self):
-    self.validate_fields('remove_key', ['key_id', 'password'])
-
     url = GH_API_URL %  "user/keys/%s" % self.key_id
     headers = self.get_auth_header(self.user, self.password)
     response, info = fetch_url(self.module, url, headers=headers, method='DELETE')
@@ -173,38 +146,43 @@ class GHKeys(object):
     }
     return headers
 
-  def validate_fields(self, action, fields):
-    for field in fields:
-      if getattr(self, field) is None:
-        raise ValueError(field + " cannot be null for action [" + action + "]")
-
   def handle_response(self, response, info):
     if info['status'] == 200:
       return response.read()
     else:
-      raise RuntimeError(info['msg']) 
+      raise RuntimeError('%s%s' % (info['msg'], \
+                                   " - key is already in use" if info['status'] == 422 else ""))
+
+def check_required_fields(module):
+  present_fields = ['title', 'key', 'password']
+  absent_fields = ['key_id', 'password']
+
+  fields = present_fields if module.params['state'] == 'present' else absent_fields
+  for field in fields:
+    if module.params[field] is None:
+      raise ValueError(field + " cannot be null for state [" + module.params['state'] + "]")
 
 def main():
   module = AnsibleModule(
     argument_spec = dict(
-      password = dict(),
+      password = dict(no_log=True),
       title    = dict(),
       key      = dict(),
       key_id   = dict(),
       user     = dict(required=True),
-      action   = dict(choices=['present', 'absent']),
-    )
+      state    = dict(choices=['present', 'absent'], default='present'),
+    ),
+    supports_check_mode=True
   )  
 
+  check_required_fields(module)
+  if module.check_mode:
+    module.exit_json(changed=True)
+
   gh_keys = GHKeys(module)
-  if gh_keys.action is None:
-    if gh_keys.key_id is not None:
-      gh_keys.action = "get_key"
-    else:
-      gh_keys.action = "list_keys"
 
   try:
-    response = gh_keys.perform_by_action()
+    response = gh_keys.handle_state()
     module.exit_json(changed=True, result=response)
   except (RuntimeError, ValueError), err:
     module.fail_json(msg=err.args)

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -150,8 +150,10 @@ class GHKeys(object):
     if info['status'] == 200:
       return response.read()
     else:
-      raise RuntimeError('%s%s' % (info['msg'], \
-                                   " - key is already in use" if info['status'] == 422 else ""))
+      msg = info['msg']
+      if info['status'] == 422:
+        msg += " - key is already in use"
+      raise RuntimeError(msg)
 
 def check_required_fields(module):
   present_fields = ['title', 'key', 'password']

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -78,6 +78,21 @@ EXAMPLES = '''
 - gh_keys: action=absent user=leocomelli password=secret key_id=8767854
 '''
 
+RETURN = '''
+output:
+  description: the data returned by Github according to the action performed
+  returned: success
+  type: dict
+  sample: 
+    {
+      "id":9999999991,
+      "key":"ssh-rsa AAA2...",
+      "url":"https://api.github.com/user/keys/9999999991",
+      "title":"my-new-pkey",
+      "verified":true
+    }
+'''
+
 import base64
 try:
   import json

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -22,7 +22,7 @@
 DOCUMENTATION = '''
 ---
 module: gh_keys
-version_added: 2.0 
+version_added: 2.1 
 short_description: Manages github ssh keys.
 description:
     - The module manages the ssh key for a specific user through Github API v3.

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -19,9 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
-import base64
-
 DOCUMENTATION = '''
 ---
 module: gh_keys
@@ -29,42 +26,59 @@ version_added: 1.9
 short_description: Manages github ssh keys.
 description:
     - The module manages the ssh key for a specific user through Github API v3.
+
 options:
   action:
     description: This tells the gh_keys module what you want it to do.
-    required: true
-    choices: [ list_keys, get_key, add_key, remove_key ]
+    choices: [ present, absent ]
+
   user:
     description: Github username.
     required: true
+
   password:
     description: Github password. If 2FA is enabled for your account, you should generate a new personal access token. Required for get_key, add_key and remove_key 
     required: false 
+
   title:
     description: Title of the new ssh key. Required for add_key
     required: false
+
   key:
     description: The path of file that contains the public key. Required for add_key
     required: false
+
   key_id:
     description: The key id provided by Github. Required for get_key and remove_key
     required: false
+
 author: Leonardo Comelli
 '''
 
 EXAMPLES = '''
 # Example from Ansible Playbooks
+
 # Lists limit informations about all keys of non-authenticated user
-- gh_keys: action=list_keys user=leocomelli
+- gh_keys: user=leocomelli
+
 # Lists all informations about all keys of authenticated user
-- gh_keys: action=list_keys user=leocomelli password=secret
+- gh_keys: user=leocomelli password=secret
+
 # Gets a single public key (authetication required)
-- gh_keys: action=get_key user=leocomelli password=secret key_id=8767854
+- gh_keys: user=leocomelli password=secret key_id=8767854
+
 # Adds a new public key (authentication required)
-- gh_keys: action=add_key user=leocomelli password=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
-# Removes an existing ssh key
-- gh_keys: action=remove_key user=leocomelli password=secret key_id=8767854
+- gh_keys: action=present user=leocomelli password=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
+
+# Removes an existing ssh key (authentication required)
+- gh_keys: action=absent user=leocomelli password=secret key_id=8767854
 '''
+
+import base64
+try:
+  import json
+except ImportError:
+  import simplejson as json
 
 GH_API_URL = "https://api.github.com/%s"
 
@@ -80,11 +94,12 @@ class GHKeys(object):
     self.key_id = module.params['key_id']
   
   def perform_by_action(self):
+    print self.action
     return {
       'list_keys'  : self.list_keys,
       'get_key'    : self.get_key,
-      'add_key'    : self.add_key,
-      'remove_key' : self.remove_key
+      'present'    : self.add_key,
+      'absent' : self.remove_key
     }[self.action]()
 
   def list_keys(self):
@@ -158,11 +173,17 @@ def main():
       key      = dict(),
       key_id   = dict(),
       user     = dict(required=True),
-      action   = dict(required=True, choices=['list_keys', 'get_key', 'add_key', 'remove_key']),
+      action   = dict(choices=['present', 'absent']),
     )
   )  
 
   gh_keys = GHKeys(module)
+  if gh_keys.action is None:
+    if gh_keys.key_id is not None:
+      gh_keys.action = "get_key"
+    else:
+      gh_keys.action = "list_keys"
+
   try:
     response = gh_keys.perform_by_action()
     module.exit_json(changed=True, result=response)

--- a/source_control/gh_keys.py
+++ b/source_control/gh_keys.py
@@ -1,0 +1,177 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, André Paramés <git@andreparames.com>
+# Based on the Git module by Leonardo Comelli <leonardo.comelli@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import requests
+from ansible.module_utils.basic import *
+
+DOCUMENTATION = '''
+---
+module: gh_keys
+version_added: n/a
+short_description: Manages github ssh keys.
+description:
+    - The module manages the ssh key for a specific user through Github API v3.
+options:
+  action:
+    description: This tells the gh_keys module what you want it to do.
+    required: true
+    choices: 
+      list_keys:
+        description: lists keys for authenticated or non-authenticated user. If the passwd field is informed, the module returns all keys and all data about its (In this case, the module will send the authentication data in request). Otherwise, the module returns only some data about the ssh keys of non-authenticated user.
+        required_fields: [user | user & passwd]
+      get_key:
+        description: gets a specific key by github ssh-key-id
+        required_fields: [user & passwd & key_id]
+      add_key:
+        description: adds a new public ssh key
+        required_fields: [user & passwd & title & key]
+      remove_key:
+        description: removes a specific key by github ssh-key-id
+        required_fields: [user & passwd & key_id]
+  user:
+    description: Github username.
+    required: true
+  passwd:
+    description: Github password. If 2FA is enabled for your account, you should generate a new personal access token. 
+    required: for actions: list_keys (your), get_key, add_key, remove_key
+  title:
+    description: Title of the new ssh key
+    required: for add_key action
+  key:
+    description: The path of file that contains the public key
+    required: for add_key action
+  key_id:
+    description: The key id provided by Github
+    required: for get_key and remove_key actions
+author: Leonardo Comelli
+'''
+
+EXAMPLES = '''
+# Example from Ansible Playbooks
+
+# Lists limit informations about all keys of non-authenticated user
+- gh_keys: action=list_keys user=leocomelli
+
+# Lists all informations about all keys of authenticated user
+- gh_keys: action=list_keys user=leocomelli passwd=secret
+
+# Gets a single public key (authetication required)
+- gh_keys: action=get_key user=leocomelli passwd=secret key_id=8767854
+
+# Adds a new public key (authentication required)
+- gh_keys: action=add_key user=leocomelli passwd=secret title=my_new_key key=/home/leocomelli/.ssh/id_rsa.pub
+
+# Removes an existing ssh key
+- gh_keys: action=remove_key user=leocomelli passwd=secret key_id=8767854
+'''
+
+GH_API_URL = "https://api.github.com/%s"
+
+class GHKeys(object):
+
+  def __init__(self, module):
+    self.action = module.params['action']
+    self.user   = module.params['user']
+    self.passwd = module.params['passwd']
+    self.title  = module.params['title']
+    self.key    = module.params['key']
+    self.key_id = module.params['key_id']
+  
+  def work(self):
+    return {
+      'list_keys'  : self.list_keys,
+      'get_key'    : self.get_key,
+      'add_key'    : self.add_key,
+      'remove_key' : self.remove_key
+    }[self.action]()
+
+  def list_keys(self):
+    if self.passwd is None:
+      url = GH_API_URL % "users/%s/keys" % self.user
+      response = requests.get(url)  
+    else:
+      url = GH_API_URL % "user/keys"
+      response = requests.get(url, auth=(self.user, self.passwd))  
+
+    return response.text
+
+  def get_key(self):
+    self.validate_fileds('get_key', ['key_id', 'passwd'])    
+
+    url = GH_API_URL %  "user/keys/%s" % self.key_id
+    response = requests.get(url, auth=(self.user, self.passwd)) 
+
+    return response.text
+
+  def add_key(self):
+    self.validate_fileds('add_key', ['title', 'key', 'passwd'])
+
+    with open(self.key, 'r') as content_file:
+      content = content_file.read()
+
+    url = GH_API_URL %  "user/keys"
+    data = json.dumps({ 'title' : self.title, 'key' : content })
+    response = requests.post(url, auth = (self.user, self.passwd), data = data) 
+
+    return response.text
+
+  def remove_key(self):
+    self.validate_fileds('remove_key', ['key_id', 'passwd'])
+
+    url = GH_API_URL %  "user/keys/%s" % self.key_id
+    response = requests.delete(url, auth=(self.user, self.passwd)) 
+
+    return response.text
+
+  def validate_fileds(self, action, fields):
+    for field in fields:
+      if getattr(self, field) is None:
+        raise ValueError(field + " cannot be null for action [" + action + "]")
+
+
+def convert_bool_to_str(value):
+  return value.replace('true', '"true"').replace('false', '"false"')
+
+def main():
+  module = AnsibleModule(
+    argument_spec = dict(
+      passwd = dict(),
+      title  = dict(),
+      key    = dict(),
+      key_id = dict(),
+      user   = dict(required=True),
+      action = dict(required=True, choices=['list_keys', 'get_key', 'add_key', 'remove_key']),
+    )
+  )  
+
+  gh_keys = GHKeys(module)
+  try:
+    result = gh_keys.work()
+    if 'message' in result:
+      raise RuntimeError(result)
+
+    module.exit_json(changed=True, stdout=result)
+  except (RuntimeError, ValueError) as err:
+    module.fail_json(msg=err.args)
+
+if __name__ == '__main__':
+  main()

--- a/source_control/gh_keys_facts.py
+++ b/source_control/gh_keys_facts.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2013, André Paramés <git@andreparames.com>
+# Based on the Git module by Leonardo Comelli <leonardo.comelli@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: gh_keys_facts
+version_added: "2.1" 
+short_description: GitHub ssh keys facts.
+description:
+  - GitHub ssh keys facts.
+
+options:
+  user:
+    description: 
+      - Github username.
+    required: true
+
+  password:
+    description: 
+      - Github password. If 2FA is enabled for your account, you should generate a new personal access token. Required for get_key, add_key and remove_key 
+    required: false
+    default: none
+
+  key_id:
+    description: 
+      - The key id provided by Github.
+    required: false
+    default: none    
+
+author: Leonardo Comelli (@leocomelli)
+'''
+
+EXAMPLES = '''
+# Example from Ansible Playbooks
+
+# Gathering facts about all keys of a non-authenticated user (limit informations)
+- gh_keys_facts: user=leocomelli
+
+# Gathering facts about all keys of an authenticated user
+- gh_keys_facts: user=leocomelli password=secret
+
+# Gathering facts about a specific key of an authenticated user
+- gh_keys_facts: user=leocomelli password=secret key_id=8767854
+'''
+
+RETURN = '''
+output:
+  description: the data returned by Github API
+  returned: success
+  type: dict
+  sample: 
+    {
+        "created_at": "2016-03-22T14:49:01Z", 
+        "id": 12345678, 
+        "key": "ssh-rsa AAA...", 
+        "read_only": false, 
+        "title": "devel", 
+        "url": "https://api.github.com/user/keys/12345678", 
+        "verified": true
+    }
+'''
+
+import base64
+try:
+  import json
+except ImportError:
+  import simplejson as json
+
+GH_API_URL = "https://api.github.com/%s"
+
+def facts(module):
+  user = module.params['user']
+  password = module.params['password']
+  key_id = module.params['key_id']
+
+  if password is None:
+    url = GH_API_URL % "users/%s/keys" % user
+    response, info = fetch_url(module, url)      
+  else:
+    url = GH_API_URL % "user/keys"
+    headers = headers = { 'Authorization': 'Basic %s' % base64.encodestring('%s:%s' % (user, password)).replace('\n', ''), }
+    if key_id is not None:
+      url = GH_API_URL %  "user/keys/%s" % key_id
+    response, info = fetch_url(module, url, headers=headers)
+
+  return response, info
+
+
+def main():
+  module = AnsibleModule(
+    argument_spec = dict(
+      user     = dict(required=True),
+      password = dict(no_log=True),
+      key_id   = dict(),
+    )
+  )  
+
+  response, info = facts(module)
+
+  if info['status'] == 200:
+    module.exit_json(changed=True, result=response.read())
+  else:
+    module.fail_json(msg=info['msg'])
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
# Ansible Module - Github Keys

An Ansible module to manage github public keys. The Github lets you add many public ssh keys, this is way that Github uses to identify trusted computers, without involving passwords.
## Features:
- Lists keys of non-authenticated user;
- Lists keys of authenticated user;
- Adds a new public ssh key;
- Gets a public ssh key by GH id;
- Removes an existing public ssh key.
## Sample

```
# file: gh_keys.yml

- hosts: devel
  user: root

  tasks:
    - name: Generate a new public key
      user:
        name: root
        generate_ssh_key: yes
        ssh_key_bits: 2048

    - name: Add a new GH public key
      gh_keys:
        action: add_key
        user: leocomelli
        passwd: secret
        title: devel
        key: /root/.ssh/id_rsa.pub
      register: keys

    - debug:
        var: keys.stdout
```
## Usage
### Lists keys of a non-authenticated user

```
...
- gh_keys:
    action: list_keys
    user: leocomelli

# output
# [{"id":999999999,"key":"ssh-rsa AAA..."}]
```
### Lists keys of an authenticated user

```
...
- gh_keys:
    action: list_keys
    user: leocomelli
    passwd: secret

# output
# [{"id":999999999,"key":"ssh-rsa AAA...","url":"https://api.github.com/user/keys/999999999","title":"test-ghkeys","verified":true}]
```
### Adds a new public ssh key (authentication required)

```
...
- gh_keys:
  action: add_key
  user: leocomelli
  passwd: secret
  title: my-new-pkey
  key: /home/leocomelli/.ssh/id_rsa.pub

# output
# {"id":9999999991,"key":"ssh-rsa AAA2...","url":"https://api.github.com/user/keys/9999999991","title":"my-new-pkey","verified":true}
```
### Gets a public ssh key by GH id (authentication required)

```
...
- gh_keys:
  action: get_key
  user: leocomelli
  passwd: secret
  key_id: 9999999991

# output
# {"id":9999999991,"key":"ssh-rsa AAA2...","url":"https://api.github.com/user/keys/9999999991","title":"my-new-pkey","verified":true}
```
### Removes an existing public ssh key (authentication required)

```
...
- gh_keys:
  action: remove_key
  user: leocomelli
  passwd: secret
  key_id: 9999999991

# output
# N/A
```
## Authentication

The user and passwd fields are used in authentication process. To execute the most action you should be authenticated in GH, in the other words you must informed your GH password. If 2FA (two-facto authentication) features will be enabled for your account, you must generate a new personal access token (Settings > Application > Personal access token > Generate new token).
