### PR TITLE
Fix the lxc container restart state

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -1065,6 +1065,9 @@ class LxcContainerManagement(object):
                 self.container.stop()
                 self.state_change = True
 
+            # Run container startup
+            self._container_startup()
+
             # Check if the container needs to have an archive created.
             self._check_archive()
 


### PR DESCRIPTION
The lxc container restart state does not ensure that the container
is in fact started unless another config or command is passed into
the task. to fix this the module simply needs to have the function
call added `self._container_startup()` after the container is
put into a stopped state.

Signed-off By: Kevin Carter kevin.carter@rackspace.com
