### PR TITLE
Add py27 compileall to test all modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,4 @@ addons:
       - python2.4
 script:
   - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/layman.py|/maven_artifact.py|clustering/consul.*\.py' .
+  - python -m compileall -fq .


### PR DESCRIPTION
This PR adds a python27 compileall "test" that amongst checking for python27 compatibility will also allow for finding syntax errors in modules excluded by the py24 compileall.
