### PR TITLE
hipchat: Fix user notification for v2 api

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -5,7 +5,7 @@ DOCUMENTATION = '''
 ---
 module: hipchat
 version_added: "1.2"
-short_description: Send a message to hipchat
+short_description: Send a message to hipchat.
 description:
    - Send a message to hipchat
 options:
@@ -56,7 +56,7 @@ options:
     version_added: 1.5.1
   api:
     description:
-      - API url if using a self-hosted hipchat server
+      - API url if using a self-hosted hipchat server. For hipchat api version 2 use C(/v2) path in URI
     required: false
     default: 'https://api.hipchat.com/v1'
     version_added: 1.6.0
@@ -67,7 +67,15 @@ author: "WAKAYAMA Shirou (@shirou), BOURDEL Paul (@pb8226)"
 '''
 
 EXAMPLES = '''
-- hipchat: token=AAAAAA room=notify msg="Ansible task finished"
+- hipchat:  room=notify msg="Ansible task finished"
+
+# Use Hipchat API version 2
+
+- hipchat: 
+    api: "https://api.hipchat.com/v2/"
+    token: OAUTH2_TOKEN
+    room: notify 
+    msg: "Ansible task finished"
 '''
 
 # ===========================================
@@ -80,7 +88,6 @@ DEFAULT_URI = "https://api.hipchat.com/v1"
 
 MSG_URI_V1 = "/rooms/message"
 
-MSG_URI_V2 = "/room/{id_or_name}/message"
 NOTIFY_URI_V2 = "/room/{id_or_name}/notification"
 
 def send_msg_v1(module, token, room, msg_from, msg, msg_format='text',
@@ -95,12 +102,8 @@ def send_msg_v1(module, token, room, msg_from, msg, msg_format='text',
     params['message_format'] = msg_format
     params['color'] = color
     params['api'] = api
-
-    if notify:
-        params['notify'] = 1
-    else:
-        params['notify'] = 0
-
+    params['notify'] = int(notify)
+  
     url = api + MSG_URI_V1 + "?auth_token=%s" % (token)
     data = urllib.urlencode(params)
 
@@ -116,7 +119,7 @@ def send_msg_v1(module, token, room, msg_from, msg, msg_format='text',
 
 
 def send_msg_v2(module, token, room, msg_from, msg, msg_format='text',
-             color='yellow', notify=False, api=MSG_URI_V2):
+             color='yellow', notify=False, api=NOTIFY_URI_V2):
     '''sending message to hipchat v2 server'''
     print "Sending message to v2 server"
 
@@ -126,13 +129,11 @@ def send_msg_v2(module, token, room, msg_from, msg, msg_format='text',
     body['message'] = msg
     body['color'] = color
     body['message_format'] = msg_format
+    params['notify'] = notify
 
-    if notify:
-        POST_URL = api + NOTIFY_URI_V2
-    else:
-        POST_URL = api + MSG_URI_V2
-
-    url = POST_URL.replace('{id_or_name}',room)
+    POST_URL = api + NOTIFY_URI_V2
+    
+    url = POST_URL.replace('{id_or_name}', room)
     data = json.dumps(body)
 
     if module.check_mode:


### PR DESCRIPTION
`notify` parameter is not working as expected for hipchat API v2. Parameter `notify: no` enables user notification and vise versa. In fact user notification is disabled by default. 

I think there is a little misunderstanding here. [Send message](https://www.hipchat.com/docs/apiv2/method/send_message) request is not supposed to be an equivalent of [room/message](https://www.hipchat.com/docs/api/method/rooms/message) from v1.It simply does not support all the parameters. [Send room notification](https://www.hipchat.com/docs/apiv2/method/send_room_notification) is a right one. It supports `notify` parameter to configure a user notification. 
