### PR TITLE
Issue #403: Add support for multiple bricks to gluster_volume

### DIFF
--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -66,7 +66,7 @@ options:
     required: false
     default: null
     description:
-      - Brick path on servers. Multiple bricks can be specified by commas
+      - Brick path on servers. Multiple brick paths can be separated by commas
   start_on_create:
     choices: [ 'yes', 'no']
     required: false

--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -62,11 +62,11 @@ options:
     default: 'tcp'
     description:
       - Transport type for volume
-  brick:
+  bricks:
     required: false
     default: null
     description:
-      - Brick path on servers. Multiple brick paths can be separated by commas
+      - Brick paths on servers. Multiple brick paths can be separated by commas
   start_on_create:
     choices: [ 'yes', 'no']
     required: false
@@ -107,7 +107,7 @@ author: Taneli Leppä
 
 EXAMPLES = """
 - name: create gluster volume
-  gluster_volume: state=present name=test1 brick=/bricks/brick1/g1 rebalance=yes cluster:"{{ play_hosts }}"
+  gluster_volume: state=present name=test1 bricks=/bricks/brick1/g1 rebalance=yes cluster:"{{ play_hosts }}"
   run_once: true
 
 - name: tune
@@ -124,6 +124,10 @@ EXAMPLES = """
 
 - name: remove gluster volume
   gluster_volume: state=absent name=test1
+
+- name: create gluster volume with multiple bricks
+  gluster_volume: state=present name=test2 bricks="/bricks/brick1/g2,/bricks/brick2/g2" cluster:"{{ play_hosts }}"
+  run_once: true
 """
 
 import shutil
@@ -312,7 +316,7 @@ def main():
             stripes=dict(required=False, default=None, type='int'),
             replicas=dict(required=False, default=None, type='int'),
             transport=dict(required=False, default='tcp', choices=[ 'tcp', 'rdma', 'tcp,rdma' ]),
-            brick=dict(required=False, default=None),
+            bricks=dict(required=False, default=None, aliases=['brick']),
             start_on_create=dict(required=False, default=True, type='bool'),
             rebalance=dict(required=False, default=False, type='bool'),
             options=dict(required=False, default={}, type='dict'),

--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -66,7 +66,7 @@ options:
     required: false
     default: null
     description:
-      - Brick path on servers
+      - Brick path on servers. Multiple bricks can be specified by commas
   start_on_create:
     choices: [ 'yes', 'no']
     required: false
@@ -256,7 +256,7 @@ def probe_all_peers(hosts, peers, myhostname):
             if myhostname != host:
                 probe(host)
 
-def create_volume(name, stripe, replica, transport, hosts, brick, force):
+def create_volume(name, stripe, replica, transport, hosts, bricks, force):
     args = [ 'volume', 'create' ]
     args.append(name)
     if stripe:
@@ -267,8 +267,9 @@ def create_volume(name, stripe, replica, transport, hosts, brick, force):
         args.append(str(replica))
     args.append('transport')
     args.append(transport)
-    for host in hosts:
-        args.append(('%s:%s' % (host, brick)))
+    for brick in bricks:
+        for host in hosts:
+            args.append(('%s:%s' % (host, brick)))
     if force:
         args.append('force')
     run_gluster(args)
@@ -329,7 +330,7 @@ def main():
     action = module.params['state']
     volume_name = module.params['name']
     cluster= module.params['cluster']
-    brick_path = module.params['brick']
+    brick_paths = module.params['brick']
     stripes = module.params['stripes']
     replicas = module.params['replicas']
     transport = module.params['transport']
@@ -340,6 +341,11 @@ def main():
 
     if not myhostname:
         myhostname = socket.gethostname()
+
+    if brick_paths != None and "," in brick_paths:
+        brick_paths = brick_paths.split(",")
+    else:
+        brick_paths = [brick_paths]
 
     options = module.params['options']
     quota = module.params['quota']
@@ -364,7 +370,7 @@ def main():
 
         # create if it doesn't exist
         if volume_name not in volumes:
-            create_volume(volume_name, stripes, replicas, transport, cluster, brick_path, force)
+            create_volume(volume_name, stripes, replicas, transport, cluster, brick_paths, force)
             volumes = get_volumes()
             changed = True
 
@@ -378,10 +384,11 @@ def main():
             removed_bricks = []
             all_bricks = []
             for node in cluster:
-                brick = '%s:%s' % (node, brick_path)
-                all_bricks.append(brick)
-                if brick not in volumes[volume_name]['bricks']:
-                    new_bricks.append(brick)
+                for brick_path in brick_paths:
+                    brick = '%s:%s' % (node, brick_path)
+                    all_bricks.append(brick)
+                    if brick not in volumes[volume_name]['bricks']:
+                        new_bricks.append(brick)
 
             # this module does not yet remove bricks, but we check those anyways
             for brick in volumes[volume_name]['bricks']:


### PR DESCRIPTION
Adds support for creating volumes with multiple bricks and adding multiple bricks to a volume at a single time.  I chose to override the `brick` parameter to take a string containing one or more paths separated by commas. Addresses Issue #403 .
