### PR TITLE
Updated lxc_container module to fix option parsing

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -616,7 +616,7 @@ class LxcContainerManagement(object):
         # TODO(cloudnull) adjust import when issue has been resolved.
         import ast
         options_dict = ast.literal_eval(_container_config)
-        parsed_options = [i.split('=') for i in options_dict]
+        parsed_options = [i.split('=', 1) for i in options_dict]
 
         config_change = False
         for key, value in parsed_options:


### PR DESCRIPTION
The option parsing object within the module was performing a split
on an '=' sign and assuming that there would only ever be one '='
in a user provided option. Sadly, the assumption is incorrect and
the list comprehension that is building the options list needs to
be set to split on the first occurrence of an '=' sign in a given
option string. This commit adds the required change to make it
possible for options to contain additional '=' signs and be handled
correctly.

Closes-Bug: https://github.com/ansible/ansible-modules-extras/issues/325
