### PR TITLE
Fixed lxc option parsing.

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -708,7 +708,7 @@ class LxcContainerManagement(object):
             for option_line in container_config:
                 # Look for key in config
                 if option_line.startswith(key):
-                    _, _value = option_line.split('=')
+                    _, _value = option_line.split('=', 1)
                     config_value = ' '.join(_value.split())
                     line_index = container_config.index(option_line)
                     # If the sanitized values don't match replace them


### PR DESCRIPTION
This fixes::

```
Traceback (most recent call last):
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080916.98-133068627776311/lxc_container", line 3355, in <module>
    main()
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080916.98-133068627776311/lxc_container", line 1724, in main
    lxc_manage.run()
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080916.98-133068627776311/lxc_container", line 1605, in run
    action()
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080916.98-133068627776311/lxc_container", line 1145, in _started
    self._config()
  File "/home/jpic/.ansible/tmp/ansible-tmp-1435080916.98-133068627776311/lxc_container", line 714, in _config
    _, _value = option_line.split('=')
ValueError: too many values to unpack
```

With such a task::

```
tasks:
- lxc_container:
    name: buildbot-master
    container_config:
    - "lxc.mount.entry = {{ cwd }} srv/peopletest none defaults,bind,uid=0,create=dir 0 0"
```
