### PR TITLE
Add EUC-JP locale name normalization

### DIFF
--- a/system/locale_gen.py
+++ b/system/locale_gen.py
@@ -44,7 +44,7 @@ def is_present(name):
 def fix_case(name):
     """locale -a might return the encoding in either lower or upper case.
     Passing through this function makes them uniform for comparisons."""
-    return name.replace(".utf8", ".UTF-8")
+    return name.replace(".utf8", ".UTF-8").replace(".eucjp", ".EUC-JP")
 
 def replace_line(existing_line, new_line):
     """Replaces lines in /etc/locale.gen"""

--- a/system/locale_gen.py
+++ b/system/locale_gen.py
@@ -32,6 +32,11 @@ EXAMPLES = '''
 - locale_gen: name=de_CH.UTF-8 state=present
 '''
 
+LOCALE_NORMALIZATION = {
+    ".utf8": ".UTF-8",
+    ".eucjp": ".EUC-JP",
+}
+
 # ===========================================
 # location module specific support methods.
 #
@@ -44,7 +49,9 @@ def is_present(name):
 def fix_case(name):
     """locale -a might return the encoding in either lower or upper case.
     Passing through this function makes them uniform for comparisons."""
-    return name.replace(".utf8", ".UTF-8").replace(".eucjp", ".EUC-JP")
+    for s, r in LOCALE_NORMALIZATION.iteritems():
+        name = name.replace(s, r)
+    return name
 
 def replace_line(existing_line, new_line):
     """Replaces lines in /etc/locale.gen"""


### PR DESCRIPTION
The function normalizes checks for UTF-8, but the same issue exists for
other locales as well.  This fix adds normalization for EUC-JP, a Japanese
locale.
