### PR TITLE
Ignore pushbullet.py from 2.4 compat checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ addons:
     packages:
       - python2.4
 script:
-  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/layman.py|/maven_artifact.py|clustering/consul.*\.py' .
+  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/layman\.py|/maven_artifact\.py|clustering/consul.*\.py|notification/pushbullet\.py' .
   - python -m compileall -fq .


### PR DESCRIPTION
In reference to #226 this PR excludes pushbullet.py from the python24 compat checks since the pushbullet module requires a newer version of python.
