### PR TITLE
make ovirt module idempotent (optionally)

### DIFF
--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 
 # (c) 2013, Vincent Van der Kussen <vincent at vanderkussen.org>
 #

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -162,7 +162,7 @@ options:
   async:
     description:
      - If True, just send command to server. If false, wait for the correct state before continuing (Idempotent)
-    default: False
+    default: 'yes'
     required: false
     version_added: "2.0"
   poll_frequency:
@@ -180,7 +180,7 @@ options:
   wait_for_ip:
     description:
      - If not async, wait for the VM to provide its IP addresses before continuing (requires that VM image has "ovirt guest agent" installed)
-    default: False
+    default: 'no'
     required: false
     version_added: "2.0"
 

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -262,56 +262,96 @@ action: ovirt >
 '''
 RETURN = '''
 instance_data:
-    description: Information about the VM Instance
-    returned: success
-    type: dictionary
-    contains:
-        uuid:
-            description: UUID of the instance
-            returned: success
-            type: string
-            sample: af824696-bdc0-46de-b7f1-44c0302960cd
-        id:
-            description: ID of the instance
-            returned: success
-            type: string
-            sample: af824696-bdc0-46de-b7f1-44c0302960cd
-        image:
-            description: Name of the instance's image
-            returned: success
-            type: string
-            sample: rhel_7x64
-        ips:
-            description: UUID of the instance
-            returned: success
-            type: list
-            sample: ["10.0.0.124"]
+  description: Information about the VM Instance
+  returned: success
+  type: dictionary
+  contains:
+    uuid:
+      description: UUID of the instance
+      returned: success
+      type: string
+      sample: af824696-bdc0-46de-b7f1-44c0302960cd
+    id:
+      description: ID of the instance
+      returned: success
+      type: string
+      sample: af824696-bdc0-46de-b7f1-44c0302960cd
+    image:
+      description: Name of the instance's image
+      returned: success
+      type: string
+      sample: rhel_7x64
+    ips:
+      description: UUID of the instance
+      returned: success
+      type: list
+      sample: ["10.0.0.124"]
+    name:
+      description: Instance name
+      returned: success
+      type: string
+      sample: ansiblevm04
+    description:
+      description: A description of the instance
+      returned: success
+      type: string
+      sample: Some description
+    status:
+      description: UUID of the instance
+      returned: success
+      type: string
+      sample: up
+      choices: ['up', 'down', 'creating', 'starting' 'stopping', 'does_not_exist', 'unknown']
+    cluster:
+      description: The ovirt cluster the instance is running on
+      returned: success
+      type: string
+      sample: local_cluster
+    tags:
+      description: Tags associated with the instance
+      returned: success
+      type: list
+      sample: ["dev", "jenkins"]
+    ovirt_guest_memory:
+      description: Memory assigned to the VM
+      returned: success
+      type: int
+      sample: 2056
+    ovirt_guest_protected:
+      description: Tags associated with the instance
+      returned: success
+      type: boolean
+      sample: True
+    ovirt_guest_nics:
+      description: Tags associated with the instance
+      returned: success
+      type: dictionary
+      contains:
         name:
-            description: Instance name
-            returned: success
-            type: string
-            sample: ansiblevm04
-        description:
-            description: A description of the instance
-            returned: success
-            type: string
-            sample: Some description
-        status:
-            description: UUID of the instance
-            returned: success
-            type: string
-            sample: up
-            choices: ['up', 'down', 'creating', 'starting' 'stopping', 'does_not_exist', 'unknown']
-        cluster:
-            description: The ovirt cluster the instance is running on
-            returned: success
-            type: string
-            sample: local_cluster
-        tags:
-            description: Tags associated with the instance
-            returned: success
-            type: list
-            sample: ["dev", "jenkins"]
+          description: Name of the NIC
+          returned: success
+          type: string
+          sample: eth0
+        mac:
+          description: Mac address of the NIC
+          returned: success
+          type: string
+          sample: 01:23:45:67:89:ab
+        machyphen:
+          description: Hyphenated Mac address of the NIC
+          returned: success
+          type: string
+          sample: 01-23-45-67-89-ab
+        macupper:
+          description: Uppercase Mac address of the NIC
+          returned: success
+          type: string
+          sample: 01:23:45:67:89:AB
+        machyphenupper:
+          description: Uppercase Hyphenated Mac address of the NIC
+          returned: success
+          type: string
+          sample: 01-23-45-67-89-AB
 '''
 
 try:
@@ -633,11 +673,11 @@ class OvirtConnection(object):
         ovirt_guest_nics = []
         for nic in niclist:
             ovirt_guest_nics.append({
-                'name' : nic.get_name(),
-                'mac' : nic.get_mac().get_address(),
-                'machyphen' : nic.get_mac().get_address().replace(':', '-'),
-                'macupper' : nic.get_mac().get_address().upper(),
-                'machyphenupper' : nic.get_mac().get_address().upper().replace(':', '-'),
+                'name': nic.get_name(),
+                'mac': nic.get_mac().get_address(),
+                'machyphen': nic.get_mac().get_address().replace(':', '-'),
+                'macupper': nic.get_mac().get_address().upper(),
+                'machyphenupper': nic.get_mac().get_address().upper().replace(':', '-'),
             })
 
         return {
@@ -652,13 +692,10 @@ class OvirtConnection(object):
             'cluster': self.conn.clusters.get(id=inst.get_cluster().get_id()).get_name(),
             'tags': tags,
             'ansible_ssh_host': ips[0] if len(ips) > 0 else None,
-            'ovirt_guest_memory' : inst.get_memory(),
-            'ovirt_guest_protected' : inst.get_delete_protected(),
-            'ovirt_guest_nics' : ovirt_guest_nics
-
+            'ovirt_guest_memory': inst.get_memory(),
+            'ovirt_guest_protected': inst.get_delete_protected(),
+            'ovirt_guest_nics': ovirt_guest_nics,
         }
-
-
 
     def vm_cloud_init(self):
         instance_name = self.module.params['instance_name']

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -23,7 +23,9 @@ module: ovirt
 author: '"Vincent Van der Kussen (@vincentvdk)" <vincent at vanderkussen.org>'
 short_description: oVirt/RHEV platform management
 description:
-    - allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances on the oVirt/RHEV platform
+    - >
+      allows you to create new instances, either from scratch or an image, in addition to deleting or stopping instances
+      on the oVirt/RHEV platform
 version_added: "1.4"
 options:
   user:
@@ -179,7 +181,9 @@ options:
     version_added: "2.0"
   wait_for_ip:
     description:
-     - If not async, wait for the VM to provide its IP addresses before continuing (requires that VM image has "ovirt guest agent" installed)
+     - >
+       If not async, wait for the VM to provide its IP addresses before continuing (requires that VM image has "ovirt
+       guest agent" installed)
     default: 'no'
     required: false
     version_added: "2.0"
@@ -328,9 +332,7 @@ OVIRT_STATE_MAP = dict(
     powering_down='stopping',
 )
 
-# ------------------------------------------------------------------- #
-# create connection with API
-#
+
 class OvirtConnection(object):
     """
     :type module: ansible.module_utils.basic.AnsibleModule
@@ -342,6 +344,7 @@ class OvirtConnection(object):
         self.conn = self.connect()
         self.tries = int(module.params['poll_tries'])
 
+    # noinspection PyBroadException
     def connect(self):
         """
         :rtype: ovirtsdk.api.API
@@ -440,6 +443,7 @@ class OvirtConnection(object):
                 )
         return cloud_init
 
+    # noinspection PyBroadException
     def add_tags(self):
         """
         :rtype: list[ovirtsdk.infrastructure.brokers.Tag]
@@ -582,6 +586,7 @@ class OvirtConnection(object):
         for tag in self.add_tags():
             self.conn.vms.get(name=instance_name).tags.add(tag)
 
+    # noinspection PyBroadException
     def instantiate(self):
         instance_name = self.module.params['instance_name']
         image = self.module.params['image']

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -31,13 +31,11 @@ options:
      - the user to authenticate with
     default: null
     required: true
-    aliases: []
   url:
     description:
      - the url of the oVirt instance
     default: null
     required: true
-    aliases: []
   instance_name:
     description:
      - the name of the instance to use
@@ -49,26 +47,22 @@ options:
      - password of the user to authenticate with
     default: null
     required: true
-    aliases: []
   image:
     description:
      - template to use for the instance
     default: null
     required: false
-    aliases: []
   resource_type:
     description:
      - whether you want to deploy an image or create an instance from scratch.
     default: null
     required: false
-    aliases: []
     choices: [ 'new', 'template' ]
   zone:
     description:
      - deploy the image to this oVirt cluster
     default: null
     required: false
-    aliases: []
   instance_disksize:
     description:
      - size of the instance's disk in GB
@@ -111,14 +105,12 @@ options:
      - define if disk is thin or preallocated
     default: thin
     required: false
-    aliases: []
     choices: [ 'thin', 'preallocated' ]
   disk_int:
     description:
      - interface type of the disk
     default: virtio
     required: false
-    aliases: []
     choices: [ 'virtio', 'ide' ]
   instance_os:
     description:
@@ -137,38 +129,35 @@ options:
      - the Storage Domain where you want to create the instance's disk on.
     default: null
     required: false
-    aliases: []
   region:
     description:
      - the oVirt/RHEV datacenter where you want to deploy to
     default: null
     required: false
-    aliases: []
   state:
     description:
      - create, terminate or remove instances
     default: 'present'
     required: false
-    aliases: []
     choices: ['present', 'absent', 'shutdown', 'started', 'restarted']
   authorised_key_file:
     description:
      - absolute path to the public key to be inserted into authorised keys on instantiation
     default: null
     required: false
-    aliases: []
+    version_added: "2.0"
   authorised_key_user:
     description:
      - insert user key into authorised keys on instantiation
     default: 'root'
     required: false
-    aliases: []
+    version_added: "2.0"
   tag:
     description:
      - comma separated list of tags
     default: null
     required: false
-    aliases: []
+    version_added: "2.0"
 
 requirements:
   - "python >= 2.6"

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -243,9 +243,17 @@ action: ovirt >
     user=admin@internal 
     password=secret 
     url=https://ovirt.example.com
-
-
 '''
+RETURN = '''
+ips:
+    description: List of IP Addresses
+    returned: success
+    type: list of strings
+    sample: [
+        "10.0.0.124"
+        ]
+'''
+
 try:
     # noinspection PyUnresolvedReferences
     from ovirtsdk.api import API

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -163,7 +163,7 @@ options:
     default: 'root'
     required: false
     aliases: []
-  authorised_key_user:
+  tag:
     description:
      - comma separated list of tags
     default: null

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -163,6 +163,12 @@ options:
     default: 'root'
     required: false
     aliases: []
+  authorised_key_user:
+    description:
+     - comma separated list of tags
+    default: null
+    required: false
+    aliases: []
 
 requirements:
   - "python >= 2.6"
@@ -288,27 +294,26 @@ def add_tags(conn, tags):
 
     :type conn: ovirtsdk.api.API
     """
-    new_tags = {tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')}
+    if tags:
+        new_tags = {tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')}
 
-    try:
-        existing_tags = {tag.get_name() for tag in conn.tags.list()}
-    except Exception:
-        print ("Could not get existing tags from server")
-        sys.exit(1)
-    else:
-        tags_to_add = []
-        for tag in new_tags:
-            if tag in existing_tags:
-                tags_to_add.append(conn.tags.get(name=tag))
-            else:
-                try:
-                    tags_to_add.append(conn.tags.add(params.Tag(name=tag)))
-                except:
-                    print("Failed to add tag to ovirt")
-                    sys.exit(1)
-        return params.Tags(tag=tags_to_add)
-
-
+        try:
+            existing_tags = {tag.get_name() for tag in conn.tags.list()}
+        except Exception:
+            print ("Could not get existing tags from server")
+            sys.exit(1)
+        else:
+            tags_to_add = []
+            for tag in new_tags:
+                if tag in existing_tags:
+                    tags_to_add.append(conn.tags.get(name=tag))
+                else:
+                    try:
+                        tags_to_add.append(conn.tags.add(params.Tag(name=tag)))
+                    except:
+                        print("Failed to add tag to ovirt")
+                        sys.exit(1)
+            return params.Tags(tag=tags_to_add)
 
 
 # ------------------------------------------------------------------- #

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -333,451 +333,449 @@ TRIES = 0
 # ------------------------------------------------------------------- #
 # create connection with API
 #
-def connect(module):
+class OvirtConnection(object):
     """
     :type module: ansible.module_utils.basic.AnsibleModule
-    :rtype: ovirtsdk.api.API
+    :type conn: ovirtsdk.api.API
     """
-    user = module.params['user']
-    url = module.params['url']
-    password = module.params['password']
 
-    if not url.endswith('api'):
-        url = '{}/api'.format(url.strip().rstrip('/'))
+    def __init__(self, module):
+        self.module = module
+        self.conn = self.connect()
 
-    try:
-        api = API(url=url, username=user, password=password, insecure=True)
-        api.test(throw_exception=True)
-    except:
-        module.fail_json(msg=u"Could not connect to server: {}".format(url))
-    else:
-        return api
+    def connect(self):
+        """
+        :rtype: ovirtsdk.api.API
+        """
+        user = self.module.params['user']
+        url = self.module.params['url']
+        password = self.module.params['password']
 
+        if not url.endswith('api'):
+            url = '{}/api'.format(url.strip().rstrip('/'))
 
-def add_auth_key(key, user='root'):
-    """
-    :type key: str
-    :type user: str
-    :rtype : ovirtsdk.xml.params.Initialization
-    """
-    cloud_init = params.CloudInit(
-        authorized_keys=params.AuthorizedKeys(
-            authorized_key=[
-                params.AuthorizedKey(
-                    user=params.User(user_name=user),
-                    key=key
-                ),
-            ]
-        )
-    )
-    return params.Initialization(cloud_init=cloud_init)
+        try:
+            api = API(url=url, username=user, password=password, insecure=True)
+            api.test(throw_exception=True)
+        except:
+            self.module.fail_json(msg=u"Could not connect to server: {}".format(url))
+        else:
+            return api
 
+    @staticmethod
+    def _generate_cloud_init(key, user='root', custom_script=None, host=None, ):
+        """
+        :type key: str
+        :type user: str
+        :type custom_script: str
+        :type host: str
+        :rtype : ovirtsdk.xml.params.Initialization
+        """
 
-def get_cloud_init(module):
-    """
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :rtype: ovirtsdk.xml.params.Initialization
-    """
-    authorized_key_file = module.params['authorized_key_file']
-    authorized_key_user = module.params['authorized_key_user']
-
-    cloud_init = None
-    if authorized_key_file:
-        if os.path.isfile(authorized_key_file):
-            try:
-                with open(authorized_key_file, 'r') as f:
-                    key = f.read()
-            except IOError:
-                module.fail_json(msg=u"Could not read the given authorized_key_file at {}".format(authorized_key_file))
+        script = ''
+        if custom_script is not None:
+            if os.path.isfile(custom_script):
+                with open(custom_script, 'r') as f:
+                    script = f.read()
             else:
-                cloud_init = add_auth_key(key, authorized_key_user)
-        else:
-            module.fail_json(
-                msg=(u"The provided authorized_key_file is not a file. "
-                     u"Please specify the absolute path to the .pub key file")
+                script = custom_script
+
+        cloud_init = params.CloudInit(
+            host=host,
+            files=params.Files(
+                file=[params.File(name="/tmp/_vmcustomscript", content=script, type_="PLAINTEXT")]
+            ),
+            authorized_keys=params.AuthorizedKeys(
+                authorized_key=[
+                    params.AuthorizedKey(
+                        user=params.User(user_name=user),
+                        key=key
+                    ),
+                ]
             )
-    return cloud_init
+        )
+        return params.Initialization(cloud_init=cloud_init)
 
+    @staticmethod
+    def add_auth_key(key, user='root'):
+        """
+        :type key: str
+        :type user: str
+        :rtype : ovirtsdk.xml.params.Initialization
+        """
+        cloud_init = params.CloudInit(
+            authorized_keys=params.AuthorizedKeys(
+                authorized_key=[
+                    params.AuthorizedKey(
+                        user=params.User(user_name=user),
+                        key=key
+                    ),
+                ]
+            )
+        )
+        return params.Initialization(cloud_init=cloud_init)
 
-def add_tags(module, conn):
-    """
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    :rtype: list[ovirtsdk.infrastructure.brokers.Tag]
-    """
-    tags = module.params['tags']
+    def get_cloud_init(self):
+        """
+        :rtype: ovirtsdk.xml.params.Initialization
+        """
+        authorized_key_file = self.module.params['authorized_key_file']
+        authorized_key_user = self.module.params['authorized_key_user']
 
-    if tags:
-        new_tags = set([tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')])
-
-        try:
-            existing_tags = set([tag.get_name() for tag in conn.tags.list()])
-        except Exception:
-            module.fail_json(msg=u"Could not get existing tags from server")
-        else:
-            tags_to_add = []
-            for tag in new_tags:
-                if tag not in existing_tags:
-                    try:
-                        conn.tags.add(params.Tag(name=tag))
-                    except:
-                        module.fail_json(msg=u"Failed to add tag '{}' to ovirt".format(tag))
+        cloud_init = None
+        if authorized_key_file:
+            if os.path.isfile(authorized_key_file):
                 try:
-                    infra_tag = conn.tags.get(name=tag)
-                    tags_to_add.append(infra_tag)
-                except:
-                    module.fail_json(msg=u"Failed to get tag '{}' from ovirt".format(tag))
-            return tags_to_add
+                    with open(authorized_key_file, 'r') as f:
+                        key = f.read()
+                except IOError:
+                    self.module.fail_json(
+                        msg=u"Could not read the given authorized_key_file at {}".format(authorized_key_file)
+                    )
+                else:
+                    cloud_init = self.add_auth_key(key, authorized_key_user)
+            else:
+                self.module.fail_json(
+                    msg=(u"The provided authorized_key_file is not a file. "
+                         u"Please specify the absolute path to the .pub key file")
+                )
+        return cloud_init
 
+    def add_tags(self):
+        """
+        :rtype: list[ovirtsdk.infrastructure.brokers.Tag]
+        """
+        tags = self.module.params['tags']
 
-def recurse(module, conn, func):
-    """
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    :type func: (ansible.module_utils.basic.AnsibleModule, ovirtsdk.api.API) -> bool
-    :rtype: bool
-    """
-    global TRIES
-    poll_frequency = float(module.params['poll_frequency'])
+        if tags:
+            new_tags = set([tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')])
 
-    time.sleep(poll_frequency)
-    TRIES -= 1
-    return func(module, conn)
+            try:
+                existing_tags = set([tag.get_name() for tag in self.conn.tags.list()])
+            except Exception:
+                self.module.fail_json(msg=u"Could not get existing tags from server")
+            else:
+                tags_to_add = []
+                for tag in new_tags:
+                    if tag not in existing_tags:
+                        try:
+                            self.conn.tags.add(params.Tag(name=tag))
+                        except:
+                            self.module.fail_json(msg=u"Failed to add tag '{}' to ovirt".format(tag))
+                    try:
+                        infra_tag = self.conn.tags.get(name=tag)
+                        tags_to_add.append(infra_tag)
+                    except:
+                        self.module.fail_json(msg=u"Failed to get tag '{}' from ovirt".format(tag))
+                return tags_to_add
 
+    def recurse(self, func):
+        """
+        :type func: (OvirtConnection) -> bool
+        :rtype: bool
+        """
+        global TRIES
+        poll_frequency = float(self.module.params['poll_frequency'])
 
-# noinspection PyUnboundLocalVariable,PyBroadException
-def create_vm(module, conn):
-    """
-    Create a VM instance
+        time.sleep(poll_frequency)
+        TRIES -= 1
+        return func()
 
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
+    # noinspection PyUnboundLocalVariable,PyBroadException
+    def create_vm(self):
+        """
+        Create a VM instance
+        """
 
-    instance_name = module.params['instance_name']
-    zone = module.params['zone']
-    instance_disksize = module.params['instance_disksize']
-    instance_nic = module.params['instance_nic']
-    instance_network = module.params['instance_network']
-    instance_mem = module.params['instance_mem']
-    disk_alloc = module.params['disk_alloc']
-    disk_int = module.params['disk_int']
-    instance_os = module.params['instance_os']
-    instance_type = module.params['instance_type']
-    instance_cores = module.params['instance_cores']
-    sdomain = module.params['sdomain']
+        instance_name = self.module.params['instance_name']
+        zone = self.module.params['zone']
+        instance_disksize = self.module.params['instance_disksize']
+        instance_nic = self.module.params['instance_nic']
+        instance_network = self.module.params['instance_network']
+        instance_mem = self.module.params['instance_mem']
+        disk_alloc = self.module.params['disk_alloc']
+        disk_int = self.module.params['disk_int']
+        instance_os = self.module.params['instance_os']
+        instance_type = self.module.params['instance_type']
+        instance_cores = self.module.params['instance_cores']
+        sdomain = self.module.params['sdomain']
 
-    if disk_alloc == 'thin':
+        if disk_alloc == 'thin':
+            vmparams = params.VM(
+                name=instance_name,
+                cluster=self.conn.clusters.get(name=zone),
+                os=params.OperatingSystem(type_=instance_os),
+                template=self.conn.templates.get(name="Blank"),
+                memory=1024 * 1024 * int(instance_mem),
+                cpu=params.CPU(topology=params.CpuTopology(cores=int(instance_cores))),
+                type_=instance_type,
+                initialization=self.get_cloud_init(),
+            )
+            vmdisk = params.Disk(
+                size=1024 * 1024 * 1024 * int(instance_disksize),
+                wipe_after_delete=True,
+                sparse=True,
+                interface=disk_int,
+                type_="System",
+                format='cow',
+                storage_domains=params.StorageDomains(storage_domain=[self.conn.storagedomains.get(name=sdomain)]),
+            )
+            network_net = params.Network(name=instance_network)
+            nic_net1 = params.NIC(name='nic1', network=network_net, interface='virtio')
+        elif disk_alloc == 'preallocated':
+            vmparams = params.VM(
+                name=instance_name,
+                cluster=self.conn.clusters.get(name=zone),
+                os=params.OperatingSystem(type_=instance_os),
+                template=self.conn.templates.get(name="Blank"),
+                memory=1024 * 1024 * int(instance_mem),
+                cpu=params.CPU(topology=params.CpuTopology(cores=int(instance_cores))),
+                type_=instance_type,
+                initialization=self.get_cloud_init(),
+            )
+            vmdisk = params.Disk(
+                size=1024 * 1024 * 1024 * int(instance_disksize),
+                wipe_after_delete=True,
+                sparse=False,
+                interface=disk_int,
+                type_="System",
+                format='raw',
+                storage_domains=params.StorageDomains(storage_domain=[self.conn.storagedomains.get(name=sdomain)])
+            )
+            network_net = params.Network(name=instance_network)
+            nic_net1 = params.NIC(name=instance_nic, network=network_net, interface='virtio')
+        else:
+            self.module.fail_json(msg=u"Invalid value for 'disk_alloc': {}".format(disk_alloc))
+
+        try:
+            self.conn.vms.add(vmparams)
+        except:
+            self.module.fail_json(msg=u"Error creating VM with specified parameters")
+        vm = self.conn.vms.get(name=instance_name)
+        try:
+            vm.disks.add(vmdisk)
+        except:
+            self.vm_remove()
+            self.module.fail_json(msg=u"Error attaching disk")
+        try:
+            vm.nics.add(nic_net1)
+        except:
+            self.vm_remove()
+            self.module.fail_json(msg=u"Error adding nic")
+        for tag in self.add_tags():
+            self.conn.vms.get(name=instance_name).tags.add(tag)
+
+    def create_vm_template(self):
+        """
+        Create an instance from a template
+        """
+        instance_name = self.module.params['instance_name']
+        zone = self.module.params['zone']
+        image = self.module.params['image']
+
         vmparams = params.VM(
             name=instance_name,
-            cluster=conn.clusters.get(name=zone),
-            os=params.OperatingSystem(type_=instance_os),
-            template=conn.templates.get(name="Blank"),
-            memory=1024 * 1024 * int(instance_mem),
-            cpu=params.CPU(topology=params.CpuTopology(cores=int(instance_cores))),
-            type_=instance_type,
-            initialization=get_cloud_init(module),
+            cluster=self.conn.clusters.get(name=zone),
+            template=self.conn.templates.get(name=image),
+            disks=params.Disks(clone=True),
+            initialization=self.get_cloud_init(),
         )
-        vmdisk = params.Disk(
-            size=1024 * 1024 * 1024 * int(instance_disksize),
-            wipe_after_delete=True,
-            sparse=True,
-            interface=disk_int,
-            type_="System",
-            format='cow',
-            storage_domains=params.StorageDomains(storage_domain=[conn.storagedomains.get(name=sdomain)]),
-        )
-        network_net = params.Network(name=instance_network)
-        nic_net1 = params.NIC(name='nic1', network=network_net, interface='virtio')
-    elif disk_alloc == 'preallocated':
-        vmparams = params.VM(
-            name=instance_name,
-            cluster=conn.clusters.get(name=zone),
-            os=params.OperatingSystem(type_=instance_os),
-            template=conn.templates.get(name="Blank"),
-            memory=1024 * 1024 * int(instance_mem),
-            cpu=params.CPU(topology=params.CpuTopology(cores=int(instance_cores))),
-            type_=instance_type,
-            initialization=get_cloud_init(module),
-        )
-        vmdisk = params.Disk(
-            size=1024 * 1024 * 1024 * int(instance_disksize),
-            wipe_after_delete=True,
-            sparse=False,
-            interface=disk_int,
-            type_="System",
-            format='raw',
-            storage_domains=params.StorageDomains(storage_domain=[conn.storagedomains.get(name=sdomain)])
-        )
-        network_net = params.Network(name=instance_network)
-        nic_net1 = params.NIC(name=instance_nic, network=network_net, interface='virtio')
-    else:
-        module.fail_json(msg=u"Invalid value for 'disk_alloc': {}".format(disk_alloc))
+        self.conn.vms.add(vmparams)
+        for tag in self.add_tags():
+            self.conn.vms.get(name=instance_name).tags.add(tag)
 
-    try:
-        conn.vms.add(vmparams)
-    except:
-        module.fail_json(msg=u"Error creating VM with specified parameters")
-    vm = conn.vms.get(name=instance_name)
-    try:
-        vm.disks.add(vmdisk)
-    except:
-        vm_remove(module, conn)
-        module.fail_json(msg=u"Error attaching disk")
-    try:
-        vm.nics.add(nic_net1)
-    except:
-        vm_remove(module, conn)
-        module.fail_json(msg=u"Error adding nic")
-    for tag in add_tags(module, conn):
-        conn.vms.get(name=instance_name).tags.add(tag)
+    def instantiate(self):
+        instance_name = self.module.params['instance_name']
+        image = self.module.params['image']
+        resource_type = self.module.params['resource_type']
 
+        if resource_type == 'template':
+            try:
+                self.create_vm_template()
+            except:
+                self.module.fail_json(msg=u'error adding template {}'.format(image))
+        elif resource_type == 'new':
+            try:
+                self.create_vm()
+            except:
+                self.module.fail_json(u"Failed to create VM: {}".format(instance_name))
+        else:
+            self.module.fail_json(msg=u"You did not specify a resource type")
 
-def create_vm_template(module, conn):
-    """
-    Create an instance from a template
+    def get_ips(self):
+        """
+        get ip addresses from instance
+    
+        :rtype: list[str]
+        """
+        instance_name = self.module.params['instance_name']
 
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    instance_name = module.params['instance_name']
-    zone = module.params['zone']
-    image = module.params['image']
-
-    vmparams = params.VM(
-        name=instance_name,
-        cluster=conn.clusters.get(name=zone),
-        template=conn.templates.get(name=image),
-        disks=params.Disks(clone=True),
-        initialization=get_cloud_init(module),
-    )
-    conn.vms.add(vmparams)
-    for tag in add_tags(module, conn):
-        conn.vms.get(name=instance_name).tags.add(tag)
-
-
-def instantiate(module, conn):
-    """
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    instance_name = module.params['instance_name']
-    image = module.params['image']
-    resource_type = module.params['resource_type']
-
-    if resource_type == 'template':
         try:
-            create_vm_template(module, conn)
-        except:
-            module.fail_json(msg=u'error adding template {}'.format(image))
-    elif resource_type == 'new':
-        try:
-            create_vm(module, conn)
-        except:
-            module.fail_json(u"Failed to create VM: {}".format(instance_name))
-    else:
-        module.fail_json(msg=u"You did not specify a resource type")
+            ips = [ip.get_address() for ip in self.conn.vms.get(name=instance_name).get_guest_info().get_ips().get_ip()]
+        except AttributeError:
+            ips = []
+        return ips
 
+    def get_instance_data(self):
+        """
+        :rtype: dict
+        """
+        instance_name = self.module.params['instance_name']
+        inst = self.conn.vms.get(name=instance_name)
 
-def get_ips(module, conn):
-    """
-    get ip addresses from instance
+        if inst is None:
+            return {}
 
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    :rtype: list[str]
-    """
-    instance_name = module.params['instance_name']
+        inst.get_custom_properties()
+        ips = self.get_ips()
+        tags = [x.get_name() for x in inst.get_tags().list()]
 
-    try:
-        ips = [ip.get_address() for ip in conn.vms.get(name=instance_name).get_guest_info().get_ips().get_ip()]
-    except AttributeError:
-        ips = []
-    return ips
+        return {
+            'uuid': inst.get_id(),
+            'id': inst.get_id(),
+            'image': inst.get_os().get_type(),
+            'machine_type': inst.get_instance_type(),
+            'ips': ips,
+            'name': inst.get_name(),
+            'description': inst.get_description(),
+            'status': inst.get_status().get_state(),
+            'zone': self.conn.clusters.get(id=inst.get_cluster().get_id()).get_name(),
+            'tags': tags,
+            # Hosts don't have a public name, so we add an IP
+            'ansible_ssh_host': ips[0] if len(ips) > 0 else None
+        }
 
+    def vm_start(self):
+        """
+        start instance
+        """
+        global TRIES
+        instance_name = self.module.params['instance_name']
+        async = self.module.boolean(self.module.params['async'])
+        wait_for_ip = self.module.boolean(self.module.params['wait_for_ip'])
 
-def get_instance_data(module, conn):
-    """
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    :rtype: dict
-    """
-    instance_name = module.params['instance_name']
-    inst = conn.vms.get(name=instance_name)
+        state = self.vm_status()
 
-    if inst is None:
-        return {}
+        if TRIES <= 0:
+            self.module.fail_json(
+                msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state)
+            )
+        if state == 'does_not_exist':
+            self.instantiate()
+            return self.recurse(self.vm_start)
+        elif state == 'unknown':
+            self.module.fail_json(msg=u"{} is in an unknown state.".format(instance_name))
+        elif state in ['creating', 'starting', 'stopping']:
+            return self.recurse(self.vm_start)
+        elif state == 'down':
+            vm = self.conn.vms.get(name=instance_name)
+            vm.start()
+            if not async:
+                return self.recurse(self.vm_start)
+        elif state == 'up':
+            if wait_for_ip:
+                ips = self.get_ips()
+                if not ips:
+                    return self.recurse(self.vm_start)
 
-    inst.get_custom_properties()
-    ips = get_ips(module, conn)
-    tags = [x.get_name() for x in inst.get_tags().list()]
+    def vm_stop(self):
+        """
+        Stop instance
+        """
+        global TRIES
+        instance_name = self.module.params['instance_name']
+        async = self.module.boolean(self.module.params['async'])
 
-    return {
-        'uuid': inst.get_id(),
-        'id': inst.get_id(),
-        'image': inst.get_os().get_type(),
-        'machine_type': inst.get_instance_type(),
-        'ips': ips,
-        'name': inst.get_name(),
-        'description': inst.get_description(),
-        'status': inst.get_status().get_state(),
-        'zone': conn.clusters.get(id=inst.get_cluster().get_id()).get_name(),
-        'tags': tags,
-        # Hosts don't have a public name, so we add an IP
-        'ansible_ssh_host': ips[0] if len(ips) > 0 else None
-    }
+        vm = self.conn.vms.get(name=instance_name)
+        state = self.vm_status()
 
+        if TRIES <= 0:
+            self.module.fail_json(
+                msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state)
+            )
+        if state == 'does_not_exist':
+            self.instantiate()
+            return self.recurse(self.vm_stop)
+        elif state == 'unknown':
+            self.module.fail_json(msg=u"{} is in an unknown state.".format(instance_name))
+        elif state in ['creating', 'starting', 'stopping']:
+            return self.recurse(self.vm_stop)
+        elif state == 'up':
+            vm.stop()
+            if not async:
+                return self.recurse(self.vm_stop)
+        elif state == 'down':
+            return True
 
-def vm_start(module, conn):
-    """
-    start instance
+    def vm_restart(self):
+        """
+        restart instance
+        """
+        stopped = self.vm_stop()
+        started = self.vm_start()
+        return stopped and started
 
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    global TRIES
-    instance_name = module.params['instance_name']
-    async = module.boolean(module.params['async'])
-    wait_for_ip = module.boolean(module.params['wait_for_ip'])
+    def vm_remove(self):
+        """
+        remove an instance
+    
+        """
+        global TRIES
+        instance_name = self.module.params['instance_name']
+        async = self.module.boolean(self.module.params['async'])
 
-    state = vm_status(module, conn)
+        vm = self.conn.vms.get(name=instance_name)
+        state = self.vm_status()
 
-    if TRIES <= 0:
-        module.fail_json(msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state))
-    if state == 'does_not_exist':
-        instantiate(module, conn)
-        return recurse(module, conn, vm_start)
-    elif state == 'unknown':
-        module.fail_json(msg=u"{} is in an unknown state.".format(instance_name))
-    elif state in ['creating', 'starting', 'stopping']:
-        return recurse(module, conn, vm_start)
-    elif state == 'down':
-        vm = conn.vms.get(name=instance_name)
-        vm.start()
-        if not async:
-            return recurse(module, conn, vm_start)
-    elif state == 'up':
-        if wait_for_ip:
-            ips = get_ips(module, conn)
-            if not ips:
-                return recurse(module, conn, vm_start)
+        if TRIES <= 0:
+            self.module.fail_json(
+                msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state)
+            )
+        if state == 'does_not_exist':
+            return True
+        elif state == 'unknown':
+            vm.delete(action=params.Action(force=True))
+            return True if async else self.recurse(self.vm_remove)
+        elif state in ['creating', 'starting', 'stopping']:
+            return self.recurse(self.vm_remove)
+        elif state == 'up':
+            self.vm_stop()
+            return self.recurse(self.vm_remove)
+        elif state == 'down':
+            vm.delete()
+            return True if async else self.recurse(self.vm_remove)
 
+    def vm_status(self):
+        """
+        Get the VMs status
+        """
+        instance_name = self.module.params['instance_name']
 
-def vm_stop(module, conn):
-    """
-    Stop instance
+        if instance_name not in set([vm.get_name() for vm in self.conn.vms.list()]):
+            status = 'does_not_exist'
+        else:
+            status = OVIRT_STATE_MAP.get(self.conn.vms.get(name=instance_name).get_status().get_state(), 'unknown')
+        return status
 
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    global TRIES
-    instance_name = module.params['instance_name']
-    async = module.boolean(module.params['async'])
+    def get_vm(self):
+        """
+        Get VM object and return it's name if object exists
+        """
+        instance_name = self.module.params['instance_name']
+        vm = self.conn.vms.get(name=instance_name)
 
-    vm = conn.vms.get(name=instance_name)
-    state = vm_status(module, conn)
+        return "empty" if vm is None else vm.get_name()
 
-    if TRIES <= 0:
-        module.fail_json(msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state))
-    if state == 'does_not_exist':
-        instantiate(module, conn)
-        return recurse(module, conn, vm_stop)
-    elif state == 'unknown':
-        module.fail_json(msg=u"{} is in an unknown state.".format(instance_name))
-    elif state in ['creating', 'starting', 'stopping']:
-        return recurse(module, conn, vm_stop)
-    elif state == 'up':
-        vm.stop()
-        if not async:
-            return recurse(module, conn, vm_stop)
-    elif state == 'down':
-        return True
-
-
-def vm_restart(module, conn):
-    """
-    restart instance
-
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    stopped = vm_stop(module, conn)
-    started = vm_start(module, conn)
-    return stopped and started
-
-
-def vm_remove(module, conn):
-    """
-    remove an instance
-
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    global TRIES
-    instance_name = module.params['instance_name']
-    async = module.boolean(module.params['async'])
-
-    vm = conn.vms.get(name=instance_name)
-    state = vm_status(module, conn)
-
-    if TRIES <= 0:
-        module.fail_json(msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state))
-    if state == 'does_not_exist':
-        return True
-    elif state == 'unknown':
-        vm.delete(action=params.Action(force=True))
-        return True if async else recurse(module, conn, vm_remove)
-    elif state in ['creating', 'starting', 'stopping']:
-        return recurse(module, conn, vm_remove)
-    elif state == 'up':
-        vm_stop(module, conn)
-        return recurse(module, conn, vm_remove)
-    elif state == 'down':
-        vm.delete()
-        return True if async else recurse(module, conn, vm_remove)
-
-
-def vm_status(module, conn):
-    """
-    Get the VMs status
-
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    instance_name = module.params['instance_name']
-
-    if instance_name not in set([vm.get_name() for vm in conn.vms.list()]):
-        status = 'does_not_exist'
-    else:
-        status = OVIRT_STATE_MAP.get(conn.vms.get(name=instance_name).get_status().get_state(), 'unknown')
-    return status
-
-
-def get_vm(module, conn):
-    """
-    Get VM object and return it's name if object exists
-
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    """
-    instance_name = module.params['instance_name']
-    vm = conn.vms.get(name=instance_name)
-
-    return "empty" if vm is None else vm.get_name()
-
-
-def finish(module, conn, changed, msg):
-    """
-    :type module: ansible.module_utils.basic.AnsibleModule
-    :type conn: ovirtsdk.api.API
-    :type changed: bool
-    :type msg: str
-    """
-    module.exit_json(
-        changed=changed,
-        msg=msg,
-        instance_data=get_instance_data(module, conn)
-    )
+    def finish(self, changed, msg):
+        """
+        :type changed: bool
+        :type msg: str
+        """
+        self.module.exit_json(
+            changed=changed,
+            msg=msg,
+            instance_data=self.get_instance_data()
+        )
 
 
 def main():
@@ -912,89 +910,78 @@ def main():
     global TRIES
     TRIES = int(module.params['poll_tries'])
 
-    # initialize connection
-    connection = connect(module)
-    initial_status = vm_status(module, connection)
+    ovirt = OvirtConnection(module)
+
+    initial_status = ovirt.vm_status()
 
     if state == 'present':
         if initial_status == "does_not_exist":
-            instantiate(module, connection)
+            ovirt.instantiate()
             if resource_type == 'template':
-                finish(
-                    module, connection,
+                ovirt.finish(
                     changed=True,
                     msg=u"deployed VM {} from template {}".format(instance_name, image),
                 )
             elif resource_type == 'new':
-                finish(
-                    module, connection,
+                ovirt.finish(
                     changed=True,
                     msg=u"deployed VM {} from scratch".format(instance_name),
                 )
         else:
-            finish(
-                module, connection,
+            ovirt.finish(
                 changed=False,
                 msg=u"VM {} already exists".format(instance_name),
             )
 
     if state == 'started':
-        if initial_status == 'up' and (not wait_for_ip or (wait_for_ip and get_ips(module, connection))):
-            finish(
-                module, connection,
+        if initial_status == 'up' and (not wait_for_ip or (wait_for_ip and ovirt.get_ips())):
+            ovirt.finish(
                 changed=False,
                 msg=u"VM {} is already running".format(instance_name),
             )
         else:
-            vm_start(module, connection)
-            finish(
-                module, connection,
+            ovirt.vm_start()
+            ovirt.finish(
                 changed=True,
                 msg=u"VM {0:s} started".format(instance_name),
             )
 
     if state == 'shutdown':
         if initial_status == 'down':
-            finish(
-                module, connection,
+            ovirt.finish(
                 changed=False,
                 msg=u"VM {0:s} is already shutdown".format(instance_name),
             )
         else:
-            vm_stop(module, connection)
-            finish(
-                module, connection,
+            ovirt.vm_stop()
+            ovirt.finish(
                 changed=True,
                 msg=u"VM {} is shutting down".format(instance_name),
             )
 
     if state == 'restart':
         if initial_status == 'up':
-            vm_restart(module, connection)
-            finish(
-                module, connection,
+            ovirt.vm_restart()
+            ovirt.finish(
                 changed=True,
                 msg=u"VM {0:s} is restarted".format(instance_name),
             )
         else:
-            vm_restart(module, connection)
-            finish(
-                module, connection,
+            ovirt.vm_restart()
+            ovirt.finish(
                 changed=True,
                 msg=u"VM {0:s} was started".format(instance_name),
             )
 
     if state == 'absent':
         if initial_status == 'does_not_exist':
-            finish(
-                module, connection,
+            ovirt.finish(
                 changed=False,
                 msg=u"VM {0:s} does not exist".format(instance_name),
             )
         else:
-            vm_remove(module, connection)
-            finish(
-                module, connection,
+            ovirt.vm_remove()
+            ovirt.finish(
                 changed=True,
                 msg=u"VM {0:s} removed".format(instance_name),
             )

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -295,10 +295,10 @@ def add_tags(conn, tags):
     :type conn: ovirtsdk.api.API
     """
     if tags:
-        new_tags = {tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')}
+        new_tags = set([tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')])
 
         try:
-            existing_tags = {tag.get_name() for tag in conn.tags.list()}
+            existing_tags = set([tag.get_name() for tag in conn.tags.list()])
         except Exception:
             print ("Could not get existing tags from server")
             sys.exit(1)

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -907,6 +907,7 @@ def main():
     instance_name = module.params['instance_name']
     image = module.params['image']
     resource_type = module.params['resource_type']
+    wait_for_ip = module.boolean(module.params['wait_for_ip'])
 
     global TRIES
     TRIES = int(module.params['poll_tries'])
@@ -938,7 +939,7 @@ def main():
             )
 
     if state == 'started':
-        if initial_status == 'up':
+        if initial_status == 'up' and (not wait_for_ip or (wait_for_ip and get_ips(module, connection))):
             finish(
                 module, connection,
                 changed=False,

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -61,11 +61,12 @@ options:
     default: null
     required: false
     choices: [ 'new', 'template' ]
-  zone:
+  cluster:
     description:
      - deploy the image to this oVirt cluster
     default: null
     required: false
+    aliases: [ zone ]
   instance_disksize:
     description:
      - size of the instance's disk in GB
@@ -142,7 +143,7 @@ options:
      - create, terminate or remove instances
     default: 'present'
     required: false
-    choices: ['present', 'absent', 'shutdown', 'started', 'restarted', 'cloud-init']
+    choices: ['present', 'absent', 'shutdown', 'started', 'restart', 'cloud-init']
   authorized_key_file:
     description:
      - absolute path to the public key to be inserted into authorized keys on instantiation
@@ -153,6 +154,12 @@ options:
     description:
      - insert user key into authorized keys on instantiation
     default: 'root'
+    required: false
+    version_added: "2.0"
+  authorized_key_user_groups:
+    description:
+     - Groups to associate to the user. comma separated list
+    default: null
     required: false
     version_added: "2.0"
   tag:
@@ -199,6 +206,30 @@ options:
     default: null
     required: false
     version_added: "2.0"
+  nic_name:
+    description:
+      - Name of the nic to apply a static ip address to
+    default: null
+    required: false
+    version_added: "2.0"
+  static_ip_address:
+    description:
+      - a static IP address to assign to the instance
+    default: null
+    required: false
+    version_added: "2.0"
+  static_netmask:
+    description:
+      - a static netmask address to assign to the instance
+    default: null
+    required: false
+    version_added: "2.0"
+  static_gateway:
+    description:
+      - a static gateway IP address to assign to the instance
+    default: null
+    required: false
+    version_added: "2.0"
 
 requirements:
   - "python >= 2.6"
@@ -208,33 +239,33 @@ EXAMPLES = '''
 # Basic example provisioning from image.
 
 action: ovirt >
-    user=admin@internal 
-    url=https://ovirt.example.com 
-    instance_name=ansiblevm04 
-    password=secret 
-    image=centos_64 
-    zone=cluster01 
+    user=admin@internal
+    url=https://ovirt.example.com
+    instance_name=ansiblevm04
+    password=secret
+    image=centos_64
+    cluster=cluster01
     resource_type=template"
 
 # Full example to create new instance from scratch
-action: ovirt > 
-    instance_name=testansible 
-    resource_type=new 
-    instance_type=server 
-    user=admin@internal 
-    password=secret 
-    url=https://ovirt.example.com 
-    instance_disksize=10 
-    zone=cluster01 
-    region=datacenter1 
-    instance_cpus=1 
-    instance_nic=nic1 
-    instance_network=rhevm 
-    instance_mem=1000 
-    disk_alloc=thin 
-    sdomain=FIBER01 
-    instance_cores=1 
-    instance_os=rhel_6x64 
+action: ovirt >
+    instance_name=testansible
+    resource_type=new
+    instance_type=server
+    user=admin@internal
+    password=secret
+    url=https://ovirt.example.com
+    instance_disksize=10
+    cluster=cluster01
+    region=datacenter1
+    instance_cpus=1
+    instance_nic=nic1
+    instance_network=rhevm
+    instance_mem=1000
+    disk_alloc=thin
+    sdomain=FIBER01
+    instance_cores=1
+    instance_os=rhel_6x64
     disk_int=virtio
     authorized_key_file=/home/user/.ssh/id_rsa.pub
     authorized_key_user=root
@@ -254,10 +285,10 @@ action: ovirt >
 
 # starting an instance
 action: ovirt >
-    instance_name=testansible 
-    state=started 
-    user=admin@internal 
-    password=secret 
+    instance_name=testansible
+    state=started
+    user=admin@internal
+    password=secret
     url=https://ovirt.example.com
 '''
 RETURN = '''
@@ -389,18 +420,26 @@ class OvirtConnection(object):
     """
     :type module: ansible.module_utils.basic.AnsibleModule
     :type conn: ovirtsdk.api.API
+    :type tries: int
+    :type cloud_init_started: bool
+    :type cloud_init_completed: bool
     """
 
     def __init__(self, module):
         self.module = module
         self.conn = None
         self.tries = int(module.params['poll_tries'])
-        self.cloud_init_run = False
+        self.cloud_init_started = False
+        self.cloud_init_completed = False
 
     def __enter__(self):
+        """
+        :rtype : OvirtConnection
+        """
         self.conn = self.connect()
         return self
 
+    # noinspection PyUnusedLocal,PyBroadException
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
             self.conn.disconnect()
@@ -420,7 +459,7 @@ class OvirtConnection(object):
             url = '{}/api'.format(url.strip().rstrip('/'))
 
         try:
-            api = API(url=url, username=user, password=password, insecure=True)
+            api = API(url=url, username=user, password=password, insecure=True, debug=False)
             api.test(throw_exception=True)
         except:
             self.module.fail_json(msg=u"Could not connect to server: {}".format(url))
@@ -428,6 +467,9 @@ class OvirtConnection(object):
             return api
 
     def _get_auth_key(self):
+        """
+        :rtype : str
+        """
         authorized_key_file = self.module.params['authorized_key_file']
 
         if authorized_key_file is not None:
@@ -445,21 +487,68 @@ class OvirtConnection(object):
                 )
 
     def _get_custom_script(self):
-        script_file = self.module.params['script_file']
+        """
+        :rtype : str
+        """
+        custom_script = self.module.params['custom_script']
 
-        if script_file is not None:
-            if os.path.isfile(script_file):
+        if custom_script is not None:
+            if os.path.isfile(custom_script):
                 try:
-                    with open(script_file, 'r') as f:
+                    with open(custom_script, 'r') as f:
                         return f.read()
                 except IOError:
                     self.module.fail_json(
-                        msg=u"Could not read the given custom script file at {}".format(script_file)
+                        msg=u"Could not read the given custom script file at {}".format(custom_script)
                     )
             else:
-                self.module.fail_json(
-                    msg=u"custom_script must be an absolute path to a file"
-                )
+                return custom_script
+
+    def _cloud_init_network(self):
+        """
+        :rtype: ovirtsdk.xml.params.NetworkConfiguration
+        """
+        nic_name = self.module.params['nic_name']
+        static_ip_address = self.module.params['static_ip_address']
+        static_netmask = self.module.params['static_netmask']
+        static_gateway = self.module.params['static_gateway']
+
+        if all([nic_name, static_ip_address, static_netmask, static_gateway]):
+            return params.NetworkConfiguration(
+                nics=params.Nics(nic=[
+                    params.NIC(
+                        name=nic_name,
+                        boot_protocol="STATIC",
+                        on_boot=True,
+                        network=params.Network(
+                            ip=params.IP(
+                                address=static_ip_address,
+                                netmask=static_netmask,
+                                gateway=static_gateway
+                            )
+                        )
+                    )
+                ])
+            )
+
+    def _cloud_init_user_groups(self):
+        user_groups = self.module.params['authorized_key_user_groups']
+        if user_groups is not None:
+            return params.Groups(
+                group=[params.Group(name=group.strip()) for group in user_groups.lower().strip().split(',')]
+            )
+
+    def _cloud_init_user(self):
+        authorized_key_user = self.module.params['authorized_key_user']
+        if authorized_key_user is not None:
+            return params.Users(
+                user=[
+                    params.User(
+                        user_name=authorized_key_user,
+                        groups=self._cloud_init_user_groups()
+                    )
+                ]
+            )
 
     def _generate_cloud_init(self):
         """
@@ -471,13 +560,18 @@ class OvirtConnection(object):
 
         script = self._get_custom_script()
         key = self._get_auth_key()
+        network = self._cloud_init_network()
 
-        cloud_init = params.CloudInit(
-            host=instance_host_name,
-            files=params.Files(
+        files = None
+        auth_key = None
+
+        if script is not None:
+            files = params.Files(
                 file=[params.File(name="/tmp/_vmcustomscript", content=script, type_="PLAINTEXT")]
-            ),
-            authorized_keys=params.AuthorizedKeys(
+            )
+
+        if key is not None:
+            auth_key = params.AuthorizedKeys(
                 authorized_key=[
                     params.AuthorizedKey(
                         user=params.User(user_name=authorized_key_user),
@@ -485,6 +579,14 @@ class OvirtConnection(object):
                     ),
                 ]
             )
+
+        cloud_init = params.CloudInit(
+            host=instance_host_name,
+            files=files,
+            authorized_keys=auth_key,
+            network_configuration=network,
+            regenerate_ssh_keys=True,
+            users=self._cloud_init_user()
         )
         return params.Initialization(cloud_init=cloud_init)
 
@@ -540,7 +642,7 @@ class OvirtConnection(object):
         Create a VM instance
         """
         instance_name = self.module.params['instance_name']
-        zone = self.module.params['zone']
+        cluster = self.module.params['cluster']
         instance_disksize = self.module.params['instance_disksize']
         instance_nic = self.module.params['instance_nic']
         instance_network = self.module.params['instance_network']
@@ -555,7 +657,7 @@ class OvirtConnection(object):
         if disk_alloc == 'thin':
             vmparams = params.VM(
                 name=instance_name,
-                cluster=self.conn.clusters.get(name=zone),
+                cluster=self.conn.clusters.get(name=cluster),
                 os=params.OperatingSystem(type_=instance_os),
                 template=self.conn.templates.get(name="Blank"),
                 memory=1024 * 1024 * int(instance_mem),
@@ -576,7 +678,7 @@ class OvirtConnection(object):
         elif disk_alloc == 'preallocated':
             vmparams = params.VM(
                 name=instance_name,
-                cluster=self.conn.clusters.get(name=zone),
+                cluster=self.conn.clusters.get(name=cluster),
                 os=params.OperatingSystem(type_=instance_os),
                 template=self.conn.templates.get(name="Blank"),
                 memory=1024 * 1024 * int(instance_mem),
@@ -620,12 +722,12 @@ class OvirtConnection(object):
         Create an instance from a template
         """
         instance_name = self.module.params['instance_name']
-        zone = self.module.params['zone']
+        cluster = self.module.params['cluster']
         image = self.module.params['image']
 
         vmparams = params.VM(
             name=instance_name,
-            cluster=self.conn.clusters.get(name=zone),
+            cluster=self.conn.clusters.get(name=cluster),
             template=self.conn.templates.get(name=image),
             disks=params.Disks(clone=True),
         )
@@ -655,7 +757,6 @@ class OvirtConnection(object):
     def get_ips(self):
         """
         get ip addresses from instance
-    
         :rtype: list[str]
         """
         instance_name = self.module.params['instance_name']
@@ -708,6 +809,9 @@ class OvirtConnection(object):
         }
 
     def vm_cloud_init(self):
+        """
+        :rtype : bool
+        """
         instance_name = self.module.params['instance_name']
         async = self.module.boolean(self.module.params['async'])
         wait_for_ip = self.module.boolean(self.module.params['wait_for_ip'])
@@ -727,16 +831,21 @@ class OvirtConnection(object):
             return self.recurse(self.vm_cloud_init)
         elif state == 'down':
             vm = self.conn.vms.get(name=instance_name)
-            vm.start(action=params.Action(params.VM(initialization=self.get_cloud_init())))
-            self.cloud_init_run = True
+            if not self.cloud_init_started:
+                vm.start(action=params.Action(vm=params.VM(initialization=self.get_cloud_init())))
+                self.cloud_init_started = True
+            else:
+                vm.start()
+                self.cloud_init_completed = True
             if not async:
                 return self.recurse(self.vm_cloud_init)
         elif state == 'up':
-            if not self.cloud_init_run:
+            if not self.cloud_init_started:
                 self.vm_stop()
                 self.recurse(self.vm_cloud_init)
+            elif not self.cloud_init_completed:
+                self.recurse(self.vm_cloud_init)
             else:
-                self.cloud_init_run = False
                 if wait_for_ip:
                     ips = self.get_ips()
                     if not ips:
@@ -745,6 +854,7 @@ class OvirtConnection(object):
     def vm_start(self):
         """
         start instance
+        :rtype : bool
         """
         instance_name = self.module.params['instance_name']
         async = self.module.boolean(self.module.params['async'])
@@ -777,6 +887,7 @@ class OvirtConnection(object):
     def vm_stop(self):
         """
         Stop instance
+        :rtype : bool
         """
         instance_name = self.module.params['instance_name']
         async = self.module.boolean(self.module.params['async'])
@@ -805,6 +916,7 @@ class OvirtConnection(object):
     def vm_restart(self):
         """
         restart instance
+        :rtype : bool
         """
         stopped = self.vm_stop()
         started = self.vm_start()
@@ -813,7 +925,7 @@ class OvirtConnection(object):
     def vm_remove(self):
         """
         remove an instance
-    
+        :rtype : bool
         """
         instance_name = self.module.params['instance_name']
         async = self.module.boolean(self.module.params['async'])
@@ -842,6 +954,7 @@ class OvirtConnection(object):
     def vm_status(self):
         """
         Get the VMs status
+        :rtype : bool
         """
         instance_name = self.module.params['instance_name']
 
@@ -854,6 +967,7 @@ class OvirtConnection(object):
     def get_vm(self):
         """
         Get VM object and return it's name if object exists
+        :rtype : str
         """
         instance_name = self.module.params['instance_name']
         vm = self.conn.vms.get(name=instance_name)
@@ -905,8 +1019,9 @@ def main():
                 type='str',
                 choices=['new', 'template']
             ),
-            zone=dict(
+            cluster=dict(
                 type='str',
+                aliases=['zone']
             ),
             instance_disksize=dict(
                 type='str',
@@ -996,6 +1111,22 @@ def main():
             instance_host_name=dict(
                 type='str',
                 default=None,
+            ),
+            nic_name=dict(
+                type='str',
+                default=None
+            ),
+            static_ip_address=dict(
+                type='str',
+                default=None
+            ),
+            static_netmask=dict(
+                type='str',
+                default=None
+            ),
+            static_gateway=dict(
+                type='str',
+                default=None
             ),
         ),
     )

--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 
 # (c) 2013, Vincent Van der Kussen <vincent at vanderkussen.org>
 #
@@ -47,6 +47,7 @@ options:
      - password of the user to authenticate with
     default: null
     required: true
+    no_log: true
   image:
     description:
      - template to use for the instance
@@ -140,15 +141,15 @@ options:
     default: 'present'
     required: false
     choices: ['present', 'absent', 'shutdown', 'started', 'restarted']
-  authorised_key_file:
+  authorized_key_file:
     description:
-     - absolute path to the public key to be inserted into authorised keys on instantiation
+     - absolute path to the public key to be inserted into authorized keys on instantiation
     default: null
     required: false
     version_added: "2.0"
-  authorised_key_user:
+  authorized_key_user:
     description:
-     - insert user key into authorised keys on instantiation
+     - insert user key into authorized keys on instantiation
     default: 'root'
     required: false
     version_added: "2.0"
@@ -156,6 +157,30 @@ options:
     description:
      - comma separated list of tags
     default: null
+    required: false
+    version_added: "2.0"
+  async:
+    description:
+     - If True, just send command to server. If false, wait for the correct state before continuing (Idempotent)
+    default: False
+    required: false
+    version_added: "2.0"
+  poll_frequency:
+    description:
+     - If not async, this sets the poll_frequency (in seconds) at which to poll for the state of the VM
+    default: 5
+    required: false
+    version_added: "2.0"
+  poll_tries:
+    description:
+     - If not async, this specifies the maximum number of times to poll before exiting
+    default: 100
+    required: false
+    version_added: "2.0"
+  wait_for_ip:
+    description:
+     - If not async, wait for the VM to provide its IP addresses before continuing (requires that VM image has "ovirt guest agent" installed)
+    default: False
     required: false
     version_added: "2.0"
 
@@ -195,9 +220,13 @@ action: ovirt >
     instance_cores=1 
     instance_os=rhel_6x64 
     disk_int=virtio
-    authorised_key_file=/home/user/.ssh/id_rsa.pub
-    authorised_key_user=root
+    authorized_key_file=/home/user/.ssh/id_rsa.pub
+    authorized_key_user=root
     tags=test,ansible,jenkins
+    async=False
+    poll_frequency=5
+    poll_tries=100
+    wait_for_ip=True
 
 # stopping an instance
 action: ovirt >
@@ -217,30 +246,62 @@ action: ovirt >
 
 
 '''
-import sys
-
 try:
+    # noinspection PyUnresolvedReferences
     from ovirtsdk.api import API
+    # noinspection PyUnresolvedReferences
     from ovirtsdk.xml import params
+
+    HAS_LIB = True
 except ImportError:
-    print "failed=True msg='ovirtsdk required for this module'"
-    sys.exit(1)
+    HAS_LIB = False
+
+OVIRT_STATE_MAP = dict(
+    unassigned='unknown',
+    down='down',
+    up='up',
+    powering_up='starting',
+    paused='down',
+    migrating_from='creating',
+    migrating_to='creating',
+    unknown='unknown',
+    not_responding='unknown',
+    wait_for_launch='starting',
+    reboot_in_progress='starting',
+    saving_state='stopping',
+    restoring_state='starting',
+    suspended='down',
+    image_illegal='unknown',
+    image_locked='creating',
+    powering_down='stopping',
+)
+
+TRIES = 0
 
 # ------------------------------------------------------------------- #
 # create connection with API
 #
-def conn(url, user, password):
-    api = API(url=url, username=user, password=password, insecure=True)
+def connect(module):
+    """
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :rtype: ovirtsdk.api.API
+    """
+    user = module.params['user']
+    url = module.params['url']
+    password = module.params['password']
+
+    if not url.endswith('api'):
+        url = '{}/api'.format(url.strip().rstrip('/'))
+
     try:
-        value = api.test()
+        api = API(url=url, username=user, password=password, insecure=True)
+        api.test()
     except:
-        print "error connecting to the oVirt API"
-        sys.exit(1)
-    return api
+        module.fail_json(msg=u"Could not connect to server: {}".format(url))
+    else:
+        return api
 
-# ------------------------------------------------------------------- #
-# create connection with API
-#
+
 def add_auth_key(key, user='root'):
     """
     :type key: str
@@ -260,37 +321,46 @@ def add_auth_key(key, user='root'):
     return params.Initialization(cloud_init=cloud_init)
 
 
-def get_cloud_init(auth_key, auth_key_user):
+def get_cloud_init(module):
+    """
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :rtype: ovirtsdk.xml.params.Initialization
+    """
+    authorized_key_file = module.params['authorized_key_file']
+    authorized_key_user = module.params['authorized_key_user']
+
     cloud_init = None
-    if auth_key:
-        if os.path.isfile(auth_key):
+    if authorized_key_file:
+        if os.path.isfile(authorized_key_file):
             try:
-                with open(auth_key, 'r') as f:
+                with open(authorized_key_file, 'r') as f:
                     key = f.read()
             except IOError:
-                print("Could not read the given auth_key at {}".format(auth_key))
-                sys.exit(1)
+                module.fail_json(msg=u"Could not read the given authorized_key_file at {}".format(authorized_key_file))
             else:
-                cloud_init = add_auth_key(key, auth_key_user)
+                cloud_init = add_auth_key(key, authorized_key_user)
         else:
-            print("The provided auth_key is not a file. Please specify the absolute path to the .pub key file")
-            sys.exit(1)
+            module.fail_json(
+                msg=(u"The provided authorized_key_file is not a file. "
+                     u"Please specify the absolute path to the .pub key file")
+            )
     return cloud_init
 
 
-def add_tags(conn, tags):
+def add_tags(module, conn):
     """
-
+    :type module: ansible.module_utils.basic.AnsibleModule
     :type conn: ovirtsdk.api.API
     """
+    tags = module.params['tags']
+
     if tags:
         new_tags = set([tag.strip().lower() for tag in tags.strip().replace(" ", "_").split(',')])
 
         try:
             existing_tags = set([tag.get_name() for tag in conn.tags.list()])
         except Exception:
-            print ("Could not get existing tags from server")
-            sys.exit(1)
+            module.fail_json(msg=u"Could not get existing tags from server")
         else:
             tags_to_add = []
             for tag in new_tags:
@@ -300,260 +370,532 @@ def add_tags(conn, tags):
                     try:
                         tags_to_add.append(conn.tags.add(params.Tag(name=tag)))
                     except:
-                        print("Failed to add tag to ovirt")
-                        sys.exit(1)
+                        module.fail_json(msg=u"Failed to add tag to ovirt")
             return params.Tags(tag=tags_to_add)
 
 
-# ------------------------------------------------------------------- #
-# Create VM from scratch
-def create_vm(conn, vmtype, vmname, zone, vmdisk_size, vmcpus, vmnic, vmnetwork, vmmem, vmdisk_alloc, sdomain, vmcores, vmos, vmdisk_int, auth_key, auth_key_user, tags):
-    if vmdisk_alloc == 'thin':
-        # define VM params
-        vmparams = params.VM(
-            name=vmname,
-            cluster=conn.clusters.get(name=zone),
-            os=params.OperatingSystem(type_=vmos),
-            template=conn.templates.get(name="Blank"),
-            memory=1024 * 1024 * int(vmmem),
-            cpu=params.CPU(topology=params.CpuTopology(cores=int(vmcores))),
-            type_=vmtype,
-            initialization=get_cloud_init(auth_key, auth_key_user),
-            tags=add_tags(conn, tags)
-        )
+def recurse(module, conn, func):
+    """
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    :type func: (ansible.module_utils.basic.AnsibleModule, ovirtsdk.api.API) -> bool
+    """
+    global TRIES
+    poll_frequency = float(module.params['poll_frequency'])
 
-        # define disk params
+    time.sleep(poll_frequency)
+    TRIES -= 1
+    return func(module, conn)
+
+
+# noinspection PyUnboundLocalVariable,PyBroadException
+def create_vm(module, conn):
+    """
+    Create a VM instance
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+
+    instance_name = module.params['instance_name']
+    zone = module.params['zone']
+    instance_disksize = module.params['instance_disksize']
+    instance_nic = module.params['instance_nic']
+    instance_network = module.params['instance_network']
+    instance_mem = module.params['instance_mem']
+    disk_alloc = module.params['disk_alloc']
+    disk_int = module.params['disk_int']
+    instance_os = module.params['instance_os']
+    instance_type = module.params['instance_type']
+    instance_cores = module.params['instance_cores']
+    sdomain = module.params['sdomain']
+
+    if disk_alloc == 'thin':
+        vmparams = params.VM(
+            name=instance_name,
+            cluster=conn.clusters.get(name=zone),
+            os=params.OperatingSystem(type_=instance_os),
+            template=conn.templates.get(name="Blank"),
+            memory=1024 * 1024 * int(instance_mem),
+            cpu=params.CPU(topology=params.CpuTopology(cores=int(instance_cores))),
+            type_=instance_type,
+            initialization=get_cloud_init(module),
+            tags=add_tags(module, conn)
+        )
         vmdisk = params.Disk(
-            size=1024 * 1024 * 1024 * int(vmdisk_size),
+            size=1024 * 1024 * 1024 * int(instance_disksize),
             wipe_after_delete=True,
             sparse=True,
-            interface=vmdisk_int,
+            interface=disk_int,
             type_="System",
             format='cow',
             storage_domains=params.StorageDomains(storage_domain=[conn.storagedomains.get(name=sdomain)]),
         )
-        # define network parameters
-        network_net = params.Network(name=vmnetwork)
+        network_net = params.Network(name=instance_network)
         nic_net1 = params.NIC(name='nic1', network=network_net, interface='virtio')
-    elif vmdisk_alloc == 'preallocated':
-        # define VM params
+    elif disk_alloc == 'preallocated':
         vmparams = params.VM(
-            name=vmname,
+            name=instance_name,
             cluster=conn.clusters.get(name=zone),
-            os=params.OperatingSystem(type_=vmos),
+            os=params.OperatingSystem(type_=instance_os),
             template=conn.templates.get(name="Blank"),
-            memory=1024 * 1024 * int(vmmem),
-            cpu=params.CPU(topology=params.CpuTopology(cores=int(vmcores))),
-            type_=vmtype,
-            initialization=get_cloud_init(auth_key, auth_key_user),
-            tags=add_tags(conn, tags)
+            memory=1024 * 1024 * int(instance_mem),
+            cpu=params.CPU(topology=params.CpuTopology(cores=int(instance_cores))),
+            type_=instance_type,
+            initialization=get_cloud_init(module),
+            tags=add_tags(module, conn)
         )
-
-        # define disk params
-        vmdisk= params.Disk(
-            size=1024 * 1024 * 1024 * int(vmdisk_size),
+        vmdisk = params.Disk(
+            size=1024 * 1024 * 1024 * int(instance_disksize),
             wipe_after_delete=True,
             sparse=False,
-            interface=vmdisk_int,
+            interface=disk_int,
             type_="System",
             format='raw',
             storage_domains=params.StorageDomains(storage_domain=[conn.storagedomains.get(name=sdomain)])
         )
-
-        # define network parameters
-        network_net = params.Network(name=vmnetwork)
-        nic_net1 = params.NIC(name=vmnic, network=network_net, interface='virtio')
+        network_net = params.Network(name=instance_network)
+        nic_net1 = params.NIC(name=instance_nic, network=network_net, interface='virtio')
     else:
-        print("Invalid value for 'vmdisk_alloc': {}".format(vmdisk_alloc))
-        sys.exit(1)
-        
+        module.fail_json(msg=u"Invalid value for 'disk_alloc': {}".format(disk_alloc))
+
     try:
         conn.vms.add(vmparams)
     except:
-        print "Error creating VM with specified parameters"
-        sys.exit(1)
-    vm = conn.vms.get(name=vmname)
+        module.fail_json(msg=u"Error creating VM with specified parameters")
+    vm = conn.vms.get(name=instance_name)
     try:
         vm.disks.add(vmdisk)
     except:
-        print "Error attaching disk"
+        vm_remove(module, conn)
+        module.fail_json(msg=u"Error attaching disk")
     try:
         vm.nics.add(nic_net1)
     except:
-        print "Error adding nic"
+        vm_remove(module, conn)
+        module.fail_json(msg=u"Error adding nic")
 
 
-# create an instance from a template
-def create_vm_template(conn, vmname, image, zone, auth_key, auth_key_user, tags):
+def create_vm_template(module, conn):
+    """
+    Create an instance from a template
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    instance_name = module.params['instance_name']
+    zone = module.params['zone']
+    image = module.params['image']
+
     vmparams = params.VM(
-        name=vmname,
+        name=instance_name,
         cluster=conn.clusters.get(name=zone),
         template=conn.templates.get(name=image),
         disks=params.Disks(clone=True),
-        initialization=get_cloud_init(auth_key, auth_key_user),
-        tags=add_tags(conn, tags)
+        initialization=get_cloud_init(module),
+        tags=add_tags(module, conn)
     )
+    conn.vms.add(vmparams)
+
+
+def get_ips(module, conn):
+    """
+    get ip addresses from instance
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    :rtype: list[str]
+    """
+    instance_name = module.params['instance_name']
+
     try:
-        conn.vms.add(vmparams)
-    except:
-        print 'error adding template %s' % image
-        sys.exit(1)
+        ips = [ip.get_address() for ip in conn.vms.get(name=instance_name).get_guest_info().get_ips().get_ip()]
+    except AttributeError:
+        ips = []
+    return ips
 
 
-# start instance
-def vm_start(conn, vmname):
-    vm = conn.vms.get(name=vmname)
-    vm.start()
 
-# Stop instance
-def vm_stop(conn, vmname):
-    vm = conn.vms.get(name=vmname)
-    vm.stop()
+def vm_start(module, conn):
+    """
+    start instance
 
-# restart instance
-def vm_restart(conn, vmname):
-    state = vm_status(conn, vmname)
-    vm = conn.vms.get(name=vmname)
-    vm.stop()
-    while conn.vms.get(vmname).get_status().get_state() != 'down':
-        time.sleep(5)
-    vm.start()
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    global TRIES
+    instance_name = module.params['instance_name']
+    async = module.boolean(module.params['async'])
+    wait_for_ip = module.boolean(module.params['wait_for_ip'])
 
-# remove an instance
-def vm_remove(conn, vmname):
-    vm = conn.vms.get(name=vmname)
-    vm.delete()
+    state = vm_status(module, conn)
 
-# ------------------------------------------------------------------- #
-# VM statuses
-#
-# Get the VMs status
-def vm_status(conn, vmname):
-    status = conn.vms.get(name=vmname).status.state
-    print "vm status is : %s" % status
+    if TRIES <= 0:
+        module.fail_json(msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state))
+    if state == 'does_not_exist':
+        module.fail_json(msg=u"Cannot stop {} as it does not appear to exist on the server".format(instance_name))
+    elif state == 'unknown':
+        module.fail_json(msg=u"{} is in an unknown state.".format(instance_name))
+    elif state in ['creating', 'starting', 'stopping']:
+        return recurse(module, conn, vm_start)
+    elif state == 'down':
+        vm = conn.vms.get(name=instance_name)
+        vm.start()
+        if not async:
+            return recurse(module, conn, vm_start)
+    elif state == 'up':
+        if wait_for_ip:
+            ips = get_ips(module, conn)
+            if not ips:
+                return recurse(module, conn, vm_start)
+
+
+def vm_stop(module, conn):
+    """
+    Stop instance
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    global TRIES
+    instance_name = module.params['instance_name']
+    async = module.boolean(module.params['async'])
+
+    vm = conn.vms.get(name=instance_name)
+    state = vm_status(module, conn)
+
+    if TRIES <= 0:
+        module.fail_json(msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state))
+    if state == 'does_not_exist':
+        module.fail_json(msg=u"Cannot stop {} as it does not appear to exist on the server".format(instance_name))
+    elif state == 'unknown':
+        module.fail_json(msg=u"{} is in an unknown state.".format(instance_name))
+    elif state in ['creating', 'starting', 'stopping']:
+        return recurse(module, conn, vm_stop)
+    elif state == 'up':
+        vm.stop()
+        if not async:
+            return recurse(module, conn, vm_stop)
+    elif state == 'down':
+        return True
+
+
+
+def vm_restart(module, conn):
+    """
+    restart instance
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    stopped = vm_stop(module, conn)
+    started = vm_start(module, conn)
+    return stopped and started
+
+
+def vm_remove(module, conn):
+    """
+    remove an instance
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    global TRIES
+    instance_name = module.params['instance_name']
+    async = module.boolean(module.params['async'])
+
+    vm = conn.vms.get(name=instance_name)
+    state = vm_status(module, conn)
+
+    if TRIES <= 0:
+        module.fail_json(msg=u"Ran out of poll_tries. {} is currently in state: '{}'".format(instance_name, state))
+    if state == 'does_not_exist':
+        return True
+    elif state == 'unknown':
+        vm.delete()
+        return True if async else recurse(module, conn, vm_remove)
+    elif state in ['creating', 'starting', 'stopping']:
+        return recurse(module, conn, vm_remove)
+    elif state == 'up':
+        vm_stop(module, conn)
+        return recurse(module, conn, vm_remove)
+    elif state == 'down':
+        vm.delete()
+        return True if async else recurse(module, conn, vm_remove)
+
+
+def vm_status(module, conn):
+    """
+    Get the VMs status
+
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    instance_name = module.params['instance_name']
+
+    if instance_name not in set([vm.get_name() for vm in conn.vms.list()]):
+        status = 'does_not_exist'
+    else:
+        status = OVIRT_STATE_MAP.get(conn.vms.get(name=instance_name).get_status().get_state(), 'unknown')
     return status
 
 
-# Get VM object and return it's name if object exists
-def get_vm(conn, vmname):
-    vm = conn.vms.get(name=vmname)
-    if vm == None:
-        name = "empty"
-        print "vmname: %s" % name
-    else:
-        name = vm.get_name()
-        print "vmname: %s" % name
-    return name
+def get_vm(module, conn):
+    """
+    Get VM object and return it's name if object exists
 
-# ------------------------------------------------------------------- #
-# Hypervisor operations
-#
-# not available yet
-# ------------------------------------------------------------------- #
-# Main
+    :type module: ansible.module_utils.basic.AnsibleModule
+    :type conn: ovirtsdk.api.API
+    """
+    instance_name = module.params['instance_name']
+    vm = conn.vms.get(name=instance_name)
+
+    return "empty" if vm is None else vm.get_name()
+
 
 def main():
-
     module = AnsibleModule(
-        argument_spec = dict(
-            state               = dict(default='present', choices=['present', 'absent', 'shutdown', 'started', 'restart']),
-            user                = dict(required=True),
-            url                 = dict(required=True),
-            instance_name       = dict(required=True, aliases=['vmname']),
-            password            = dict(required=True),
-            image               = dict(),
-            resource_type       = dict(choices=['new', 'template']),
-            zone                = dict(),
-            instance_disksize   = dict(aliases=['vm_disksize']),
-            instance_cpus       = dict(default=1, aliases=['vmcpus']),
-            instance_nic        = dict(aliases=['vmnic']),
-            instance_network    = dict(default='rhevm', aliases=['vmnetwork']),
-            instance_mem        = dict(aliases=['vmmem']),
-            instance_type       = dict(default='server', aliases=['vmtype'], choices=['server', 'desktop']),
-            disk_alloc          = dict(default='thin', choices=['thin', 'preallocated']),
-            disk_int            = dict(default='virtio', choices=['virtio', 'ide']),
-            instance_os         = dict(aliases=['vmos']),
-            instance_cores      = dict(default=1, aliases=['vmcores']),
-            sdomain             = dict(),
-            region              = dict(),
-            authorised_key_file = dict(),
-            authorised_key_user = dict(default='root'),
-            tags                = dict()
+        argument_spec=dict(
+            state=dict(
+                type='str',
+                default='present',
+                choices=['present', 'absent', 'shutdown', 'started', 'restart']
+            ),
+            user=dict(
+                type='str',
+                required=True
+            ),
+            url=dict(
+                type='str',
+                required=True
+            ),
+            instance_name=dict(
+                type='str',
+                required=True,
+                aliases=['instance_name']
+            ),
+            password=dict(
+                type='str',
+                required=True,
+                no_log=True
+            ),
+            image=dict(
+                type='str',
+            ),
+            resource_type=dict(
+                type='str',
+                choices=['new', 'template']
+            ),
+            zone=dict(
+                type='str',
+            ),
+            instance_disksize=dict(
+                type='str',
+                aliases=['vm_disksize']
+            ),
+            instance_cpus=dict(
+                type='str',
+                default=1,
+                aliases=['instance_cpus']
+            ),
+            instance_nic=dict(
+                type='str',
+                aliases=['instance_nic']
+            ),
+            instance_network=dict(
+                type='str',
+                default='rhevm',
+                aliases=['instance_network']
+            ),
+            instance_mem=dict(
+                type='str',
+                aliases=['instance_mem']
+            ),
+            instance_type=dict(
+                type='str',
+                default='server',
+                aliases=['instance_type'],
+                choices=['server', 'desktop']
+            ),
+            disk_alloc=dict(
+                type='str',
+                default='thin',
+                choices=['thin', 'preallocated']
+            ),
+            disk_int=dict(
+                type='str',
+                default='virtio',
+                choices=['virtio', 'ide']
+            ),
+            instance_os=dict(
+                type='str',
+                aliases=['instance_os']
+            ),
+            instance_cores=dict(
+                type='str',
+                default=1,
+                aliases=['instance_cores']
+            ),
+            sdomain=dict(
+                type='str',
+            ),
+            region=dict(
+                type='str',
+            ),
+            authorized_key_file=dict(
+                type='str',
+            ),
+            authorized_key_user=dict(
+                type='str',
+                default='root'
+            ),
+            tags=dict(
+                type='str',
+            ),
+            async=dict(
+                type='bool',
+                default=True,
+                choices=BOOLEANS
+            ),
+            poll_frequency=dict(
+                type='float',
+                default=5.0
+            ),
+            poll_tries=dict(
+                type='int',
+                default=100
+            ),
+            wait_for_ip=dict(
+                type='bool',
+                default=False,
+                choices=BOOLEANS
+            ),
         ),
     )
 
-    state         = module.params['state']
-    user          = module.params['user']
-    url           = module.params['url']
-    vmname        = module.params['instance_name']
-    password      = module.params['password']
-    image         = module.params['image']               # name of the image to deploy
-    resource_type = module.params['resource_type']       # template or from scratch
-    zone          = module.params['zone']                # oVirt cluster
-    vmdisk_size   = module.params['instance_disksize']   # disksize
-    vmcpus        = module.params['instance_cpus']       # number of cpu
-    vmnic         = module.params['instance_nic']        # network interface
-    vmnetwork     = module.params['instance_network']    # logical network
-    vmmem         = module.params['instance_mem']        # mem size
-    vmdisk_alloc  = module.params['disk_alloc']          # thin, preallocated
-    vmdisk_int    = module.params['disk_int']            # disk interface virtio or ide
-    vmos          = module.params['instance_os']         # Operating System
-    vmtype        = module.params['instance_type']       # server or desktop
-    vmcores       = module.params['instance_cores']      # number of cores
-    sdomain       = module.params['sdomain']             # storage domain to store disk on
-    region        = module.params['region']              # oVirt Datacenter
-    auth_key_file = module.params['authorised_key_file'] # Instantiate with given pubkey in authorised hosts
-    auth_key_user = module.params['authorised_key_user'] # user account associated with the auth_key
-    tags          = module.params['tags']                # tags to be associated with the VM
+    if not HAS_LIB:
+        module.fail_json(msg=u'ovirtsdk required for this module')
 
-    #initialize connection
-    c = conn(url+"/api", user, password)
+    state = module.params['state']
+    instance_name = module.params['instance_name']
+    image = module.params['image']
+    resource_type = module.params['resource_type']
 
-    if state == 'present':
-        if get_vm(c, vmname) == "empty":
+    global TRIES
+    TRIES = int(module.params['poll_tries'])
+
+    # initialize connection
+    try:
+        connection = connect(module)
+    except:
+        module.fail_json(msg=u"error connecting to the oVirt API")
+    else:
+        initial_status = vm_status(module, connection)
+
+        def instantiate():
             if resource_type == 'template':
-                create_vm_template(c, vmname, image, zone, auth_key_file, auth_key_user, tags)
-                module.exit_json(changed=True, msg="deployed VM %s from template %s"  % (vmname,image))
+                try:
+                    create_vm_template(module, connection)
+                except:
+                    module.fail_json(msg=u'error adding template {}'.format(image))
             elif resource_type == 'new':
-                # FIXME: refactor, use keyword args.
-                create_vm(c, vmtype, vmname, zone, vmdisk_size, vmcpus, vmnic, vmnetwork, vmmem, vmdisk_alloc, sdomain, vmcores, vmos, vmdisk_int, auth_key_file, auth_key_user, tags)
-                module.exit_json(changed=True, msg="deployed VM %s from scratch"  % vmname)
+                try:
+                    create_vm(module, connection)
+                except:
+                    module.fail_json(u"Failed to create VM: {}".format(instance_name))
             else:
-                module.exit_json(changed=False, msg="You did not specify a resource type")
-        else:
-            module.exit_json(changed=False, msg="VM %s already exists" % vmname)
+                module.fail_json(msg=u"You did not specify a resource type")
 
-    if state == 'started':
-        if vm_status(c, vmname) == 'up':
-            module.exit_json(changed=False, msg="VM %s is already running" % vmname)
-        else:
-            vm_start(c, vmname)
-            module.exit_json(changed=True, msg="VM %s started" % vmname)
+        if state == 'present':
+            if initial_status == "does_not_exist":
+                instantiate()
+                if resource_type == 'template':
+                    module.exit_json(
+                        changed=True,
+                        msg=u"deployed VM {} from template {}".format(instance_name, image),
+                        ips=get_ips(module, connection)
+                    )
+                elif resource_type == 'new':
+                    module.exit_json(
+                        changed=True,
+                        msg=u"deployed VM {} from scratch".format(instance_name),
+                        ips=get_ips(module, connection)
+                    )
+            else:
+                module.exit_json(
+                    changed=False,
+                    msg=u"VM {} already exists".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
 
-    if state == 'shutdown':
-        if vm_status(c, vmname) == 'down':
-            module.exit_json(changed=False, msg="VM %s is already shutdown" % vmname)
-        else:
-            vm_stop(c, vmname)
-            module.exit_json(changed=True, msg="VM %s is shutting down" % vmname)
-    
-    if state == 'restart':
-        if vm_status(c, vmname) == 'up':
-            vm_restart(c, vmname)
-            module.exit_json(changed=True, msg="VM %s is restarted" % vmname)
-        else:
-            module.exit_json(changed=False, msg="VM %s is not running" % vmname)
+        if state == 'started':
+            if initial_status == 'up':
+                module.exit_json(
+                    changed=False,
+                    msg=u"VM {} is already running".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
+            else:
+                if initial_status == 'does_not_exist':
+                    instantiate()
+                vm_start(module, connection)
+                module.exit_json(
+                    changed=True,
+                    msg=u"VM {0:s} started".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
 
-    if state == 'absent':
-        if get_vm(c, vmname) == "empty":
-            module.exit_json(changed=False, msg="VM %s does not exist" % vmname)
-        else:
-            vm_remove(c, vmname)
-            module.exit_json(changed=True, msg="VM %s removed" % vmname)
+        if state == 'shutdown':
+            if initial_status == 'down':
+                module.exit_json(
+                    changed=False,
+                    msg=u"VM {0:s} is already shutdown".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
+            else:
+                if initial_status == 'does_not_exist':
+                    instantiate()
+                vm_stop(module, connection)
+                module.exit_json(
+                    changed=True,
+                    msg=u"VM {} is shutting down".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
 
+        if state == 'restart':
+            if initial_status == 'up':
+                vm_restart(module, connection)
+                module.exit_json(
+                    changed=True,
+                    msg=u"VM {0:s} is restarted".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
+            else:
+                if initial_status == 'does_not_exist':
+                    instantiate()
+                vm_restart(module, connection)
+                module.exit_json(
+                    changed=True,
+                    msg=u"VM {0:s} was started".format(instance_name),
+                    ips=get_ips(module, connection)
+                )
 
-
+        if state == 'absent':
+            if initial_status == 'does_not_exist':
+                module.exit_json(
+                    changed=False,
+                    msg=u"VM {0:s} does not exist".format(instance_name),
+                    ips=[]
+                )
+            else:
+                vm_remove(module, connection)
+                module.exit_json(
+                    changed=True,
+                    msg=u"VM {0:s} removed".format(instance_name),
+                    ips=[]
+                )
 
 # import module snippets
 from ansible.module_utils.basic import *
+
 main()


### PR DESCRIPTION
- The ovirt module can now be idempotent (using `async=no`)
- Removed all `sys.exit` calls and replaced with `fail_json`
- Removed all `print` statements
- Returns instance ip if it is available
- Builds on #583 
