### PR TITLE
Fix alternatives module in non-English locale

### DIFF
--- a/system/alternatives.py
+++ b/system/alternatives.py
@@ -85,7 +85,7 @@ def main():
 
     # Run `update-alternatives --display <name>` to find existing alternatives
     (rc, display_output, _) = module.run_command(
-        [UPDATE_ALTERNATIVES, '--display', name]
+        ['env', 'LC_ALL=C', UPDATE_ALTERNATIVES, '--display', name]
     )
 
     if rc == 0:
@@ -106,7 +106,7 @@ def main():
             # This is only compatible on Debian-based systems, as the other
             # alternatives don't have --query available
             rc, query_output, _ = module.run_command(
-                [UPDATE_ALTERNATIVES, '--query', name]
+                ['env', 'LC_ALL=C', UPDATE_ALTERNATIVES, '--query', name]
             )
             if rc == 0:
                 for line in query_output.splitlines():


### PR DESCRIPTION
The alternatives module parses the output of update-alternatives, but the expected English phrases may not show up if the system locale is not English. Setting LC_ALL=C when invoking update-alternatives fixes this problem.

This is the symptom:

TASK: [laptop | Debian: update alternatives to use X11-enabled emacs] ********\* 
failed: [_hostname_] => {"failed": true, "parsed": false}
OpenSSH_6.7p1-hpn14v5, OpenSSL 1.0.1m 19 Mar 2015
debug1: Reading configuration data /etc/ssh/ssh_config
debug1: auto-mux: Trying existing master
debug1: mux_client_request_session: master session id: 2
Traceback (most recent call last):
  File "<stdin>", line 1742, in <module>
  File "<stdin>", line 96, in main
AttributeError: 'NoneType' object has no attribute 'group'
