### PR TITLE
Fix documentation bug: gluster_volume module

### DIFF
--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -115,7 +115,7 @@ EXAMPLES = """
   gluster_volume: state=present name=test1 options='{performance.cache-size: 256MB}'
 
 - name: start gluster volume
-  gluster_volume: status=started name=test1
+  gluster_volume: state=started name=test1
 
 - name: limit usage
   gluster_volume: state=present name=test1 directory=/foo quota=20.0MB


### PR DESCRIPTION
This is super minor, but the documentation shows "status" instead of "state" which could lead to confusing folks somewhat new to Ansible. :+1: 
