### PR TITLE
bower module. Non-interactive mode and allow-root moved to _exec.

### DIFF
--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -86,7 +86,7 @@ class Bower(object):
 
     def _exec(self, args, run_in_check_mode=False, check_rc=True):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
-            cmd = ["bower"] + args
+            cmd = ["bower"] + args + ['--config.interactive=false', '--allow-root']
 
             if self.name:
                 cmd.append(self.name_version)
@@ -108,7 +108,7 @@ class Bower(object):
         return ''
 
     def list(self):
-        cmd = ['list', '--json', '--config.interactive=false', '--allow-root']
+        cmd = ['list', '--json']
 
         installed = list()
         missing = list()


### PR DESCRIPTION
Reported here https://github.com/ansible/ansible-modules-extras/issues/335 . But not properly fixed in https://github.com/elventear/ansible-modules-extras/commit/07f5de86c3318771e463b2f7fe9c48c3012338cb commit.
We should pass these options to all bower invocations, not only the `list` command.

Options applicable to any bower commands. See [non-interactive-mode](http://bower.io/docs/api/#non-interactive-mode) and [--allow-root](http://bower.io/docs/api/#allow-root).
