### PR TITLE
disable ask on sync operation

### DIFF
--- a/packaging/os/portage.py
+++ b/packaging/os/portage.py
@@ -231,7 +231,7 @@ def sync_repositories(module, webrsync=False):
         webrsync_path = module.get_bin_path('emerge-webrsync', required=True)
         cmd = '%s --quiet' % webrsync_path
     else:
-        cmd = '%s --sync --quiet' % module.emerge_path
+        cmd = '%s --sync --quiet --ask=n' % module.emerge_path
 
     rc, out, err = module.run_command(cmd)
     if rc != 0:


### PR DESCRIPTION
ansible hangs when portage has the ask option set in its configuration. Therefore 926194f75d53846a11b85ca579b2fc451facac76 disabled the ask option for package operations. This commit disables the ask option for portage tree sync operations, too.
