### PR TITLE
lldp - Ignore lines that do not have the key in them

### DIFF
--- a/network/lldp.py
+++ b/network/lldp.py
@@ -54,7 +54,7 @@ def gather_lldp():
         lldp_entries = output.split("\n")
 
         for entry in lldp_entries:
-            if entry:
+            if entry.startswith('lldp'):
                 path, value = entry.strip().split("=", 1)
                 path = path.split(".")
                 path_components, final = path[:-1], path[-1]


### PR DESCRIPTION
Some switches return multi-line output, which breaks the split function,
the change seeks to only preform the split on a line that has the key.
