### PR TITLE
Fixed incorrect connect_to_aws call

### DIFF
--- a/cloud/amazon/ec2_vpc_igw.py
+++ b/cloud/amazon/ec2_vpc_igw.py
@@ -29,7 +29,7 @@ options:
     default: null
   region:
     description:
-      - The AWS region to use.  Must be specified if ec2_url is not used. If not specified then the value of the EC2_REGION environment variable, if any, is used. See U(http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)
+      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used. See U(http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)
     required: false
     default: null
     aliases: [ 'aws_region', 'ec2_region' ]
@@ -47,7 +47,7 @@ EXAMPLES = '''
 
 # Ensure that the VPC has an Internet Gateway.
 # The Internet Gateway ID is can be accessed via {{igw.gateway_id}} for use in setting up NATs etc.
-module: ec2_vpc_igw
+ec2_vpc_igw:
   vpc_id: vpc-abcdefgh
   state: present
 register: igw

--- a/cloud/amazon/ec2_vpc_igw.py
+++ b/cloud/amazon/ec2_vpc_igw.py
@@ -20,18 +20,25 @@ short_description: Manage an AWS VPC Internet gateway
 description:
     - Manage an AWS VPC Internet gateway
 version_added: "2.0"
-author: Robert Estelle, @erydo
+author: Robert Estelle (@erydo)
 options:
   vpc_id:
     description:
       - The VPC ID for the VPC in which to manage the Internet Gateway.
     required: true
     default: null
+  region:
+    description:
+      - The AWS region to use.  Must be specified if ec2_url is not used. If not specified then the value of the EC2_REGION environment variable, if any, is used. See U(http://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region)
+    required: false
+    default: null
+    aliases: [ 'aws_region', 'ec2_region' ]
   state:
     description:
       - Create or terminate the IGW
     required: false
     default: present
+    choices: [ 'present', 'absent' ]
 extends_documentation_fragment: aws
 '''
 
@@ -39,16 +46,13 @@ EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 # Ensure that the VPC has an Internet Gateway.
-# The Internet Gateway ID is can be accessed via {{igw.gateway_id}} for use
-# in setting up NATs etc.
-      local_action:
-        module: ec2_vpc_igw
-        vpc_id: {{vpc.vpc_id}}
-        region: {{vpc.vpc.region}}
-        state: present
-      register: igw
-'''
+# The Internet Gateway ID is can be accessed via {{igw.gateway_id}} for use in setting up NATs etc.
+module: ec2_vpc_igw
+  vpc_id: vpc-abcdefgh
+  state: present
+register: igw
 
+'''
 
 import sys  # noqa
 
@@ -116,8 +120,8 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            vpc_id = dict(required=True),
-            state = dict(choices=['present', 'absent'], default='present')
+            vpc_id = dict(required=True, default=None),
+            state = dict(required=False, default='present', choices=['present', 'absent'])
         )
     )
 
@@ -133,14 +137,14 @@ def main():
 
     if region:
         try:
-            connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
+            connection = connect_to_aws(boto.vpc, region, **aws_connect_params)
         except (boto.exception.NoAuthHandlerFound, StandardError), e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="region must be specified")
 
     vpc_id = module.params.get('vpc_id')
-    state = module.params.get('state', 'present')
+    state = module.params.get('state')
 
     try:
         if state == 'present':


### PR DESCRIPTION
switched to boto.vpc instead of boto.ec2

Module will always fail without this
