### PR TITLE
Fix TravisCI failure for system/osx_defaults.py on python 2.4

### DIFF
--- a/system/osx_defaults.py
+++ b/system/osx_defaults.py
@@ -343,7 +343,7 @@ def main():
                                array_add=array_add, value=value, state=state, path=path)
         changed = defaults.run()
         module.exit_json(changed=changed)
-    except OSXDefaultsException as e:
+    except OSXDefaultsException, e:
         module.fail_json(msg=e.message)
 
 # /main ------------------------------------------------------------------- }}}

--- a/system/osx_defaults.py
+++ b/system/osx_defaults.py
@@ -209,7 +209,10 @@ class OSXDefaults(object):
 
         # We need to convert some values so the defaults commandline understands it
         if type(self.value) is bool:
-            value = "TRUE" if self.value else "FALSE"
+            if self.value:
+                value = "TRUE"
+            else:
+                value = "FALSE"
         elif type(self.value) is int or type(self.value) is float:
             value = str(self.value)
         elif self.array_add and self.current_value is not None:


### PR DESCRIPTION
Previous commit failed TravisCI checks because of this issue.

You cannot use ternary expressions (x if C else y) in python 2.4.
https://www.python.org/dev/peps/pep-0308/

And another issue is related to using 'except Exception as e'.

Now Travis continues happily on python 2.4
