### PR TITLE
Define HAS_LXC even if import lxc doesn't fail.

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -385,6 +385,8 @@ try:
     import lxc
 except ImportError:
     HAS_LXC = False
+else:
+    HAS_LXC = True
 
 
 # LXC_COMPRESSION_MAP is a map of available compression types when creating


### PR DESCRIPTION
This fixes::

```
Traceback (most recent call last):
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080800.61-38257321141340/lxc_container", line 3353, in <module>
    main()
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080800.61-38257321141340/lxc_container", line 1712, in main
    if not HAS_LXC:
NameError: global name 'HAS_LXC' is not defined
```
