### PR TITLE
2 bug fixes for monit module

### DIFF
--- a/monitoring/monit.py
+++ b/monitoring/monit.py
@@ -77,7 +77,7 @@ def main():
             # Process 'name'    Running - restart pending
             parts = line.split()
             if len(parts) > 2 and parts[0].lower() == 'process' and parts[1] == "'%s'" % name:
-                return ' '.join(parts[2:])
+                return ' '.join(parts[2:]).lower()
         else:
             return ''
 

--- a/monitoring/monit.py
+++ b/monitoring/monit.py
@@ -119,7 +119,7 @@ def main():
         if module.check_mode:
             module.exit_json(changed=True)
         status = run_command('unmonitor')
-        if status in ['not monitored']:
+        if status in ['not monitored'] or 'unmonitor pending' in status:
             module.exit_json(changed=True, name=name, state=state)
         module.fail_json(msg='%s process not unmonitored' % name, status=status)
 

--- a/monitoring/monit.py
+++ b/monitoring/monit.py
@@ -86,7 +86,8 @@ def main():
         module.run_command('%s %s %s' % (MONIT, command, name), check_rc=True)
         return status()
 
-    present = status() != ''
+    process_status = status()
+    present = process_status != ''
 
     if not present and not state == 'present':
         module.fail_json(msg='%s process not presently configured with monit' % name, name=name, state=state)
@@ -102,7 +103,7 @@ def main():
                 module.exit_json(changed=True, name=name, state=state)
         module.exit_json(changed=False, name=name, state=state)
 
-    running = 'running' in status()
+    running = 'running' in process_status 
 
     if running and state in ['started', 'monitored']:
         module.exit_json(changed=False, name=name, state=state)


### PR DESCRIPTION
Two bug fixes for monit module
- status returned by monit has capitol letter but status are compared to lowercase strings, so I added a lower function before return status string in status function. Without this fix monit module cannot really detect the process status returned by monit.
- after an unmonitor command monit status could be "not monitored - unmonitor pending"

There is also a little optimization for status function called twice
