### PR TITLE
win_webpicmd module for IIS module installation

### DIFF
--- a/windows/win_webpicmd.ps1
+++ b/windows/win_webpicmd.ps1
@@ -1,0 +1,135 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2015, Peter Mounce <public@neverrunwithscissors.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+$ErrorActionPreference = "Stop"
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+If ($params.name)
+{
+    $package = $params.name
+}
+Else
+{
+    Fail-Json $result "missing required argument: name"
+}
+
+Function Find-Command
+{
+    [CmdletBinding()]
+    param(
+      [Parameter(Mandatory=$true, Position=0)] [string] $command
+    )
+    $installed = get-command $command -erroraction Ignore
+    write-verbose "$installed"
+    if ($installed.length -gt 0)
+    {
+        return $installed[0]
+    }
+    return $null
+}
+
+Function Find-WebPiCmd
+{
+    [CmdletBinding()]
+    param()
+    $p = Find-Command "webpicmd.exe"
+    if ($p -ne $null)
+    {
+        return $p
+    }
+    $a = Find-Command "c:\programdata\chocolatey\bin\webpicmd.exe"
+    if ($a -ne $null)
+    {
+        return $a
+    }
+    Throw "webpicmd.exe is not installed. It must be installed (use chocolatey)"
+}
+
+Function Test-IsInstalledFromWebPI
+{
+    [CmdletBinding()]
+
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$package
+    )
+
+    $cmd = "$executable /list /listoption:installed"
+    $results = invoke-expression $cmd
+
+    if ($LastExitCode -ne 0)
+    {
+        Set-Attr $result "webpicmd_error_cmd" $cmd
+        Set-Attr $result "webpicmd_error_log" "$results"
+
+        Throw "Error checking installation status for $package"
+    }
+    Write-Verbose "$results"
+
+    $matches = $results | select-string -pattern "^$package\s+"
+    return $matches.length -gt 0
+}
+
+Function Install-WithWebPICmd
+{
+    [CmdletBinding()]
+
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [string]$package
+    )
+
+    $cmd = "$executable /install /products:$package /accepteula /suppressreboot"
+
+    $results = invoke-expression $cmd
+
+    if ($LastExitCode -ne 0)
+    {
+        Set-Attr $result "webpicmd_error_cmd" $cmd
+        Set-Attr $result "webpicmd_error_log" "$results"
+        Throw "Error installing $package"
+    }
+
+    write-verbose "$results"
+    $success = $results | select-string -pattern "Install of Products: SUCCESS"
+    if ($success.length -gt 0)
+    {
+        $result.changed = $true
+    }
+}
+
+Try
+{
+    $script:executable = Find-WebPiCmd
+    if ((Test-IsInstalledFromWebPI -package $package) -eq $false)
+    {
+        Install-WithWebPICmd -package $package
+    }
+
+    Exit-Json $result;
+}
+Catch
+{
+     Fail-Json $result $_.Exception.Message
+}

--- a/windows/win_webpicmd.py
+++ b/windows/win_webpicmd.py
@@ -1,0 +1,48 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2014, Trond Hindenes <trond@hindenes.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_webpicmd
+version_added: "1.9"
+short_description: Installs packages using Web Platform Installer command-line
+description:
+    - Installs packages using Web Platform Installer command-line (http://www.iis.net/learn/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release).
+    - Must be installed and present in PATH (see win_chocolatey module; 'webpicmd' is the package name, and you must install 'lessmsi' first too)
+    - Install IIS first (see win_feature module)
+    - Note: accepts EULAs and suppresses reboot - you will need to check manage reboots yourself (see win_reboot module)
+options:
+  name:
+    description:
+      - Name of the package to be installed
+    required: true
+    default: null
+    aliases: []
+author: Peter Mounce
+'''
+
+EXAMPLES = '''
+  # Install URLRewrite2.
+  win_webpicmd:
+    name: URLRewrite2
+'''

--- a/windows/win_webpicmd.py
+++ b/windows/win_webpicmd.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_webpicmd
-version_added: "1.9"
+version_added: "2.0"
 short_description: Installs packages using Web Platform Installer command-line
 description:
     - Installs packages using Web Platform Installer command-line (http://www.iis.net/learn/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release).
@@ -36,8 +36,6 @@ options:
     description:
       - Name of the package to be installed
     required: true
-    default: null
-    aliases: []
 author: Peter Mounce
 '''
 

--- a/windows/win_webpicmd.py
+++ b/windows/win_webpicmd.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2014, Trond Hindenes <trond@hindenes.com>
+# (c) 2015, Peter Mounce <public@neverrunwithscissors.com>
 #
 # This file is part of Ansible
 #


### PR DESCRIPTION
Chocolatey 0.9.9+ deprecated support for the `webpi` custom source, so I needed to write this.

[Windows Web Platform Installer](http://www.microsoft.com/web/downloads/platform.aspx) is a way of installing products and applications for Microsoft IIS on Windows. It has a [command line](http://www.iis.net/learn/install/web-platform-installer/web-platform-installer-v4-command-line-webpicmdexe-rtw-release); this ansible module allows IIS modules to be installed via this means.

To find out names of modules, use `webpicmd /list /listoption:available`.

Notes:
- `webpicmd` must be installed and on `PATH` first (see `win_chocolatey` module; package is `webpicmd`)
- `webpicmd` does not allow modules to be uninstalled
- IIS must be installed first (see `win_feature` module; package is `Web-Server`)
- Installations will
  - accept EULA (which otherwise requires user input)
  - suppress reboots (so you have to manage those; see `win_reboot` module)
