### PR TITLE
Update twilio.py module name in Examples

### DIFF
--- a/notification/twilio.py
+++ b/notification/twilio.py
@@ -57,14 +57,14 @@ author: Matt Makai
 EXAMPLES = '''
 # send a text message from the local server about the build status to (555) 303 5681
 # note: you have to have purchased the 'from_number' on your Twilio account
-- local_action: text msg="All servers with webserver role are now configured." 
+- local_action: twilio msg="All servers with webserver role are now configured." 
   account_sid={{ twilio_account_sid }}
   auth_token={{ twilio_auth_token }}
   from_number=+15552014545 to_number=+15553035681
 
 # send a text message from a server to (555) 111 3232
 # note: you have to have purchased the 'from_number' on your Twilio account
-- text: msg="This server's configuration is now complete."
+- twilio: msg="This server's configuration is now complete."
   account_sid={{ twilio_account_sid }}
   auth_token={{ twilio_auth_token }}
   from_number=+15553258899 to_number=+15551113232


### PR DESCRIPTION
First time to use Github so please be gentle if I get it wrong. The module name in the Examples section said "text" when in fact the module is called "twilio". Before reporting this, I tried using the module name "text" as it was in the Examples section just to be sure it wouldn't work and indeed I got "FAILED => module text not found in configured module paths".  However, the same invocation with a module name of "twilio" delivered an SMS to my phone.
