### PR TITLE
Spurious newline could corrupt payload

### DIFF
--- a/cloud/vmware/vsphere_copy
+++ b/cloud/vmware/vsphere_copy
@@ -120,11 +120,10 @@ def main():
     atexit.register(conn.close)
 
     remote_path = vmware_path(datastore, datacenter, dest)
-    auth = base64.encodestring('%s:%s' % (login, password))
+    auth = base64.encodestring('%s:%s' % (login, password)).rstrip()
     headers = {
         "Content-Type": "application/octet-stream",
         "Content-Length": str(len(data)),
-        "Accept": "text/plain",
         "Authorization": "Basic %s" % auth,
     }
 


### PR DESCRIPTION
Due to a spurious newline we corrupted the payload. It depends on the order of the headers and if there were headers added by vSphere.

The Accept header was also not needed.
