### PR TITLE
[lldp] Merge wrapped lines.

### DIFF
--- a/network/lldp.py
+++ b/network/lldp.py
@@ -58,6 +58,8 @@ def gather_lldp():
                 path, value = entry.strip().split("=", 1)
                 path = path.split(".")
                 path_components, final = path[:-1], path[-1]
+            else:
+                value = current_dict[final] + '\n' + entry
 
             current_dict = output_dict
             for path_component in path_components:


### PR DESCRIPTION
Some devices return their description on multiple lines such as:

```
lldp.eth0.chassis.descr=cisco CISCO7609-S running on
Cisco IOS Software, c7600s72033_rp Software (c7600s72033_rp-IPSERVICESK9-M), Version 12.2(33)SRE3, RELEASE SOFTWARE (fc1)
Technical Support: http://www.cisco.com/techsupport
Copyright (c) 1986-2011 by Cisco Systems, Inc.
Compiled Wed 26-Jan-11 06:54 by prod_rel_team
```

The generated fact will result as:

```
"descr": "cisco CISCO7609-S running on"
```

This patch fixes the line wrapping to return the full description
handling line breaks:

```
"descr": "cisco CISCO7609-S running on\nCisco IOS Software, c7600s72033_rp Software (c7600s72033_rp-IPSERVICESK9-M), Version 12.2(33)SRE3, RELEASE SOFTWARE (fc1)\nTechnical Support: http://www.cisco.com/techsupport\nCopyright (c) 1986-2011 by Cisco Systems, Inc.\nCompiled Wed 26-Jan-11 06:54 by prod_rel_team"
```
