### PR TITLE
Make the state parameter for locale_gen non-mandatory with a default value.

### DIFF
--- a/system/locale_gen.py
+++ b/system/locale_gen.py
@@ -146,7 +146,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True),
-            state = dict(choices=['present','absent'], required=True),
+            state = dict(choices=['present','absent'], default='present'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
The module documentation for `locale_gen` indicates that the _state_ parameter is not required, with a default value of _present_. At present however, failure to specify _state_ when using the module results in an error. This pull requests amends the module to act in accordance with the documentation.
