### PR TITLE
Fix typo in hipchat notification failure message.

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -137,7 +137,7 @@ def main():
     try:
         send_msg(module, token, room, msg_from, msg, msg_format, color, notify, api)
     except Exception, e:
-        module.fail_json(msg="unable to sent msg: %s" % e)
+        module.fail_json(msg="unable to send msg: %s" % e)
 
     changed = True
     module.exit_json(changed=changed, room=room, msg_from=msg_from, msg=msg)


### PR DESCRIPTION
Wish it could be more substantial, but alas, it's just a typo in a string.
