### PR TITLE
pkgutil.py syntax fix

### DIFF
--- a/packaging/os/pkgutil.py
+++ b/packaging/os/pkgutil.py
@@ -165,9 +165,9 @@ def main():
     if rc is None:
         # pkgutil was not executed because the package was already present/absent
         result['changed'] = False
-    elif rc == 0
+    elif rc == 0:
         result['changed'] = True
-    else
+    else:
         result['changed'] = False
         result['failed'] = True
 


### PR DESCRIPTION
Fix for:

```
packaging/os/pkgutil.py:168:17: invalid syntax
    elif rc == 0
                ^
```
