### PR TITLE
irc: remove version_added for nick option

### DIFF
--- a/notification/irc.py
+++ b/notification/irc.py
@@ -42,7 +42,6 @@ options:
       - Nickname to send the message from. May be shortened, depending on server's NICKLEN setting.
     required: false
     default: ansible
-    version_added: "2.0"
   msg:
     description:
       - The message body.


### PR DESCRIPTION
Sorry, wanted to update it for the new nick_to option, but this was already in the meanwhile.

Good catch @abadger
Also see GH-693
