### PR TITLE
Fix possible values for zfs sync property

### DIFF
--- a/system/zfs.py
+++ b/system/zfs.py
@@ -177,7 +177,7 @@ options:
     description:
       - The sync property.
     required: False
-    choices: ['on','off']
+    choices: ['standard','always','disabled']
   utf8only:
     description:
       - The utf8only property.
@@ -368,7 +368,7 @@ def main():
             'sharenfs':        {'required': False},
             'sharesmb':        {'required': False},
             'snapdir':         {'required': False, 'choices':['hidden', 'visible']},
-            'sync':            {'required': False, 'choices':['on', 'off']},
+            'sync':            {'required': False, 'choices':['standard', 'always', 'disabled']},
             # Not supported
             #'userquota':       {'required': False},
             'utf8only':        {'required': False, 'choices':['on', 'off']},


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.9.0.1
##### Environment:

Debian Jessie, FreeBSD
##### Summary:

The permitted values for the ZFS Module  "sync' property are not correct.

from http://www.freebsd.org/cgi/man.cgi?zfs(8)

```
     sync=standard | always | disabled
     Controls the behavior of synchronous requests (e.g.  fsync(2),
     O_DSYNC). This property accepts the following values:

         standard  This is the POSIX specified behavior of ensuring all
               synchronous requests are written to stable storage and
               all devices are flushed to ensure data is not cached by
               device controllers (this is the default).

         always    All file system transactions are written and flushed
               before their system calls return. This has a large per-
               formance penalty.

         disabled  Disables synchronous requests. File system transactions
               are only committed to stable storage periodically. This
               option will give the highest performance.  However, it
               is very dangerous as ZFS would be ignoring the synchro-
               nous transaction demands of applications such as data-
               bases or NFS.  Administrators should only use this
               option when the risks are understood.
```
##### Steps To Reproduce:

Run the following task:

```
    - zfs: name='rpool/tmp' state=present sync='disabled'
```
##### Expected Results:

The 'sync' property of the ZFS filesystem should be set as 'disabled'.
##### Actual Results:

when setting 'sync' to 'disabled', there is an error message from ansible:

```
msg: value of sync must be one of: on,off, got: disabled
```

when setting 'sync' to 'off', there is an error message from zfs:

```
msg: cannot set property for 'rpool/tmp': 'sync' must be one of 'standard | always | disabled'
```
