### PR TITLE
correct version_added for known_hosts

### DIFF
--- a/system/known_hosts.py
+++ b/system/known_hosts.py
@@ -26,7 +26,7 @@ description:
    - The M(known_hosts) module lets you add or remove a host from the C(known_hosts) file. 
      This is useful if you're going to want to use the M(git) module over ssh, for example. 
      If you have a very large number of host keys to manage, you will find the M(template) module more useful.
-version_added: "1.6"
+version_added: "1.9"
 options:
   name:
     aliases: [ 'host' ]


### PR DESCRIPTION
It was added in 1.9, not 1.6.
