### PR TITLE
Added example block for the "SMTP username and password"

### DIFF
--- a/notification/mail.py
+++ b/notification/mail.py
@@ -116,6 +116,16 @@ EXAMPLES = '''
 # Example playbook sending mail to root
 - local_action: mail msg='System {{ ansible_hostname }} has been successfully provisioned.'
 
+# Sending an e-mail using Gmail SMTP servers
+- local_action: mail
+                host='smtp.gmail.com'
+                port=587
+                username=username@gmail.com
+                password='mysecret'
+                to="John Smith <john.smith@example.com>"
+                subject='Ansible-report'
+                msg='System {{ ansible_hostname }} has been successfully provisioned.'
+
 # Send e-mail to a bunch of users, attaching files
 - local_action: mail
                 host='127.0.0.1'


### PR DESCRIPTION
Since my recent merge request. I noticed that the docs and example hasn't been updated for a example block using the username and password. 

A example block pull request, using the Gmail SMTP servers on port 587(TLS). Hopefully this will update the docs too.

Thanks.
