### PR TITLE
fix errorhandling in zypper.py module

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -183,6 +183,11 @@ def package_latest(m, name, installed_state, disable_gpg_check, disable_recommen
     # first of all, make sure all the packages are installed
     (rc, stdout, stderr, changed) = package_present(m, name, installed_state, disable_gpg_check, disable_recommends, old_zypper)
 
+    # return if an error occured while installation
+    # otherwise error messages will be lost and user doesn`t see any error
+    if rc:
+        return (rc, stdout, stderr, changed)
+
     # if we've already made a change, we don't have to check whether a version changed
     if not changed:
         pre_upgrade_versions = get_current_version(m, name)


### PR DESCRIPTION
package_latest was calling package_present but did not care
about the return code so errors in package_present were hidden
and everthing look ok on the console when zypper update did not fail,
but no packages where installed.
