### PR TITLE
puppet: ensure puppet is in live mode per default

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -156,10 +156,14 @@ def main():
             cmd += " --show-diff"
         if module.check_mode:
             cmd += " --noop"
+        else:
+            cmd += " --no-noop"
     else:
         cmd = "%s apply --detailed-exitcodes " % base_cmd
         if module.check_mode:
             cmd += "--noop "
+        else:
+            cmd += "--no-noop "
         cmd += pipes.quote(p['manifest'])
     rc, stdout, stderr = module.run_command(cmd)
 


### PR DESCRIPTION
puppet may be configured to operate in `--noop` mode per default.

That is why we must pass a `--no-noop` to make sure, changes are going to be applied.

owner: @emonty 
