### PR TITLE
Support both new and old pkgin versions by testing if '-p' flag exists.

### DIFF
--- a/packaging/os/pkgin.py
+++ b/packaging/os/pkgin.py
@@ -76,9 +76,19 @@ def query_package(module, pkgin_path, name):
     * False      - not installed or not found
     """
 
+    # test whether '-p' (parsable) flag is supported.
+    rc, out, err = module.run_command("%s -p -v" % pkgin_path)
+
+    if rc == 0:
+        pflag = '-p'
+        splitchar = ';'
+    else:
+        pflag = ''
+        splitchar = ' '
+
     # Use "pkgin search" to find the package. The regular expression will
     # only match on the complete name.
-    rc, out, err = module.run_command("%s search \"^%s$\"" % (pkgin_path, name))
+    rc, out, err = module.run_command("%s %s search \"^%s$\"" % (pkgin_path, pflag, name))
 
     # rc will not be 0 unless the search was a success
     if rc == 0:
@@ -93,7 +103,7 @@ def query_package(module, pkgin_path, name):
         #     '<' - installed but out of date
         #     '=' - installed and up to date
         #     '>' - installed but newer than the repository version
-        pkgname_with_version, raw_state = out.split(' ')[0:2]
+        pkgname_with_version, raw_state = out.split(splitchar)[0:2]
 
         # Strip version
         # (results in sth like 'gcc47-libs')


### PR DESCRIPTION
This fixes a problem with newer versions of pkgin which change their output if output is not a tty.  Pull request #316 also deals with this issue, but not as thoroughly.

Tested with pkgin 0.8.0 (new style) and pkgin 0.6.4 (old style) on NetBSD 7 and NetBSD 6.
