### PR TITLE
Use expanduser to deal with path in bower module

### DIFF
--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -154,7 +154,7 @@ def main():
 
     name = module.params['name']
     offline = module.params['offline']
-    path = module.params['path']
+    path = os.path.expanduser(module.params['path'])
     state = module.params['state']
     version = module.params['version']
 


### PR DESCRIPTION
There's a bug in the bower module. 
When using the bower module with a path containing  `~` (`~/foo` for exmple), it would report a failure saying that  `No such file or directory: '~/foo'` even though the path actually exists.

This patch make sure that `expanduser` is always called so bower module can correctly deal with paths containing `~`.
