### PR TITLE
maven_artifact: ensure latest snapshot of certain version is getting downloaded

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -309,7 +309,7 @@ def main():
             repository_url = dict(default=None),
             username = dict(default=None),
             password = dict(default=None),
-            state = dict(default="present", choices=["present","absent"]), # TODO - Implement a "latest" state 
+            state = dict(default="present", choices=["present","absent"]), # TODO - Implement a "latest" state
             dest = dict(default=None),
         )
     )
@@ -339,7 +339,10 @@ def main():
     if os.path.isdir(dest):
         dest = dest + "/" + artifact_id + "-" + version + "." + extension
     if os.path.lexists(dest):
-        prev_state = "present"
+        if not artifact.is_snapshot():
+            prev_state = "present"
+        elif downloader.verify_md5(dest, downloader.find_uri_for_artifact(artifact) + '.md5'):
+            prev_state = "present"
     else:
         path = os.path.dirname(dest)
         if not os.path.exists(path):


### PR DESCRIPTION
Until now, once a snapshot was downloaded, it would never be updated, even though it's not the latest snapshot version in remote repository.

This change does checksum comparison for snapshots, to ensure it is the latest snapshot.
