### PR TITLE
cloudstack: rename modules to more meaningful name schema

### DIFF
--- a/cloud/cloudstack/cs_firewall.py
+++ b/cloud/cloudstack/cs_firewall.py
@@ -19,7 +19,7 @@
 # along with Ansible. If not, see <http://www.gnu.org/licenses/>.
 
 DOCUMENTATION = '''
-module: cloudstack_fw
+module: cs_firewall
 short_description: Manages firewall rules on Apache CloudStack based clouds.
 description: Creates and removes firewall rules.
 version_added: '2.0'
@@ -77,7 +77,7 @@ EXAMPLES = '''
 ---
 # Allow inbound port 80/tcp from 1.2.3.4 to 4.3.2.1
 - local_action:
-    module: cloudstack_fw
+    module: cs_firewall
     ip_address: 4.3.2.1
     start_port: 80
     end_port: 80
@@ -86,7 +86,7 @@ EXAMPLES = '''
 
 # Allow inbound tcp/udp port 53 to 4.3.2.1
 - local_action:
-    module: cloudstack_fw
+    module: cs_firewall
     ip_address: 4.3.2.1
     start_port: 53
     end_port: 53
@@ -98,7 +98,7 @@ EXAMPLES = '''
 
 # Ensure firewall rule is removed
 - local_action:
-    module: cloudstack_fw
+    module: cs_firewall
     ip_address: 4.3.2.1
     start_port: 8000
     end_port: 8888

--- a/cloud/cloudstack/cs_iso.py
+++ b/cloud/cloudstack/cs_iso.py
@@ -20,7 +20,7 @@
 
 DOCUMENTATION = '''
 ---
-module: cloudstack_iso
+module: cs_iso
 short_description: Manages ISOs images on Apache CloudStack based clouds.
 description: Register and remove ISO images.
 version_added: '2.0'
@@ -100,7 +100,7 @@ EXAMPLES = '''
 ---
 # Register an ISO if ISO name does not already exist.
 - local_action:
-    module: cloudstack_iso
+    module: cs_iso
     name: Debian 7 64-bit
     url: http://mirror.switch.ch/ftp/mirror/debian-cd/current/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso
     os_type: Debian GNU/Linux 7(64-bit)
@@ -108,7 +108,7 @@ EXAMPLES = '''
 
 # Register an ISO with given name if ISO md5 checksum does not already exist.
 - local_action:
-    module: cloudstack_iso
+    module: cs_iso
     name: Debian 7 64-bit
     url: http://mirror.switch.ch/ftp/mirror/debian-cd/current/amd64/iso-cd/debian-7.7.0-amd64-netinst.iso
     os_type:    
@@ -117,14 +117,14 @@ EXAMPLES = '''
 
 # Remove an ISO by name
 - local_action:
-    module: cloudstack_iso
+    module: cs_iso
     name: Debian 7 64-bit
     state: absent
 
 
 # Remove an ISO by checksum
 - local_action:
-    module: cloudstack_iso
+    module: cs_iso
     name: Debian 7 64-bit
     checksum: 0b31bccccb048d20b551f70830bb7ad0
     state: absent

--- a/cloud/cloudstack/cs_sshkeypair.py
+++ b/cloud/cloudstack/cs_sshkeypair.py
@@ -20,7 +20,7 @@
 
 DOCUMENTATION = '''
 ---
-module: cloudstack_sshkey
+module: cs_sshkeypair
 short_description: Manages SSH keys on Apache CloudStack based clouds.
 description:
   - If no key was found and no public key was provided and a new SSH
@@ -53,15 +53,15 @@ options:
 EXAMPLES = '''
 ---
 # create a new private / public key pair:
-- local_action: cloudstack_sshkey name=linus@example.com
+- local_action: cs_sshkeypair name=linus@example.com
   register: key
 - debug: msg='private key is {{ key.private_key }}'
 
 # remove a public key by its name:
-- local_action: cloudstack_sshkey name=linus@example.com state=absent
+- local_action: cs_sshkeypair name=linus@example.com state=absent
 
 # register your existing local public key:
-- local_action: cloudstack_sshkey name=linus@example.com public_key='{{ lookup('file', '~/.ssh/id_rsa.pub') }}'
+- local_action: cs_sshkeypair name=linus@example.com public_key='{{ lookup('file', '~/.ssh/id_rsa.pub') }}'
 '''
 
 RETURN = '''


### PR DESCRIPTION
We decided to change the module name schema to be more meaningful and "closer" to the CloudStack API with a prefix of `cs_`. This way it makes it easier for user to use intuitively the correct module name.

Since the modules are new in 2.0, this **does not break backward compatibily.**

Please merge asap, as it is just a simple rename. Thanks in advance.
