### PR TITLE
Fixes bug where state=absent did not work in gluster_volume

### DIFF
--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -356,7 +356,9 @@ def main():
     # do the work!
     if action == 'absent':
         if volume_name in volumes:
-            run_gluster([ 'volume', 'delete', name ])
+            if volumes[volume_name]['status'].lower() != 'stopped':
+                stop_volume(volume_name)
+            run_gluster_yes([ 'volume', 'delete', volume_name ])
             changed = True
 
     if action == 'present':


### PR DESCRIPTION
This fixes a bug where state=absent did not work. It failed because 'name' was not defined globally. The fix was to change it to volume_name. I also added a check to see if the volume was running, and if so stop it. Since it cannot delete a running volume.

Here is what the bug looked like before this fixed it.

```
[root@phy01 new]# ansible -i hosts all -m gluster_volume -a "name=test1 state=present brick=/export/BRICK1/brick cluster=centos7.soh.re"
centos7.soh.re | success >> {
    "ansible_facts": {
        "glusterfs": {
            "peers": {},
            "quotas": {},
            "volumes": {
                "test1": {
                    "bricks": [
                        "centos7.soh.re:/export/BRICK1/brick"
                    ],
                    "id": "26320f78-0822-4c70-8a7b-ded51fb30dc4",
                    "name": "test1",
                    "options": {},
                    "quota": false,
                    "status": "Started",
                    "transport": "tcp"
                }
            }
        }
    },
    "changed": false
}

[root@phy01 new]# ansible -i hosts all -m gluster_volume -a "name=test1 state=absent brick=/export/BRICK1/brick cluster=centos7.soh.re"
centos7.soh.re | FAILED >> {
    "failed": true,
    "msg": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1429471626.51-19362940833130/gluster_volume\", line 2041, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1429471626.51-19362940833130/gluster_volume\", line 359, in main\r\n    run_gluster([ 'volume', 'delete', name ])\r\nNameError: global name 'name' is not defined\r\nOpenSSH_6.6.1, OpenSSL 1.0.1e-fips 11 Feb 2013\r\ndebug1: Reading configuration data /root/.ssh/config\r\ndebug1: /root/.ssh/config line 4: Applying options for *\r\ndebug1: Reading configuration data /etc/ssh/ssh_config\r\ndebug1: /etc/ssh/ssh_config line 51: Applying options for *\r\ndebug1: auto-mux: Trying existing master\r\ndebug1: mux_client_request_session: master session id: 2\r\nShared connection to centos7.soh.re closed.\r\n",
    "parsed": false
}
```

Also once fixing name to volume_name, the module would hang, this is because gluster is asking the user to confirm deletion by pressing yes. By adding run_gluster_yes instead of run_gluster it fixes that specific issue as well.
