### PR TITLE
Add openstack keystone modules

### DIFF
--- a/cloud/openstack/os_project.py
+++ b/cloud/openstack/os_project.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+module: os_project
+version_added: "1.9"
+short_description: Manage OpenStack Identity (keystone) projects
+extends_documentation_fragment: openstack
+description:
+   - Manage project in OpenStack.
+options:
+  state:
+    description:
+      - Should the resource be present or absent.
+    choices: [present, absent]
+    default: present
+  project:
+    description:
+      - The project name or id that has to be added/removed
+    required: true
+  description:
+    description:
+      - A description for the project
+    required: false
+    default: None
+  enabled:
+    description:
+      - Should the project be enabled
+    required: false
+    default: 'yes'
+    choices: ['yes', 'no']
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Create a project
+- os_project: name=demo description="Default Tenant"
+'''
+
+
+def get_project(keystone, name_or_id):
+    """Retrieve a project by name or id."""
+    projects = [x for x in keystone.projects.list()
+                if x.id = name_or_id or x.name == name_or_id]
+    if projects:
+        return projects[0]
+    return None
+
+
+def ensure_project_exists(
+        cloud, name, description, enabled, check_mode):
+    """Ensure that a project exists.
+
+       Return (True, id) if a new project was created, (False, None) if it
+       already existed.
+    """
+
+    # Check if project already exists
+    changed = False
+    project = cloud.get_project(name)
+    if project:
+        if (project['description'] != description
+                or project['enabled'] != enabled):
+            changed = True
+            # We need to update the project description
+            if not check_mode:
+                project = cloud.update_project(
+                    project['id'], description=description, enabled=enabled)
+        return (changed, project)
+        
+    # We now know we will have to create a new project
+    changed = True
+    if check_mode:
+        return (changed, None)
+
+    ks_project = cloud.create_project(
+        name=name, description=description, enabled=enabled)
+    return (changed, ks_project)
+
+
+def ensure_project_absent(cloud, name, check_mode):
+    """Ensure that a project does not exist
+
+        Return True if the project was removed, False if it didn't exist
+        in the first place
+    """
+    project = cloud.get_project(project_name)
+    if not project:
+        return False
+
+    # We now know we will have to delete the project
+    if check_mode:
+        return True
+
+    cloud.delete_project(project['id'])
+    return True
+
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        project=dict(required=True),
+        description=dict(required=False),
+        state=dict(default='present', choices=['absent', 'present']),
+        enabled=dict(default='yes', type='bool'),
+    )
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    project = module.params['project']
+    description = module.params['description']
+    state = module.params['state']
+    enabled = module.params['enabled']
+
+    check_mode = module.check_mode
+
+    try:
+        cloud = shade.openstack_cloud(**module.params)
+
+        if state == "present":
+            changed, project_obj = ensure_project_exists(
+                cloud, project, description, enabled, check_mode)
+            module.exit_json(changed=changed, project=project_obj)
+        elif state == "absent":
+            changed = ensure_project_absent(cloud, project, check_mode)
+            module.exit_json(changed=changed)
+    except shade.OpenStackCloudException as e:
+        if check_mode:
+            # If we have a failure in check mode
+            module.exit_json(changed=True,
+                             msg=e.message, extra_data=e.extra_data)
+        else:
+            module.fail_json(msg=e.message, extra_dtata=e.extra_data)
+    else:
+        module.exit_json(**d)
+
+# this is magic, see lib/ansible/module_common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_role.py
+++ b/cloud/openstack/os_role.py
@@ -1,0 +1,261 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+module: os_role
+version_added: "1.9"
+short_description: Manage OpenStack Identity roles
+extends_documentation_fragment: openstack
+description:
+   - Manage role assignments for OpenStack.
+options:
+  state:
+    description:
+      - Should the resource be present or absent.
+    choices: [present, absent]
+    default: present
+  name:
+    description:
+       - The name of the role to be assigned
+    required: true
+  user:
+    description:
+       - The name of the user the role should be applied to
+    required: true
+  project:
+    description:
+       - The project name in which the role should be applied to the user
+    required: true
+  domain:
+    description:
+       - The domain to operate in
+    required: false
+    default: None
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Apply the admin role to the john user in the demo project
+- os_role: name=admin user=john project=demo
+'''
+
+def user_exists(keystone, user):
+    """Return True if user already exists."""
+    return user in [x.name for x in keystone.users.list()]
+
+
+def get_user(keystone, name):
+    """Retrieve a user by name."""
+    users = [x for x in keystone.users.list() if x.name == name]
+    count = len(users)
+    if count == 0:
+        raise KeyError("No keystone users with name %s" % name)
+    elif count > 1:
+        raise ValueError("%d users with name %s" % (count, name))
+    else:
+        return users[0]
+
+
+def get_role(keystone, name):
+    """Retrieve a role by name."""
+    roles = [x for x in keystone.roles.list() if x.name == name]
+    count = len(roles)
+    if count == 0:
+        raise KeyError("No keystone roles with name %s" % name)
+    elif count > 1:
+        raise ValueError("%d roles with name %s" % (count, name))
+    else:
+        return roles[0]
+
+
+def get_project_id(keystone, name):
+    return get_project(keystone, name).id
+
+
+def get_user_id(keystone, name):
+    return get_user(keystone, name).id
+
+
+def ensure_user_exists(keystone, user_name, password, email, project_name,
+                       check_mode):
+    """Check if user exists.
+
+       Return (True, id) if a new user was created, (False, id) user already
+       exists
+    """
+
+    # Check if project already exists
+    try:
+        user = get_user(keystone, user_name)
+    except KeyError:
+        # Tenant doesn't exist yet
+        pass
+    else:
+        # User does exist, we're done
+        return (False, user.id)
+
+    # We now know we will have to create a new user
+    if check_mode:
+        return (True, None)
+
+    project = get_project(keystone, project_name)
+
+    user = keystone.users.create(name=user_name, password=password,
+                                 email=email, project_id=project.id)
+    return (True, user.id)
+
+
+def ensure_role_exists(keystone, user_name, project_name, role_name,
+                       check_mode):
+    """Check if role exists.
+
+       Return (True, id) if a new role was created or if the role was newly
+       assigned to the user for the project. (False, id) if the role already
+       exists and was already assigned to the user ofr the project.
+
+    """
+    # Check if the user has the role in the project
+    user = get_user(keystone, user_name)
+    project = get_project(keystone, project_name)
+    roles = [x for x in keystone.roles.roles_for_user(user, project)
+             if x.name == role_name]
+    count = len(roles)
+
+    if count == 1:
+        # If the role is in there, we are done
+        role = roles[0]
+        return (False, role.id)
+    elif count > 1:
+        # Too many roles with the same name, throw an error
+        raise ValueError("%d roles with name %s" % (count, role_name))
+
+    # At this point, we know we will need to make changes
+    if check_mode:
+        return (True, None)
+
+    # Get the role if it exists
+    try:
+        role = get_role(keystone, role_name)
+    except KeyError:
+        # Role doesn't exist yet
+        role = keystone.roles.create(role_name)
+
+    # Associate the role with the user in the admin
+    keystone.roles.add_user_role(user, role, project)
+    return (True, role.id)
+
+
+def ensure_user_absent(keystone, user, check_mode):
+    raise NotImplementedError("Not yet implemented")
+
+
+def ensure_role_absent(keystone, uesr, project, role, check_mode):
+    raise NotImplementedError("Not yet implemented")
+
+
+def dispatch(keystone, user=None, password=None, project=None,
+             project_description=None, email=None, role=None,
+             state="present", endpoint=None, token=None, login_user=None,
+             login_password=None, check_mode=False):
+    """Dispatch to the appropriate method.
+
+       Returns a dict that will be passed to exit_json
+
+       project  user  role   state
+       -------  ----  ----  --------
+         X                   present     ensure_project_exists
+         X                   absent      ensure_project_absent
+         X       X           present     ensure_user_exists
+         X       X           absent      ensure_user_absent
+         X       X     X     present     ensure_role_exists
+         X       X     X     absent      ensure_role_absent
+
+
+    """
+    changed = False
+    id = None
+    if project and not user and not role and state == "present":
+        changed, id = ensure_project_exists(
+            keystone, project, project_description, check_mode)
+    elif project and not user and not role and state == "absent":
+        changed = ensure_project_absent(keystone, project, check_mode)
+    elif project and user and not role and state == "present":
+        changed, id = ensure_user_exists(
+            keystone, user, password, email, project, check_mode)
+    elif project and user and not role and state == "absent":
+        changed = ensure_user_absent(keystone, user, check_mode)
+    elif project and user and role and state == "present":
+        changed, id = ensure_role_exists(
+            keystone, user, project, role, check_mode)
+    elif project and user and role and state == "absent":
+        changed = ensure_role_absent(keystone, user, project, role, check_mode)
+    else:
+        # Should never reach here
+        raise ValueError("Code should never reach here")
+
+    return dict(changed=changed, id=id)
+
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        name=dict(required=True),
+        user=dict(required=False),
+        project=dict(required=False),
+        domain=dict(required=False),
+        state=dict(default='present', choices=['absent', 'present']),
+    )
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    name = module.params['name']
+    user = module.params['user']
+    project = module.params['project']
+    domain = module.params['domain']
+    state = module.params['state']
+
+    check_mode = module.check_mode
+
+    try:
+        cloud = shade.openstack_cloud(**module.params)
+
+    except shade.OpenStackCloudException as e:
+        if check_mode:
+            # If we have a failure in check mode
+            module.exit_json(changed=True,
+                             msg=e.message, extra_data=e.extra_data)
+        else:
+            module.fail_json(msg=e.message, extra_dtata=e.extra_data)
+    else:
+        module.exit_json(**d)
+
+# this is magic, see lib/ansible/module_common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_user.py
+++ b/cloud/openstack/os_user.py
@@ -1,0 +1,170 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+module: os_user
+version_added: "1.9"
+short_description: Manage OpenStack users
+extends_documentation_fragment: openstack
+description:
+   - Manage users for OpenStack.
+options:
+  state:
+    description:
+      - Should the resource be present or absent.
+    choices: [present, absent]
+    default: present
+  name:
+    description:
+       - The name of the user that to be added/removed from OpenStack
+    required: true
+  password:
+    description:
+       - The password to be assigned to the user
+    required: false
+    default: None
+  project:
+    description:
+       - The default project name or id for the user
+    required: false
+    default: None
+  email:
+    description:
+       - An email address for the user
+    required: false
+    default: None
+  enabled:
+    description:
+      - Should the user be enabled
+    required: false
+    default: 'yes'
+    choices: ['yes', 'no']
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Create a user
+- os_user: user=john project=demo password=secrete
+'''
+
+def get_user_id(keystone, name):
+    return get_user(keystone, name).id
+
+def ensure_user_exists(cloud, name, password, email, project, enabled, check_mode):
+    """Check if user exists.
+
+       Return (True, user) if a new user was created, (False, user) user already
+       exists
+    """
+
+    # Check if project already exists
+    user = cloud.get_user(name)
+    if user:
+        if user['enabled'] == enabled && user['email'] == email:
+            return (False, user)
+        if check_mode:
+            return (True, user)
+        user = cloud.update_user(
+            name_or_id=user['id'], email=email, enabled=enabled)
+        return (True, user)
+
+    # We now know we will have to create a new user
+    if check_mode:
+        return (True, None)
+
+    user = cloud.create_user(
+        name=name, password=password, email=email, project=project,
+        enabled=enabled)
+    return (True, user)
+
+
+def ensure_user_absent(cloud, name_or_id, check_mode):
+    """Ensure that a user does not exist
+
+        Return True if the user was removed, False if it didn't exist
+        in the first place
+    """
+    user = cloud.get_user(name_or_id)
+    if not user:
+        return False
+
+    # We now know we will have to delete the project
+    if check_mode:
+        return True
+
+    cloud.delete_project(user['id'])
+    return True
+
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        name=dict(required=True),
+        email=dict(required=False),
+        project=dict(required=False),
+        password=dict(required=False),
+        enabled=dict(default='yes', type='bool'),
+        state=dict(default='present', choices=['absent', 'present']),
+    )
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    name = module.params['name']
+    password = module.params['password']
+    project = module.params['project']
+    email = module.params['email']
+    state = module.params['state']
+    enabled = module.params['enabled']
+
+    check_mode = module.check_mode
+
+    try:
+        cloud = shade.openstack_cloud(**module.params)
+
+        if state == 'present':
+            (changed, user_obj) = ensure_user_present(
+                cloud, name, password, project, email, enabled, check_mode)
+            module.exit_json(changed=changed, user=user_obj)
+        else:
+            changed = ensure_user_absent(cloud, name, check_mode)
+            module.exit_json(changed=changed)
+    except shade.OpenStackCloudException as e:
+        if check_mode:
+            # If we have a failure in check mode
+            module.exit_json(changed=True,
+                             msg=e.message, extra_data=e.extra_data)
+        else:
+            module.fail_json(msg=e.message, extra_dtata=e.extra_data)
+    else:
+        module.exit_json(**d)
+
+# this is magic, see lib/ansible/module_common.py
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add modules for managing keystone users, roles and projects. These are
end-user modules because in keystone v3, cloud consumers can be domain
admins and as such can create users, roles and projects in their domain.
In earlier keystone v2 clouds, only admin users would use these modules.
