### PR TITLE
haproxy - Fix argument passing to module constructor

### DIFF
--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -243,7 +243,7 @@ def main():
     if not socket:
         module.fail_json(msg="unable to locate haproxy socket")
 
-    ansible_haproxy = HAProxy(module, **module.params)
+    ansible_haproxy = HAProxy(module)
     ansible_haproxy.act()
 
 # import module snippets


### PR DESCRIPTION
- Change to remove kwargs in a97d1016dc77186de8ad05704b6b4c141c005409
  did not remove arguments passed in to the constructor.
