### PR TITLE
Add `verify` param; set false to ignore SSL cert

### DIFF
--- a/network/f5/bigip_monitor_tcp.py
+++ b/network/f5/bigip_monitor_tcp.py
@@ -49,6 +49,14 @@ options:
             - BIG-IP password
         required: true
         default: null
+    validate_certs:
+        description:
+            - If C(no), SSL certificates will not be validated. This should only be used
+              on personally controlled sites using self-signed certificates.
+        required: false
+        default: 'yes'
+        choices: ['yes', 'no']
+        version_added: 1.9.1
     state:
         description:
             - Monitor state
@@ -196,6 +204,14 @@ def bigip_api(bigip, user, password):
     return api
 
 
+def disable_ssl_cert_validation():
+
+    # You probably only want to do this for testing and never in production.
+    # From https://www.python.org/dev/peps/pep-0476/#id29
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
+
 def check_monitor_exists(module, api, monitor, parent):
 
     # hack to determine if monitor exists
@@ -331,6 +347,7 @@ def main():
             server    = dict(required=True),
             user      = dict(required=True),
             password  = dict(required=True),
+            validate_certs = dict(default='yes', type='bool'),
             partition = dict(default='Common'),
             state     = dict(default='present', choices=['present', 'absent']),
             name      = dict(required=True),
@@ -351,6 +368,7 @@ def main():
     server = module.params['server']
     user = module.params['user']
     password = module.params['password']
+    validate_certs = module.params['validate_certs']
     partition = module.params['partition']
     parent_partition = module.params['parent_partition']
     state = module.params['state']
@@ -371,6 +389,9 @@ def main():
     TEMPLATE_TYPE = type
 
     # end monitor specific stuff
+
+    if not validate_certs:
+        disable_ssl_cert_validation()
 
     if not bigsuds_found:
         module.fail_json(msg="the python bigsuds module is required")

--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -56,6 +56,14 @@ options:
         default: null
         choices: []
         aliases: []
+    validate_certs:
+        description:
+            - If C(no), SSL certificates will not be validated. This should only be used
+              on personally controlled sites using self-signed certificates.
+        required: false
+        default: 'yes'
+        choices: ['yes', 'no']
+        version_added: 1.9.1
     state:
         description:
             - Pool member state
@@ -189,6 +197,12 @@ def bigip_api(bigip, user, password):
     api = bigsuds.BIGIP(hostname=bigip, username=user, password=password)
     return api
 
+def disable_ssl_cert_validation():
+    # You probably only want to do this for testing and never in production.
+    # From https://www.python.org/dev/peps/pep-0476/#id29
+    import ssl
+    ssl._create_default_https_context = ssl._create_unverified_context
+
 def pool_exists(api, pool):
     # hack to determine if pool exists
     result = False
@@ -282,6 +296,7 @@ def main():
             server = dict(type='str', required=True),
             user = dict(type='str', required=True),
             password = dict(type='str', required=True),
+            validate_certs = dict(default='yes', type='bool'),
             state = dict(type='str', default='present', choices=['present', 'absent']),
             pool = dict(type='str', required=True),
             partition = dict(type='str', default='Common'),
@@ -301,6 +316,7 @@ def main():
     server = module.params['server']
     user = module.params['user']
     password = module.params['password']
+    validate_certs = module.params['validate_certs']
     state = module.params['state']
     partition = module.params['partition']
     pool = "/%s/%s" % (partition, module.params['pool'])
@@ -311,6 +327,9 @@ def main():
     host = module.params['host']
     address = "/%s/%s" % (partition, host)
     port = module.params['port']
+
+    if not validate_certs:
+        disable_ssl_cert_validation()
 
     # sanity check user supplied values
 


### PR DESCRIPTION
Ignoring SSL cert verification may be necessary when testing with a server that has a self-signed certificate.

See https://github.com/ansible/ansible-modules-extras/pull/288#issuecomment-85196736

Cc: @mhite, @sudarkoff
