### PR TITLE
Import boto.ec2 in sns to allow boto profiles to be used

### DIFF
--- a/notification/sns.py
+++ b/notification/sns.py
@@ -105,6 +105,7 @@ from ansible.module_utils.ec2 import *
 
 try:
     import boto
+    import boto.ec2
     import boto.sns
 except ImportError:
     print "failed=True msg='boto required for this module'"


### PR DESCRIPTION
If you try to use boto profiles with the SNS notification module, you will see the following error:

```
failed: [localhost -> 127.0.0.1] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1427903357.81-226906533943713/sns", line 1988, in <module>
    main()
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1427903357.81-226906533943713/sns", line 1949, in main
    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1427903357.81-226906533943713/sns", line 1844, in get_aws_connection_info
    if not boto_supports_profile_name():
  File "/home/ec2-user/.ansible/tmp/ansible-tmp-1427903357.81-226906533943713/sns", line 1775, in boto_supports_profile_name
    return hasattr(boto.ec2.EC2Connection, 'profile_name')
AttributeError: 'module' object has no attribute 'ec2'
```

This PR does fix the issue because line [73 of `lib/ansible/module_utils/ec2.py`](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/ec2.py#L73) uses `boto.ec2`, however perhaps the fix should be in that file instead?

Thanks to @bamdadd for the fix
