### PR TITLE
cloudstack: fix missing zone param used in get_vm() in utils

### DIFF
--- a/cloud/cloudstack/cs_vmsnapshot.py
+++ b/cloud/cloudstack/cs_vmsnapshot.py
@@ -41,6 +41,11 @@ options:
       - Snapshot memory if set to true.
     required: false
     default: false
+  zone:
+    description:
+      - Name of the zone in which the VM is in. If not set, default zone is used.
+    required: false
+    default: null
   project:
     description:
       - Name of the project the VM is assigned to.
@@ -241,6 +246,7 @@ def main():
             vm = dict(required=True),
             description = dict(default=None),
             project = dict(default=None),
+            zone = dict(default=None),
             snapshot_memory = dict(choices=BOOLEANS, default=False),
             state = dict(choices=['present', 'absent', 'revert'], default='present'),
             poll_async = dict(choices=BOOLEANS, default=True),

--- a/cloud/cloudstack/cs_vmsnapshot.py
+++ b/cloud/cloudstack/cs_vmsnapshot.py
@@ -31,6 +31,10 @@ options:
       - Unique Name of the snapshot. In CloudStack terms C(displayname).
     required: true
     aliases: ['displayname']
+  vm:
+    description:
+      - Name of the virtual machine.
+    required: true
   description:
     description:
       - Description of the snapshot.


### PR DESCRIPTION
This fix depend on a fix covered in https://github.com/ansible/ansible/pull/10833
