### PR TITLE
Added eval for pasting tag lists

### DIFF
--- a/monitoring/datadog_event.py
+++ b/monitoring/datadog_event.py
@@ -116,7 +116,10 @@ def post_event(module):
     if module.params['date_happened'] != None:
         body['date_happened'] = module.params['date_happened']
     if module.params['tags'] != None:
-        body['tags'] = module.params['tags'].split(",")
+        if module.params['tags'].startswith("[") and module.params['tags'].endswith("]"):
+            body['tags'] = eval(module.params['tags'])
+        else:
+            body['tags'] = module.params['tags'].split(",")
     if module.params['aggregation_key'] != None:
         body['aggregation_key'] = module.params['aggregation_key']
     if module.params['source_type_name'] != None:


### PR DESCRIPTION
We faced some problems while adding tags which included Variables. The reason was that inside of Ansible some tags were unicode formatted. 

We got a list like this:
['tag1', u'tag1-production', u'host:host1', 'tag2']

Which resulted in tags with leading "u_" in Datadog. I added a 'best hope' if-check because the tags are a string.
