### PR TITLE
Synchronizes the valid cask and directory name regexs between the homebrew and homebrew_cask plugins 

### DIFF
--- a/packaging/os/homebrew_cask.py
+++ b/packaging/os/homebrew_cask.py
@@ -68,6 +68,7 @@ class HomebrewCask(object):
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
         \s                  # spaces
         :                   # colons
+        .                   # dots
         {sep}               # the OS-specific path separator
         -                   # dashes
     '''.format(sep=os.path.sep)
@@ -75,12 +76,15 @@ class HomebrewCask(object):
     VALID_BREW_PATH_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
         \s                  # spaces
+        .                   # dots
         {sep}               # the OS-specific path separator
         -                   # dashes
     '''.format(sep=os.path.sep)
 
     VALID_CASK_CHARS = r'''
         \w                  # alphanumeric characters (i.e., [a-zA-Z0-9_])
+        .                   # dots
+        \+                  # plusses
         -                   # dashes
     '''
 


### PR DESCRIPTION
Corrects defect #699 with the following changes:
- Modifies homebrew_cask to consider hidden directories valid for the Homebrew root (e.g. ~/.homebrew)
- Modifies the VALID_CASK_CHARS constant in homebrew_cask to match VALID_PACKAGE_CHARS in homebrew since Homebrew packages and casks use the same naming rules

/cc @danieljaouen 
