### PR TITLE
Allow for specifying name instead of host as per the documentation

### DIFF
--- a/system/known_hosts.py
+++ b/system/known_hosts.py
@@ -82,7 +82,7 @@ def enforce_state(module, params):
     Add or remove key.
     """
 
-    host = params["host"]
+    host = params["name"]
     key = params.get("key",None)
     port = params.get("port",None)
     #expand the path parameter; otherwise module.add_path_info


### PR DESCRIPTION
The documentation at http://docs.ansible.com/known_hosts_module.html indicates that this module needs only a "name" parameter but the code is looking for a "host" parameter and fails with a "KeyError: 'host'" if no "host" parameter is given.
