### PR TITLE
Support empty locale.gen

### DIFF
--- a/system/locale_gen.py
+++ b/system/locale_gen.py
@@ -57,6 +57,10 @@ def replace_line(existing_line, new_line):
     """Replaces lines in /etc/locale.gen"""
     with open("/etc/locale.gen", "r") as f:
         lines = [line.replace(existing_line, new_line) for line in f]
+        
+    if new_line not in lines:
+        lines.append('%s\n' % new_line)
+         
     with open("/etc/locale.gen", "w") as f:
         f.write("".join(lines))
 


### PR DESCRIPTION
Apparently, locale.gen is really distro-specific and is generated by the glibc distro package, so there's not really a sane default we can rely on. Anyway, if `existing_line` is not in `/etc/locale.gen`, then the module will always report as having "changed" and will never make a change. This patch fixes that issue by appending `new_line` if it's not in `lines` before writing to `/etc/locale.gen`.
