### PR TITLE
Specify that travis should use python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,15 @@
 sudo: false
 language: python
+python:
+  - "2.7"
 addons:
   apt:
     sources:
       - deadsnakes
     packages:
       - python2.4
+      - python2.6
 script:
   - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/layman\.py|/maven_artifact\.py|clustering/consul.*\.py|notification/pushbullet\.py' .
-  - python -m compileall -fq .
+  - python2.6 -m compileall -fq .
+  - python2.7 -m compileall -fq .


### PR DESCRIPTION
This PR specifies that travis should use python26 in addition to the default 2.7.

This matches up more closely to the travis/tox config in the `v2_final` branch in the core repo.
