### PR TITLE
Portage: --usepkg and --usepkgonly flags, --usepkgonly should not imply --getbinpkg

### DIFF
--- a/packaging/os/portage.py
+++ b/packaging/os/portage.py
@@ -267,14 +267,14 @@ def emerge_packages(module, packages):
         'verbose': '--verbose',
         'getbinpkg': '--getbinpkg',
         'usepkgonly': '--usepkgonly',
+        'usepkg': '--usepkg',
     }
     for flag, arg in emerge_flags.iteritems():
         if p[flag]:
             args.append(arg)
 
-    # usepkgonly implies getbinpkg
-    if p['usepkgonly'] and not p['getbinpkg']:
-        args.append('--getbinpkg')
+    if 'usepkg' in p and 'usepkgonly' in p:
+        module.fail_json(msg='Use only one of usepkg, usepkgonly')
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)
     if rc != 0:
@@ -406,6 +406,7 @@ def main():
             sync=dict(default=None, choices=['yes', 'web']),
             getbinpkg=dict(default=None, choices=['yes']),
             usepkgonly=dict(default=None, choices=['yes']),
+            usepkg=dict(default=None, choices=['yes']),
         ),
         required_one_of=[['package', 'sync', 'depclean']],
         mutually_exclusive=[['nodeps', 'onlydeps'], ['quiet', 'verbose']],

--- a/packaging/os/portage.py
+++ b/packaging/os/portage.py
@@ -273,7 +273,7 @@ def emerge_packages(module, packages):
         if p[flag]:
             args.append(arg)
 
-    if 'usepkg' in p and 'usepkgonly' in p:
+    if p['usepkg'] and p['usepkgonly']:
         module.fail_json(msg='Use only one of usepkg, usepkgonly')
 
     cmd, (rc, out, err) = run_emerge(module, packages, *args)


### PR DESCRIPTION
As pointed out by @AdmiralNemo https://github.com/ansible/ansible-modules-extras/commit/5a6de937cb053d8366e06c01ec59b37c22d0629c#commitcomment-11754224
