### PR TITLE
Replaced special double quote characters with ascii backticks

### DIFF
--- a/system/locale_gen.py
+++ b/system/locale_gen.py
@@ -129,7 +129,7 @@ def main():
             # Ubuntu created its own system to manage locales.
             ubuntuMode = True
         else:
-            module.fail_json(msg="/etc/locale.gen and /var/lib/locales/supported.d/local are missing. Is the package “locales” installed?")
+            module.fail_json(msg="/etc/locale.gen and /var/lib/locales/supported.d/local are missing. Is the package `locales` installed?")
     else:
         # We found the common way to manage locales.
         ubuntuMode = False


### PR DESCRIPTION
This fixes that exception on arch linux:

```
TASK: [locale_gen name=en_US.UTF-8 state=present] ***************************** 
fatal: [arch-01] => Traceback (most recent call last):
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/runner/__init__.py", line 590, in _executor
    exec_rc = self._executor_internal(host, new_stdin)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/runner/__init__.py", line 792, in _executor_internal
    return self._executor_internal_inner(host, self.module_name, self.module_args, inject, port, complex_args=complex_args)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/runner/__init__.py", line 1025, in _executor_internal_inner
    result = handler.run(conn, tmp, module_name, module_args, inject, complex_args)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/runner/action_plugins/normal.py", line 57, in run
    return self.runner._execute_module(conn, tmp, module_name, module_args, inject=inject, complex_args=complex_args)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/runner/__init__.py", line 471, in _execute_module
    ) = self._configure_module(conn, module_name, args, inject, complex_args)
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/runner/__init__.py", line 1336, in _configure_module
    module_path, complex_args, module_args, inject
  File "/home/jpic/env/lib/python2.7/site-packages/ansible/module_common.py", line 188, in modify_module
    module_data = "\n".join(lines)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 117: ordinal not in range(128)


FATAL: all hosts have already failed -- aborting
```
