### PR TITLE
Remove `homebrew-` prefix when checking if repo has already been tapped

### DIFF
--- a/packaging/os/homebrew_tap.py
+++ b/packaging/os/homebrew_tap.py
@@ -63,8 +63,11 @@ def already_tapped(module, brew_path, tap):
         brew_path,
         'tap',
     ])
+
     taps = [tap_.strip().lower() for tap_ in out.split('\n') if tap_]
-    return tap.lower() in taps
+    tap_name = re.sub('homebrew-', '', tap.lower())
+
+    return tap_name in taps
 
 
 def add_tap(module, brew_path, tap):


### PR DESCRIPTION
I was trying to add `neovim` in my `ansible` installation script but I had a problem:
- First time it's working well.
- Second time it should do nothing **but** it tries to install it again and fail.

`neovim` uses a repository named `neovim/homebrew-neovim` to install the formulae. In this particular case, `brew tap` remove the `homebrew-` prefix when we display the list of taps:
Example:

```
$ brew tap neovim/homebrew-neovim
$ brew tap
neovim/neovim
...
```

Here the brew implementation: https://github.com/Homebrew/homebrew/blob/master/Library/Homebrew/cmd/tap.rb

This Pull-Request mimics the `brew` behaviours in the `already_tapped` method. Also I tried the ansible test script named `ansible/hacking/test-module`. It was working but I didn't found any unit test so I didn't write any. Do I miss something?

Thanks for your feedbacks
