### PR TITLE
Create win_dotnet_ngen module

### DIFF
--- a/windows/win_dotnet_ngen.ps1
+++ b/windows/win_dotnet_ngen.ps1
@@ -1,0 +1,69 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2015, Peter Mounce <public@neverrunwithscissors.com>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+$ErrorActionPreference = "Stop"
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+function Invoke-NGen
+{
+    [CmdletBinding()]
+
+    param
+    (
+       [Parameter(Mandatory=$false, Position=0)] [string] $arity = ""
+    )
+
+    if ($arity -eq $null)
+    {
+        $arity = ""
+    }
+    $cmd = "$($env:windir)\microsoft.net\framework$($arity)\v4.0.30319\ngen.exe"
+    if (test-path $cmd)
+    {
+        $update = Invoke-Expression "$cmd update /force";
+        Set-Attr $result "dotnet_ngen$($arity)_update_exit_code" $lastexitcode
+        Set-Attr $result "dotnet_ngen$($arity)_update_output" $update
+        $eqi = Invoke-Expression "$cmd executequeueditems";
+        Set-Attr $result "dotnet_ngen$($arity)_eqi_exit_code" $lastexitcode
+        Set-Attr $result "dotnet_ngen$($arity)_eqi_output" $eqi
+
+        $result.changed = $true
+    }
+    else
+    {
+        Write-Host "Not found: $cmd"
+    }
+}
+
+Try
+{
+    Invoke-NGen
+    Invoke-NGen -arity "64"
+
+    Exit-Json $result;
+}
+Catch
+{
+    Fail-Json $result $_.Exception.Message
+}

--- a/windows/win_dotnet_ngen.py
+++ b/windows/win_dotnet_ngen.py
@@ -31,9 +31,10 @@ description:
     - This happens via scheduled task, usually at some inopportune time.
     - This module allows you to run this task on your own schedule, so you incur the CPU hit at some more convenient and controlled time.
     - "http://blogs.msdn.com/b/dotnet/archive/2013/08/06/wondering-why-mscorsvw-exe-has-high-cpu-usage-you-can-speed-it-up.aspx"
-    - "Note: there are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem"
-    - "Note: there's no way to test if they've been completed (?)"
-    - Note: the stdout is quite likely to be several megabytes
+notes:
+    - there are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem
+    - there's no way to test if they've been completed (?)
+    - the stdout is quite likely to be several megabytes
 options:
 author: Peter Mounce
 '''

--- a/windows/win_dotnet_ngen.py
+++ b/windows/win_dotnet_ngen.py
@@ -33,6 +33,7 @@ description:
     - http://blogs.msdn.com/b/dotnet/archive/2013/08/06/wondering-why-mscorsvw-exe-has-high-cpu-usage-you-can-speed-it-up.aspx
     - Note: there are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem
     - Note: there's no way to test if they've been completed (?)
+    - Note: the stdout is quite likely to be several megabytes
 options:
 author: Peter Mounce
 '''

--- a/windows/win_dotnet_ngen.py
+++ b/windows/win_dotnet_ngen.py
@@ -1,0 +1,43 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Peter Mounce <public@neverrunwithscissors.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_dotnet_ngen
+version_added: "1.9"
+short_description: Runs ngen to recompile DLLs after .NET  updates
+description:
+    - After .NET framework is installed/updated, Windows will probably want to recompile things to optimise for the host.
+    - This happens via scheduled task, usually at some inopportune time.
+    - This module allows you to run this task on your own schedule, so you incur the CPU hit at some more convenient and controlled time.
+    - http://blogs.msdn.com/b/dotnet/archive/2013/08/06/wondering-why-mscorsvw-exe-has-high-cpu-usage-you-can-speed-it-up.aspx
+    - Note: there are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem
+    - Note: there's no way to test if they've been completed (?)
+options:
+author: Peter Mounce
+'''
+
+EXAMPLES = '''
+  # Run ngen tasks
+  win_dotnet_ngen:
+'''

--- a/windows/win_dotnet_ngen.py
+++ b/windows/win_dotnet_ngen.py
@@ -24,15 +24,15 @@
 DOCUMENTATION = '''
 ---
 module: win_dotnet_ngen
-version_added: "1.9"
+version_added: "2.0"
 short_description: Runs ngen to recompile DLLs after .NET  updates
 description:
     - After .NET framework is installed/updated, Windows will probably want to recompile things to optimise for the host.
     - This happens via scheduled task, usually at some inopportune time.
     - This module allows you to run this task on your own schedule, so you incur the CPU hit at some more convenient and controlled time.
-    - http://blogs.msdn.com/b/dotnet/archive/2013/08/06/wondering-why-mscorsvw-exe-has-high-cpu-usage-you-can-speed-it-up.aspx
-    - Note: there are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem
-    - Note: there's no way to test if they've been completed (?)
+    - "http://blogs.msdn.com/b/dotnet/archive/2013/08/06/wondering-why-mscorsvw-exe-has-high-cpu-usage-you-can-speed-it-up.aspx"
+    - "Note: there are in fact two scheduled tasks for ngen but they have no triggers so aren't a problem"
+    - "Note: there's no way to test if they've been completed (?)"
     - Note: the stdout is quite likely to be several megabytes
 options:
 author: Peter Mounce


### PR DESCRIPTION
When .NET is installed or updated, ngen is triggered to optimise the installation. This triggers high CPU while it's happening, and usually happens at an inconvenient time.

This allows you to trigger it when you like. Full details and background in doc.
[Reference](http://blogs.msdn.com/b/dotnet/archive/2013/08/06/wondering-why-mscorsvw-exe-has-high-cpu-usage-you-can-speed-it-up.aspx)

(I don't know a way to figure out whether this is required without actually running it.)
