### PR TITLE
Document mail module's 'msg' param and fix examples

### DIFF
--- a/notification/mail.py
+++ b/notification/mail.py
@@ -61,7 +61,7 @@ options:
     required: false
   subject:
     description:
-      - The subject of the email being sent.
+      - The subject of the email being sent. Alias: I(msg)
     aliases: [ msg ]
     required: true
   body:
@@ -115,7 +115,7 @@ options:
 
 EXAMPLES = '''
 # Example playbook sending mail to root
-- local_action: mail msg='System {{ ansible_hostname }} has been successfully provisioned.'
+- local_action: mail subject='System {{ ansible_hostname }} has been successfully provisioned.'
 
 # Sending an e-mail using Gmail SMTP servers
 - local_action: mail
@@ -125,7 +125,7 @@ EXAMPLES = '''
                 password='mysecret'
                 to="John Smith <john.smith@example.com>"
                 subject='Ansible-report'
-                msg='System {{ ansible_hostname }} has been successfully provisioned.'
+                body='System {{ ansible_hostname }} has been successfully provisioned.'
 
 # Send e-mail to a bunch of users, attaching files
 - local_action: mail

--- a/notification/mail.py
+++ b/notification/mail.py
@@ -61,8 +61,7 @@ options:
     required: false
   subject:
     description:
-      - The subject of the email being sent. Alias: I(msg)
-    aliases: [ msg ]
+      - The subject of the email being sent.
     required: true
   body:
     description:


### PR DESCRIPTION
The 'msg' alias for 'subject' isn't in the documentation, so adding it.

In the gmail example, it uses both the 'subject' and 'msg' params, but 'msg' is an alias of 'subject', so you are essentially declaring the same param twice. If you use this example, then no subject is sent (I tested with gmail). Documentation example is updated to use 'body' as intended.

Also, updated the simple example to use 'subject' instead of the 'msg' alias since it is more explicit.
