### PR TITLE
Add force option to alternatives module

### DIFF
--- a/system/alternatives.py
+++ b/system/alternatives.py
@@ -144,7 +144,7 @@ def main():
 
                 if need_to_force:
                     module.run_command(
-                        [UPDATE_ALTERNATIVES, '--install', '--force', link, name, path, str(DEFAULT_LINK_PRIORITY)],
+                        [UPDATE_ALTERNATIVES, '--force', '--install', link, name, path, str(DEFAULT_LINK_PRIORITY)],
                         check_rc=True
                     )
 


### PR DESCRIPTION
This allows you to pass the --force option to update-alternatives, from the manpage:

``
       --force
              Let update-alternatives replace or drop any real file that is installed where an alternative link has to be installed or removed.

```
```
