### PR TITLE
CloudStack: omit hypervisor option if not set

### DIFF
--- a/cloud/cloudstack/cs_instance.py
+++ b/cloud/cloudstack/cs_instance.py
@@ -70,8 +70,6 @@ options:
   hypervisor:
     description:
       - Name the hypervisor to be used for creating the new instance.
-      - Relevant when using C(state=present) and option C(ISO) is used.
-      - If not set, first found hypervisor will be used.
     required: false
     default: null
     choices: [ 'KVM', 'VMware', 'BareMetal', 'XenServer', 'LXC', 'HyperV', 'UCS', 'OVM' ]
@@ -511,7 +509,7 @@ class AnsibleCloudStackInstance(AnsibleCloudStack):
         args['projectid']           = self.get_project('id')
         args['diskofferingid']      = self.get_disk_offering_id()
         args['networkids']          = self.get_network_ids()
-        args['hypervisor']          = self.get_hypervisor()
+        args['hypervisor']          = self.module.params.get('hypervisor')
         args['userdata']            = self.get_user_data()
         args['keyboard']            = self.module.params.get('keyboard')
         args['ipaddress']           = self.module.params.get('ip_address')


### PR DESCRIPTION
cs_instance uses first found hypervisor when it deploys a VM if user does not specify hypervisor type.
This causes mismatch of hypervisor type between option and templates like ollowing.

```
msg: Failed: 'Hypervisor passed to the deployVm call, is different from the hypervisor type of the template'
```

This patch omits hypervisor option if user does not set hypervisor type because CloudStack uses hypervisor type of the template properly if it is not set.
