### PR TITLE
Suppress prompts from lvcreate using --yes when LVM supports this option

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -125,7 +125,10 @@ def main():
     if version_found == None:
         module.fail_json(msg="Failed to get LVM version number")
     version_yesopt = mkversion(2, 2, 99) # First LVM with the "--yes" option
-    yesopt = "--yes" if version_found >= version_yesopt else ""
+    if version_found >= version_yesopt:
+        yesopt = "--yes"
+    else:
+        yesopt = ""
 
     vg = module.params['vg']
     lv = module.params['lv']

--- a/system/lvol.py
+++ b/system/lvol.py
@@ -83,6 +83,8 @@ import re
 
 decimal_point = re.compile(r"(\.|,)")
 
+def mkversion(major, minor, patch):
+    return (1000 * 1000 * int(major)) + (1000 * int(minor)) + int(patch)
 
 def parse_lvs(data):
     lvs = []
@@ -93,6 +95,17 @@ def parse_lvs(data):
             'size': int(decimal_point.split(parts[1])[0]),
         })
     return lvs
+
+
+def get_lvm_version(module):
+    ver_cmd = module.get_bin_path("lvm", required=True)
+    rc, out, err = module.run_command("%s version" % (ver_cmd))
+    if rc != 0:
+        return None
+    m = re.search("LVM version:\s+(\d+)\.(\d+)\.(\d+).*(\d{4}-\d{2}-\d{2})", out)
+    if not m:
+        return None
+    return mkversion(m.group(1), m.group(2), m.group(3))
 
 
 def main():
@@ -106,6 +119,13 @@ def main():
         ),
         supports_check_mode=True,
     )
+
+    # Determine if the "--yes" option should be used
+    version_found = get_lvm_version(module)
+    if version_found == None:
+        module.fail_json(msg="Failed to get LVM version number")
+    version_yesopt = mkversion(2, 2, 99) # First LVM with the "--yes" option
+    yesopt = "--yes" if version_found >= version_yesopt else ""
 
     vg = module.params['vg']
     lv = module.params['lv']
@@ -187,7 +207,7 @@ def main():
                 changed = True
             else:
                 lvcreate_cmd = module.get_bin_path("lvcreate", required=True)
-                rc, _, err = module.run_command("%s -n %s -%s %s%s %s" % (lvcreate_cmd, lv, size_opt, size, size_unit, vg))
+                rc, _, err = module.run_command("%s %s -n %s -%s %s%s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, vg))
                 if rc == 0:
                     changed = True
                 else:


### PR DESCRIPTION
Occasionally, "lvcreate" will prompt on stdin for confirmation. In particular, this may happen when the volume is being created close to the location on disk where another volume existed previously. When this happens, Ansible will hang indefinitely with no indication of the problem. To work prevent this problem, the "--yes" command-line argument can be passed to "lvcreate", which will instruct it not to prompt.

A simple patch which adds "--yes" to the lvcreate command was already proposed and merged before (PR 332):
https://github.com/ansible/ansible-modules-extras/pull/332
The problem with this fix is it introduced a regression as old LVM versions (before 2.02.99) did not support the "--yes" option. Hence lvcreate just rejected the option and failed with old LVM versions. This patch has then been reverted.

With this new fix the lvol module will first get the LVM version number and it will only add "--yes" to the lvcreate command if the LVM version is 2.02.99 or more recent. This fix has been tested on CentOS 7.1 (which comes with LVM 2.02.115) and Ubuntu-12.04.5 (which comes with LVM 2.02.66) in order to test both situations.
