### PR TITLE
Convert symlinks specified in pvs to actual path

### DIFF
--- a/system/lvg.py
+++ b/system/lvg.py
@@ -135,7 +135,9 @@ def main():
     elif state == 'present':
         module.fail_json(msg="No physical volumes given.")
 
-
+    # LVM always uses real paths not symlinks so replace symlinks with actual path
+    for idx, dev in enumerate(dev_list):
+        dev_list[idx] = os.path.realpath(dev)
 
     if state=='present':
         ### check given devices


### PR DESCRIPTION
This is a PR to fix https://github.com/ansible/ansible-modules-extras/issues/197

LVM always follows symlinks and resolves them to the actual path so this PR just does the same, converting symlinks specified in the pvs parameter to real paths.
