### PR TITLE
Updates the doc information for the python2-lxc dep

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -173,9 +173,9 @@ options:
           - list of 'key=value' options to use when configuring a container.
         required: false
 requirements:
-  - 'lxc >= 1.0'
-  - 'python >= 2.6'
-  - 'python2-lxc >= 0.1'
+  - 'lxc >= 1.0 # OS package'
+  - 'python >= 2.6 # OS Package'
+  - 'lxc-python2 >= 0.1 # PIP Package from https://github.com/lxc/python2-lxc'
 notes:
   - Containers must have a unique name. If you attempt to create a container
     with a name that already exists in the users namespace the module will
@@ -195,7 +195,8 @@ notes:
     creating the archive.
   - If your distro does not have a package for "python2-lxc", which is a
     requirement for this module, it can be installed from source at
-    "https://github.com/lxc/python2-lxc"
+    "https://github.com/lxc/python2-lxc" or installed via pip using the package
+    name lxc-python2.
 """
 
 EXAMPLES = """


### PR DESCRIPTION
The python2-lxc library has been uploaded to pypi as such this commit
updates the requirements and doc information for the module such that
it instructs the user to install the pip package "lxc-python2" while
also noting that the package could be gotten from source as well. In
the update comments have been added to the requirements list which
notes where the package should come from,

Closes-Bug: https://github.com/ansible/ansible-modules-extras/issues/550
