### PR TITLE
Add backup_copy option to the patch module

### DIFF
--- a/files/patch.py
+++ b/files/patch.py
@@ -65,7 +65,7 @@ options:
     required: false
     type: "int"
     default: "0"
-  backup_copy:
+  backup:
     description:
       - passes --backup --version-control=numbered to patch, 
         producing numbered backup copies
@@ -133,8 +133,9 @@ def main():
             'basedir': {},
             'strip':   {'default': 0, 'type': 'int'},
             'remote_src': {'default': False, 'type': 'bool'},
-            # don't call it "backup" since the semantics differs from the default one
-            'backup_copy': { 'default': False, 'type': 'bool' }
+            # NB: for 'backup' parameter, semantics is slightly different from standard
+            #     since patch will create numbered copies, not strftime("%Y-%m-%d@%H:%M:%S~")
+            'backup': { 'default': False, 'type': 'bool' }
         },
         required_one_of=[['dest', 'basedir']],
         supports_check_mode=True
@@ -168,7 +169,7 @@ def main():
     if not is_already_applied(patch_func, p.src, p.basedir, dest_file=p.dest, strip=p.strip):
         try:
             apply_patch( patch_func, p.src, p.basedir, dest_file=p.dest, strip=p.strip,
-                         dry_run=module.check_mode, backup=p.backup_copy )
+                         dry_run=module.check_mode, backup=p.backup )
             changed = True
         except PatchError, e:
             module.fail_json(msg=str(e))


### PR DESCRIPTION
Hi Guys,

I'm sure there's a better way to do this -- but as backups are a generally desirable feature, having at least numbered backups provided by the patch utility itself would be nice. 

Kind regards,
/t13

PS. I'm sure making "timestamped" backups would be better, I'm just not that well acquainted with ansible code yet ( much less than an hour ) to make it the right way. However, if you're also busy, I wonder if we can have this for now, since IMHO it's much better than nothing.  
