### PR TITLE
composer: Fixes changed status

### DIFF
--- a/packaging/language/composer.py
+++ b/packaging/language/composer.py
@@ -159,7 +159,8 @@ def main():
         output = parse_out(err)
         module.fail_json(msg=output)
     else:
-        output = parse_out(out)
+        # Composer version > 1.0.0-alpha9 now use stderr for standard notification messages
+        output = parse_out(out + err)
         module.exit_json(changed=has_changed(output), msg=output)
 
 # import module snippets


### PR DESCRIPTION
Fixes changed status that always returns `False` with composer.

This [previous PR](https://github.com/ansible/ansible-modules-extras/pull/61) had fixed the issue but because of a [Composer recent change](https://github.com/composer/composer/commit/cb336a5416595efa321c024735e6452c9c7df106) stderr is now used for reporting information meant for humans while stdout is more for the output of the command.

This PR would solve this "changed status" detection in a more definitive way.
