### PR TITLE
Update twilio module for MMS & multiple message recipients

### DIFF
--- a/notification/twilio.py
+++ b/notification/twilio.py
@@ -87,8 +87,8 @@ EXAMPLES = '''
       - "+19735559010"
   delegate_to: localhost
 
-# send an MMS to multiple phone numbers with an update on the
-# deployment and a screenshot of the results
+# send an MMS to a single recipient with an update on the deployment
+# and an image of the results
 # note: replace account_sid and auth_token values with your credentials
 # and you have to have the 'from_number' on your Twilio account
 - twilio:

--- a/notification/twilio.py
+++ b/notification/twilio.py
@@ -157,17 +157,15 @@ def main():
     to_number = module.params['to_number']
     media_url = module.params['media_url']
 
-    try:
-        if isinstance(to_number, list):
-            for number in to_number:
-                post_twilio_api(module, account_sid, auth_token, msg,
-                    from_number, number, media_url)
-        else:
+    if not isinstance(to_number, list):
+        to_number = [to_number]
+
+    for number in to_number:
+        try:
             post_twilio_api(module, account_sid, auth_token, msg,
-                from_number, to_number, media_url)
-        pass
-    except Exception:
-        module.fail_json(msg="unable to send text message to %s" % to_number)
+                from_number, number, media_url)
+        except Exception:
+            module.fail_json(msg="unable to send message to %s" % number)
 
     module.exit_json(msg=msg, changed=False)
 


### PR DESCRIPTION
The twilio module can now support multiple recipients. Previously you could only send to a single phone number. Now you can also specify a list of recipients if you choose. This change is backwards compatible. 

I also updated the documentation to be in line with current Ansible doc recommendations thanks to @abadger.
