### PR TITLE
fixed chocolatey prompting for confirmation

### DIFF
--- a/windows/win_chocolatey.ps1
+++ b/windows/win_chocolatey.ps1
@@ -190,6 +190,7 @@ elseif (($source -eq "windowsfeatures") -or ($source -eq "webpi") -or ($source -
 {
     $expression += " -source $source"
 }
+$expression += " -y"
 
 Set-Attr $result "chocolatey command" $expression
 $op_result = invoke-expression $expression


### PR DESCRIPTION
chocolatey requires the `-y` option to install without opening a dialog since the release of 0.9.0
