### PR TITLE
cloudstack: fix CloudStackException in cs_project 

### DIFF
--- a/cloud/cloudstack/cs_project.py
+++ b/cloud/cloudstack/cs_project.py
@@ -167,7 +167,7 @@ class AnsibleCloudStackProject(AnsibleCloudStack):
             projects = self.cs.listProjects(**args)
             if projects:
                 for p in projects['project']:
-                    if project in [ p['name'], p['id']]:
+                    if project.lower() in [ p['name'].lower(), p['id']]:
                         self.project = p
                         break
         return self.project

--- a/cloud/cloudstack/cs_project.py
+++ b/cloud/cloudstack/cs_project.py
@@ -160,7 +160,6 @@ class AnsibleCloudStackProject(AnsibleCloudStack):
             project = self.module.params.get('name')
 
             args                = {}
-            args['listall']     = True
             args['account']     = self.get_account(key='name')
             args['domainid']    = self.get_domain(key='id')
 


### PR DESCRIPTION
fixes:

```
../ansible/hacking/test-module -m cloud/cloudstack/cs_project.py -a "name=stxt_test"
* including generated source, if any, saving to: /home/resmo/.ansible_module_generated
* this may offset any line numbers in tracebacks/debuggers!
***********************************
RAW OUTPUT
{"msg": "CloudStackException: ('HTTP 431 response from CloudStack', <Response [431]>, {u'errorcode': 431, u'uuidList': [], u'cserrorcode': 4350, u'errortext': u'Project with name stxt_test already exists in domain id=1'})", "failed": true}


***********************************
PARSED OUTPUT
{
    "failed": true,
    "msg": "CloudStackException: ('HTTP 431 response from CloudStack', <Response [431]>, {u'errorcode': 431, u'uuidList': [], u'cserrorcode': 4350, u'errortext': u'Project with name stxt_test already exists in domain id=1'})"
}

```
