### PR TITLE
Add check_mode support to HipChat module

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -96,6 +96,11 @@ def send_msg(module, token, room, msg_from, msg, msg_format='text',
 
     url = api + "?auth_token=%s" % (token)
     data = urllib.urlencode(params)
+
+    if module.check_mode:
+        # In check mode, exit before actually sending the message
+        module.exit_json(changed=False)
+
     response, info = fetch_url(module, url, data=data)
     if info['status'] == 200:
         return response.read()
@@ -119,8 +124,8 @@ def main():
                                                   "purple", "gray", "random"]),
             msg_format=dict(default="text", choices=["text", "html"]),
             notify=dict(default=True, type='bool'),
-            validate_certs = dict(default='yes', type='bool'),
-            api = dict(default=MSG_URI),
+            validate_certs=dict(default='yes', type='bool'),
+            api=dict(default=MSG_URI),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
The HipChat module declares to support check_mode,
but the message is sent in any case.

With this, if executed in check mode, the module will exit
before actually sending the message to HipChat.

I based this on the flowdock behaviour, except that the module returns things as changed, since things would have changed (as a message would have been sent). This is my understanding of changed and check mode, but happy to change it one way or the other.

(Also fix a couple of PEP8 issues a bit further down).
