### PR TITLE
Add docker_login module

### DIFF
--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -46,9 +46,9 @@ options:
     required: true
   email:
     description:
-       - The email address for the registry account
+       - The email address for the registry account. Note that private registries usually don't need this, but if you want to log into your Docker Hub account (default behaviour) you need to specify this in order to be able to log in.
     required: false
-    default: anonymous@localhost.local
+    default: None
   reauth:
     description:
        - Whether refresh existing authentication on the Docker server (boolean)
@@ -218,7 +218,7 @@ def main():
             registry        = dict(required=False, default='https://index.docker.io/v1/'),
             username        = dict(required=True),
             password        = dict(required=True),
-            email           = dict(required=False, default='anonymous@localhost.local'),
+            email           = dict(required=False, default=None),
             reauth          = dict(required=False, default=False, type='bool'),
             dockercfg_path  = dict(required=False, default='~/.dockercfg'),
             docker_url      = dict(default='unix://var/run/docker.sock'),

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -84,7 +84,7 @@ Login to a Docker registry without performing any other action. Make sure that t
 
 - name: login to private Docker remote registry and force reauthentification
   docker_login:
-    registry: https://your.private.registry.io/v1/
+    registry: your.private.registry.io
     username: yourself
     password: secrets3
     reauth: yes
@@ -139,10 +139,6 @@ class DockerLoginManager:
 
         if self.reauth:
             self.log.append("Enforcing reauthentification")
-
-        # Extract hostname part from self.registry if url was specified.
-        registry_url = urlparse(self.registry)
-        self.registry = registry_url.netloc or registry_url.path
 
         # Connect to registry and login if not already logged in or reauth is enforced.
         try:

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -229,7 +229,7 @@ def main():
     try:
         manager = DockerLoginManager(module)
         manager.login()
-        module.exit_json(changed=manager.has_changed(), msg=manager.get_msg(), registry=manager.registry)
+        module.exit_json(changed=manager.has_changed(), msg=manager.get_msg())
 
     except Exception as e:
         module.fail_json(msg="Module execution has failed due to an unexpected error", error=repr(e))

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -153,6 +153,8 @@ class DockerLoginManager:
                 reauth=self.reauth,
                 dockercfg_path=self.dockercfg_path
             )
+        except DockerAPIError as e:
+            self.module.fail_json(msg="Docker API Error: %s" % e.explanation)
         except Exception as e:
             self.module.fail_json(msg="failed to login to the remote registry", error=repr(e))
 

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -244,4 +244,5 @@ def main():
 # import module snippets
 from ansible.module_utils.basic import *
 
-main()
+if __name__ == '__main__':
+    main()

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -220,7 +220,7 @@ def main():
         argument_spec = dict(
             registry        = dict(required=False, default='https://index.docker.io/v1/'),
             username        = dict(required=True),
-            password        = dict(required=True),
+            password        = dict(required=True, no_log=True),
             email           = dict(required=False, default=None),
             reauth          = dict(required=False, default=False, type='bool'),
             dockercfg_path  = dict(required=False, default='~/.docker/config.json'),

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -139,6 +139,10 @@ class DockerLoginManager:
         if self.reauth:
             self.log.append("Enforcing reauthentification")
 
+        # Extract hostname part from self.registry if url was specified.
+        registry_url = urlparse(self.registry)
+        self.registry = registry_url.netloc or registry_url.path
+
         # Connect to registry and login if not already logged in or reauth is enforced.
         try:
             self.response = self.client.login(

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -97,7 +97,6 @@ Login to a Docker registry without performing any other action. Make sure that t
 '''
 
 import os.path
-import sys
 import json
 import base64
 from urlparse import urlparse

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -70,7 +70,7 @@ options:
     required: false
     default: 600
 
-requirements: [ "python >= 2.6", "docker-py" ]
+requirements: [ "python >= 2.6", "docker-py >= 1.1.0" ]
 '''
 
 EXAMPLES = '''
@@ -102,11 +102,16 @@ import os.path
 import json
 import base64
 from urlparse import urlparse
+from distutils.version import StrictVersion
 
 try:
     import docker.client
     from docker.errors import APIError as DockerAPIError
     has_lib_docker = True
+    if StrictVersion(docker.__version__) >= StrictVersion("1.1.0"):
+        has_correct_lib_docker_version = True
+    else:
+        has_correct_lib_docker_version = False
 except ImportError, e:
     has_lib_docker = False
 
@@ -231,7 +236,10 @@ def main():
     )
 
     if not has_lib_docker:
-        module.fail_json(msg="python library docker-py required: pip install docker-py==1.1.0")
+        module.fail_json(msg="python library docker-py required: pip install docker-py>=1.1.0")
+
+    if not has_correct_lib_docker_version:
+        module.fail_json(msg="your version of docker-py is outdated: pip install docker-py>=1.1.0")
 
     if not has_lib_requests_execeptions:
         module.fail_json(msg="python library requests required: pip install requests")

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -47,6 +47,7 @@ options:
     description:
        - The email address for the registry account
     required: false
+    default: anonymous@localhost.local
   reauth:
     description:
        - Whether refresh existing authentication on the Docker server (boolean)
@@ -214,7 +215,7 @@ def main():
             registry        = dict(required=True),
             username        = dict(required=True),
             password        = dict(required=True),
-            email           = dict(required=False, default=None),
+            email           = dict(required=False, default='anonymous@localhost.local'),
             reauth          = dict(required=False, default=False, type='bool'),
             dockercfg_path  = dict(required=False, default='~/.dockercfg'),
             docker_url      = dict(default='unix://var/run/docker.sock'),

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -1,0 +1,243 @@
+#!/usr/bin/python
+#
+
+# (c) 2015, Olaf Kilian <olaf.kilian@symanex.com>
+#
+# This file is part of Ansible
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+######################################################################
+
+DOCUMENTATION = '''
+---
+module: docker_login
+author: Olaf Kilian
+version_added: "1.9"
+short_description: Manage Docker registry logins
+description:
+     - Ansible version of the "docker login" CLI command.
+     - This module allows you to login to a Docker registry without directly pulling an image or performing any other actions.
+     - It will write your login credentials to your local .dockercfg file that is compatible to the Docker CLI client as well as docker-py and all other Docker related modules that are based on docker-py.
+options:
+  registry:
+    description:
+       - URL of the registry, for example: https://index.docker.io/v1/
+    required: true
+    default: null
+    aliases: []
+  username:
+    description:
+       - The username for the registry account
+    required: true
+    default: null
+    aliases: []
+  password:
+    description:
+       - The plaintext password for the registry account
+    required: true
+    default: null
+    aliases: []
+  email:
+    description:
+       - The email address for the registry account
+    required: false
+    default: None
+    aliases: []
+  reauth:
+    description:
+       - Whether refresh existing authentication on the Docker server (boolean)
+    required: false
+    default: false
+    aliases: []
+  dockercfg_path:
+    description:
+       - Use a custom path for the .dockercfg file
+    required: false
+    default: ~/.dockercfg
+    aliases: []
+  docker_url:
+    descriptions:
+       - Refers to the protocol+hostname+port where the Docker server is hosted
+    required: false
+    default: unix://var/run/docker.sock
+    aliases: []
+  timeout:
+    description:
+       - The HTTP request timeout in seconds
+    required: false
+    default: 600
+    aliases: []
+
+requirements: [ "docker-py" ]
+'''
+
+EXAMPLES = '''
+Login to a Docker registry without performing any other action. Make sure that the user you are using is either in the docker group which owns the Docker socket or use sudo to perform login actions:
+
+- name: login to DockerHub remote registry using your account
+  docker_login:
+    username: docker
+    password: rekcod
+    email: docker@docker.io
+
+- name: login to private Docker remote registry and force reauthentification
+  docker_login:
+    registry: https://your.private.registry.io/v1/
+    username: yourself
+    password: secrets3
+    reauth: yes
+
+- name: login to DockerHub remote registry using a custom dockercfg file location
+  docker_login:
+    username: docker
+    password: rekcod
+    email: docker@docker.io
+    dockercfg_path: /tmp/.mydockercfg
+
+'''
+
+try:
+    import os.path
+    import sys
+    import json
+    import base64
+    import docker.client
+    from requests.exceptions import *
+    from urlparse import urlparse
+except ImportError, e:
+    print "failed=True msg='failed to import python module: %s'" % e
+    sys.exit(1)
+
+try:
+    from docker.errors import APIError as DockerAPIError
+except ImportError:
+    from docker.client import APIError as DockerAPIError
+
+class DockerLoginManager:
+
+    def __init__(self, module):
+
+        self.module = module
+        self.registry = self.module.params.get('registry')
+        self.username = self.module.params.get('username')
+        self.password = self.module.params.get('password')
+        self.email = self.module.params.get('email')
+        self.reauth = self.module.params.get('reauth')
+        self.dockercfg_path = os.path.expanduser(self.module.params.get('dockercfg_path'))
+
+        docker_url = urlparse(module.params.get('docker_url'))
+        self.client = docker.Client(base_url=docker_url.geturl(), timeout=module.params.get('timeout'))
+
+        self.changed = False
+        self.response = False
+        self.log = list()
+
+    def login(self):
+
+        if self.reauth:
+            self.log.append("Enforcing reauthentification")
+
+        # Connect to registry and login if not already logged in or reauth is enforced.
+        try:
+            self.response = self.client.login(
+                self.username,
+                password=self.password,
+                email=self.email,
+                registry=self.registry,
+                reauth=self.reauth,
+                dockercfg_path=self.dockercfg_path
+            )
+        except Exception as e:
+            self.module.fail_json(msg="failed to login to the remote registry", error=repr(e))
+
+        # Get status from registry response.
+        if self.response.has_key("Status"):
+            self.log.append(self.response["Status"])
+            if self.response["Status"] == "Login Succeeded":
+                self.changed = True
+        else:
+            self.log.append("Already Authentificated")
+
+        # Update the dockercfg if changed but not failed.
+        if self.has_changed():
+            self.update_dockercfg()
+
+    # This is what the underlaying docker-py unfortunately doesn't do (yet).
+    def update_dockercfg(self):
+
+        # Create dockercfg file if it does not exist.
+        if not os.path.exists(self.dockercfg_path):
+            open(self.dockercfg_path, "w")
+            self.log.append("Created new Docker config file at %s" % self.dockercfg_path)
+        else:
+            self.log.append("Updated existing Docker config file at %s" % self.dockercfg_path)
+
+        # Get existing dockercfg into a dict.
+        try:
+            docker_config = json.load(open(self.dockercfg_path, "r"))
+        except ValueError:
+            docker_config = dict()
+        if not docker_config.has_key(self.registry):
+            docker_config[self.registry] = dict()
+        docker_config[self.registry] = dict(
+            auth  = base64.b64encode(self.username + b':' + self.password),
+            email = self.email
+        )
+
+        # Write updated dockercfg to dockercfg file.
+        try:
+            json.dump(docker_config, open(self.dockercfg_path, "w"), indent=4, sort_keys=True)
+        except Exception as e:
+            self.module.fail_json(msg="failed to write auth details to file", error=repr(e))
+
+    # Compatible to docker-py auth.decode_docker_auth()
+    def encode_docker_auth(self, auth):
+        s = base64.b64decode(auth)
+        login, pwd = s.split(b':', 1)
+        return login.decode('ascii'), pwd.decode('ascii')
+
+    def get_msg(self):
+        return ". ".join(self.log)
+
+    def has_changed(self):
+        return self.changed
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            registry        = dict(required=True, default=None),
+            username        = dict(required=True, default=None),
+            password        = dict(required=True, default=None),
+            email           = dict(required=False, default=None),
+            reauth          = dict(required=False, default=False, type='bool'),
+            dockercfg_path  = dict(required=False, default='~/.dockercfg'),
+            docker_url      = dict(default='unix://var/run/docker.sock'),
+            timeout         = dict(default=10, type='int')
+        )
+    )
+
+    try:
+        manager = DockerLoginManager(module)
+        manager.login()
+        module.exit_json(changed=manager.has_changed(), msg=manager.get_msg(), registry=manager.registry)
+
+    except Exception as e:
+        module.fail_json(msg="Module execution has failed due to an unexpected error", error=repr(e))
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+main()

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -70,7 +70,7 @@ options:
     required: false
     default: 600
 
-requirements: [ "docker-py" ]
+requirements: [ "python >= 2.6", "docker-py" ]
 '''
 
 EXAMPLES = '''

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -33,8 +33,9 @@ description:
 options:
   registry:
     description:
-       - URL of the registry, for example: https://index.docker.io/v1/
-    required: true
+       - URL of the registry, defaults to: https://index.docker.io/v1/
+    required: false
+    default: https://index.docker.io/v1/
   username:
     description:
        - The username for the registry account
@@ -214,7 +215,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec = dict(
-            registry        = dict(required=True),
+            registry        = dict(required=False, default='https://index.docker.io/v1/'),
             username        = dict(required=True),
             password        = dict(required=True),
             email           = dict(required=False, default='anonymous@localhost.local'),


### PR DESCRIPTION
- Ansible version of "docker login" CLI command
- Persists Docker registry authentification in .dockercfg (only login once - no need to specify credentials over and over again anymore)
- Works for all other docker-py based modules (docker, docker_images) as well as the Docker CLI client
