### PR TITLE
Require semicolon to support pkgin version 0.7.0 because of parsable output

### DIFF
--- a/packaging/os/pkgin.py
+++ b/packaging/os/pkgin.py
@@ -93,7 +93,7 @@ def query_package(module, pkgin_path, name):
         #     '<' - installed but out of date
         #     '=' - installed and up to date
         #     '>' - installed but newer than the repository version
-        pkgname_with_version, raw_state = out.split(' ')[0:2]
+        pkgname_with_version, raw_state = out.split(';')[0:2]
 
         # Strip version
         # (results in sth like 'gcc47-libs')


### PR DESCRIPTION
The newest version of pkgin use parsable output by non tty sessions. Because
some description have also hyphens it result in an error for checking installed
packages. For example: "openvpn-2.3.6;=;Easy-to-use SSL VPN daemon"

Details about the pkgin version could be found here:
  https://github.com/NetBSDfr/pkgin/blob/master/CHANGES#L48
  https://github.com/NetBSDfr/pkgin/blob/master/main.c#L62
