### PR TITLE
Another potential fix for issue 109; now catches WebFault

### DIFF
--- a/network/f5/bigip_facts.py
+++ b/network/f5/bigip_facts.py
@@ -105,7 +105,7 @@ EXAMPLES = '''
 
 try:
     import bigsuds
-    from suds import MethodNotFound
+    from suds import MethodNotFound, WebFault
 except ImportError:
     bigsuds_found = False
 else:
@@ -1364,7 +1364,7 @@ def generate_dict(api_obj, fields):
         for field in fields:
             try:
                 api_response = getattr(api_obj, "get_" + field)()
-            except MethodNotFound:
+            except (MethodNotFound, WebFault):
                 pass
             else:
                 lists.append(api_response)
@@ -1380,7 +1380,7 @@ def generate_simple_dict(api_obj, fields):
     for field in fields:
         try:
             api_response = getattr(api_obj, "get_" + field)()
-        except MethodNotFound:
+        except (MethodNotFound, WebFault):
             pass
         else:
             result_dict[field] = api_response


### PR DESCRIPTION
This is another potential fix for issue #109. Instead of removing the get_fw_rule API call that is no longer supported by F5, I am catching the suds WebFault and ignoring like we do with MethodNotFound. The benefit of doing this is that it still provides the get_fw_rule functionality for users running 11.3 - 11.5.
