### PR TITLE
Interpolate container name into error message

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -794,7 +794,7 @@ class LxcContainerManagement(object):
                 rc=1,
                 msg='The container [ %s ] failed to start. Check to lxc is'
                     ' available and that the container is in a functional'
-                    ' state.'
+                    ' state.' % self.container_name
             )
 
     def _check_archive(self):


### PR DESCRIPTION
##### Bugfix Pull Request:
##### Ansible Version:

```
# ansible --version
ansible 1.9.0.1
  configured module search path = None
```
##### Ansible Configuration:

None
##### Environment:

Ubuntu 14.04 / Ubuntu 14.04
##### Summary:

If you have a task that creates and starts a container and you run it with -vv, if the container fails to start then you'll see the error message without the container name interpolated.
##### Steps To Reproduce:

Create a task which will cause the created lxc container to fail to start.
##### Expected Results:

```
msg: The container [ infra1_glance_api ] failed to start. Check to lxc is available and that the container is in a functional state.
```
##### Actual Results:

```
msg: The container [ %s ] failed to start. Check to lxc is available and that the container is in a functional state.
```
