### PR TITLE
[homebew_cask] Be consistent in the documentation

### DIFF
--- a/packaging/os/homebrew_cask.py
+++ b/packaging/os/homebrew_cask.py
@@ -32,7 +32,7 @@ options:
     state:
         description:
             - state of the cask
-        choices: [ 'installed', 'uninstalled' ]
+        choices: [ 'present', 'absent' ]
         required: false
         default: present
 '''


### PR DESCRIPTION
The documentation for the `state` field is not very clear. 

It says possible values are `installed`, `uninstalled` and default value is `present`
The examples below also uses `present` and `absent`.

This patch uses`absent` and `present` instead of `installed` and `uninstalled`

Moreover, this is consistent with other packaging modules, like homebrew itself
