### PR TITLE
Ignore extra lines from Pivotal's RabbitMQ package

### DIFF
--- a/messaging/rabbitmq_plugin.py
+++ b/messaging/rabbitmq_plugin.py
@@ -88,13 +88,21 @@ class RabbitMqPlugins(object):
         return list()
 
     def get_all(self):
-        return self._exec(['list', '-E', '-m'], True)
+        list_output = self._exec(['list', '-E', '-m'], True)
+        plugins = []
+        for plugin in list_output:
+            if not plugin:
+                break
+            plugins.append(plugin)
+
+        return plugins
 
     def enable(self, name):
         self._exec(['enable', name])
 
     def disable(self, name):
         self._exec(['disable', name])
+
 
 def main():
     arg_spec = dict(


### PR DESCRIPTION
Pivotal's packaging of RabbitMQ shows a banner at the end of the plugin
listing talking about their official plugins. The start of the banner is
divided by a blank line so the changed plugin listing will now
break after the first empty line.

An example listing with the rabbitmq_management plugin enabled:

```
    $ rabbitmq-plugins list -E -m
    rabbitmq_management

    Pivotal officially maintains and supports the plugins:

      rabbitmq_auth_backend_ldap, rabbitmq_auth_mechanism_ssl,
      rabbitmq_consistent_hash_exchange, rabbitmq_federation,
      rabbitmq_federation_management, rabbitmq_jms_topic_exchange,
      rabbitmq_management, rabbitmq_management_agent,
      rabbitmq_mqtt, rabbitmq_shovel, rabbitmq_shovel_management,
      and rabbitmq_stomp.
```

Pivotal's packaging of RabbitMQ can be found here: http://rabbitmq.docs.pivotal.io/doc/34/topics/install-getstart.html#install-RHEL

I'm not entirely sure how to test this change apart from manually, which
I've done. Is there something else I should do as well?
