### PR TITLE
portal ipv6 address must be escaped with brackets on target discovery

### DIFF
--- a/system/open_iscsi.py
+++ b/system/open_iscsi.py
@@ -148,6 +148,9 @@ def iscsi_get_cached_nodes(module, portal=None):
 
 def iscsi_discover(module, portal, port):
 
+    if ':' in portal:
+        portal = '[%s]' % portal
+
     cmd = '%s --mode discovery --type sendtargets --portal %s:%s' % (iscsiadm_cmd, portal, port)
     (rc, out, err) = module.run_command(cmd)
 


### PR DESCRIPTION
if port is passed to iscsiadmin command ipv6 portals must be escaped '[::1]:3260'.

example:
sudo iscsiadm -m discovery -t sendtargets -p ::1:3260
iscsiadm: cannot make connection to ::0.1.50.96: Network is unreachable
