### PR TITLE
system/lvol: Suppress prompts from lvcreate

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -187,7 +187,7 @@ def main():
                 changed = True
             else:
                 lvcreate_cmd = module.get_bin_path("lvcreate", required=True)
-                rc, _, err = module.run_command("%s -n %s -%s %s%s %s" % (lvcreate_cmd, lv, size_opt, size, size_unit, vg))
+                rc, _, err = module.run_command("%s --yes -n %s -%s %s%s %s" % (lvcreate_cmd, lv, size_opt, size, size_unit, vg))
                 if rc == 0:
                     changed = True
                 else:


### PR DESCRIPTION
Occasionally, `lvcreate` will prompt on stdin for confirmation. In
particular, this may happen when the volume is being created close to
the location on disk where another volume existed previously. When this
happens, Ansible will hang indefinitely with no indication of the
problem. To work prevent this problem, the `--yes` command-line argument
can be passed to `lvcreate`, which will instruct it not to prompt.

Signed-off-by: Dustin C. Hatch dustin@hatch.name
