### PR TITLE
pkgng: add 'batch' parameter

### DIFF
--- a/packaging/os/pkgng.py
+++ b/packaging/os/pkgng.py
@@ -63,13 +63,6 @@ options:
               for newer pkgng versions, specify a the name of a repository
               configured in /usr/local/etc/pkg/repos
         required: false
-    batch:
-        description:
-            - for packages with interactive prompts during installation,
-              this makes pkgng automatically accept all default options for
-              the installation of the package.
-        default: yes
-        required: false
 author: bleader
 notes:
     - When using pkgsite, be careful that already in cache packages won't be downloaded again.
@@ -143,7 +136,7 @@ def remove_packages(module, pkgng_path, packages):
     return (False, "package(s) already absent")
 
 
-def install_packages(module, pkgng_path, packages, cached, pkgsite, batch):
+def install_packages(module, pkgng_path, packages, cached, pkgsite):
 
     install_c = 0
 
@@ -156,10 +149,8 @@ def install_packages(module, pkgng_path, packages, cached, pkgsite, batch):
         else:
             pkgsite = "-r %s" % (pkgsite)
 
-    if batch == True:
-      batch_var = 'env BATCH=yes'
-    else:
-      batch_var = ''
+    batch_var = 'env BATCH=yes' # This environment variable skips mid-install prompts,
+                                # setting them to their default values.
 
     if not module.check_mode and not cached:
         if old_pkgng:
@@ -276,8 +267,7 @@ def main():
                 name            = dict(aliases=["pkg"], required=True),
                 cached          = dict(default=False, type='bool'),
                 annotation      = dict(default="", required=False),
-                pkgsite         = dict(default="", required=False),
-                batch           = dict(default=False, required=False, type='bool')),
+                pkgsite         = dict(default="", required=False)),
             supports_check_mode = True)
 
     pkgng_path = module.get_bin_path('pkg', True)
@@ -290,7 +280,7 @@ def main():
     msgs = []
 
     if p["state"] == "present":
-        _changed, _msg = install_packages(module, pkgng_path, pkgs, p["cached"], p["pkgsite"], p["batch"])
+        _changed, _msg = install_packages(module, pkgng_path, pkgs, p["cached"], p["pkgsite"])
         changed = changed or _changed
         msgs.append(_msg)
 


### PR DESCRIPTION
Some packages attempt to prompt the user for certain settings during
installation. Thus, this parameter sets the environment variable
$BATCH to 'yes', which forces package installation scripts to accept
default values for these interactive prompts. This should work for all
prompts that have a default value and aren't implemented through a
custom script (as this variable is built into the ports/package system).
This feature was created once I realized that package installs hang
when installing an interactive package without this variable set.
Hopefully someone smarter then me can fix that issue.

A good matching feature would be allowing the user to specify custom
answers to these package prompts.

Although this variable is integrated into the pkg/port system and thus
should work with most prompts, I have NOT tested this with any
packages besides bsdstats. Please let me know what I can improve
upon next time.
