### PR TITLE
Devices in the current_devs list must also be converted to absolute d…

### DIFF
--- a/system/lvg.py
+++ b/system/lvg.py
@@ -211,7 +211,7 @@ def main():
                     module.fail_json(msg="Refuse to remove non-empty volume group %s without force=yes"%(vg))
 
         ### resize VG
-        current_devs = [ pv['name'] for pv in pvs if pv['vg_name'] == vg ]
+        current_devs = [ os.path.realpath(pv['name']) for pv in pvs if pv['vg_name'] == vg ]
         devs_to_remove = list(set(current_devs) - set(dev_list))
         devs_to_add = list(set(dev_list) - set(current_devs))
 


### PR DESCRIPTION
…evice paths so comparison with dev_list works

This fixes issue #455 as all lists of devices must contains real paths so they can be compared. The code compares two lists of devices (current_devs and dev_list) which are the lists of PVs in the VG (the list of PV devices we currently have in the VG and the list of PV devices we want to have in the VG).

At the beginning of the module os.path.realpath is used to make sure devices in dev_list are converted to a real path if necessary. But this operation is not being done in current_devs, hence this list can contain a symbolic link to a device and this device will be considered as different in the following comparisons even though they refer to the same device.
        devs_to_remove = list(set(current_devs) - set(dev_list))
        devs_to_add = list(set(dev_list) - set(current_devs))

The fix simply uses os.path.realpath to convert all devices in current_devs to real paths.
