### PR TITLE
homebrew_tap: Make valid tap check more accepting

### DIFF
--- a/packaging/os/homebrew_tap.py
+++ b/packaging/os/homebrew_tap.py
@@ -52,7 +52,7 @@ homebrew_tap: tap=homebrew/dupes,homebrew/science state=present
 
 def a_valid_tap(tap):
     '''Returns True if the tap is valid.'''
-    regex = re.compile(r'^(\S+)/(homebrew-)?(\w+)$')
+    regex = re.compile(r'^(\S+)/(homebrew-)?(\S+)$')
     return regex.match(tap)
 
 


### PR DESCRIPTION
Homebrew tap's [naming convention](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/brew-tap.md#naming-conventions-and-limitations) basically tries to validate that the taps match `username/repo_name`. It's not worth it to try to validate github's naming convention for username/repos or homebrew's slight tweaks to it. One thing that does seem to be required here is the `/` since it is looking for a repo within a namespace of some sort; in this case it's username. All other checks we should leave it up to the hombrew tap library instead of doing it in ansible. The basic check for `/` at least verifies that the users aren't trying to tap a homebrew package. Although, I would be even be ok with getting rid of the is valid check completely from this module.

Some version of this is important to merge in soon as it's preventing users from actually tapping valid libraries such as `homebrew/homebrew-head-only`
