### PR TITLE
patch: Add binary option that maps to --binary to handle CLRF patches

### DIFF
--- a/files/patch.py
+++ b/files/patch.py
@@ -70,6 +70,12 @@ options:
     description:
       - passes --backup --version-control=numbered to patch, 
         producing numbered backup copies
+  binary:
+    version_added: "2.0"
+    description:
+      - Setting to true will disable patch's heuristic for transforming CRLF
+        line endings into LF. Line endings of src and dest must match. If set to
+        False, patch will replace CRLF in src files on POSIX.
     required: false
     type: "bool"
     default: "False"
@@ -98,10 +104,12 @@ class PatchError(Exception):
     pass
 
 
-def is_already_applied(patch_func, patch_file, basedir, dest_file=None, strip=0):
+def is_already_applied(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0):
     opts = ['--quiet', '--reverse', '--forward', '--dry-run',
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
+    if binary:
+        opts.append('--binary')
     if dest_file:
         opts.append("'%s'" % dest_file)
 
@@ -109,12 +117,14 @@ def is_already_applied(patch_func, patch_file, basedir, dest_file=None, strip=0)
     return rc == 0
 
 
-def apply_patch(patch_func, patch_file, basedir, dest_file=None, strip=0, dry_run=False, backup=False):
+def apply_patch(patch_func, patch_file, basedir, dest_file=None, binary=False, strip=0, dry_run=False, backup=False):
     opts = ['--quiet', '--forward', '--batch', '--reject-file=-',
             "--strip=%s" % strip, "--directory='%s'" % basedir,
             "--input='%s'" % patch_file]
     if dry_run:
         opts.append('--dry-run')
+    if binary:
+        opts.append('--binary')
     if dest_file:
         opts.append("'%s'" % dest_file)
     if backup:
@@ -136,7 +146,8 @@ def main():
             'remote_src': {'default': False, 'type': 'bool'},
             # NB: for 'backup' parameter, semantics is slightly different from standard
             #     since patch will create numbered copies, not strftime("%Y-%m-%d@%H:%M:%S~")
-            'backup': { 'default': False, 'type': 'bool' }
+            'backup': {'default': False, 'type': 'bool'},
+            'binary': {'default': False, 'type': 'bool'},
         },
         required_one_of=[['dest', 'basedir']],
         supports_check_mode=True
@@ -167,9 +178,9 @@ def main():
     p.src = os.path.abspath(p.src)
     
     changed = False
-    if not is_already_applied(patch_func, p.src, p.basedir, dest_file=p.dest, strip=p.strip):
+    if not is_already_applied(patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip):
         try:
-            apply_patch( patch_func, p.src, p.basedir, dest_file=p.dest, strip=p.strip,
+            apply_patch( patch_func, p.src, p.basedir, dest_file=p.dest, binary=p.binary, strip=p.strip,
                          dry_run=module.check_mode, backup=p.backup )
             changed = True
         except PatchError, e:


### PR DESCRIPTION
```
  binary:
    description:
      - Setting to true will disable patch's heuristic for transforming CRLF
        line endings into LF. Line endings of src and dest must match. If set to
        False, patch will replace CRLF in src files on POSIX.
    required: false
    type: "bool"
    default: "False"
```
