### PR TITLE
Add slash to valid characters for packages

### DIFF
--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -116,6 +116,7 @@ class Homebrew(object):
     VALID_PACKAGE_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
         .                   # dots
+        /                   # slash (for taps)
         \+                  # plusses
         -                   # dashes
     '''


### PR DESCRIPTION
To allow it to download packes from taps, or external commands like
caskroom/cask/brew-cask
