### PR TITLE
Prevent Zabbix config from being overwritten by providing a create_on…

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -92,7 +92,7 @@ options:
         required: false
     create_only:
         description:
-            - Will only create a host in Zabbix if it does not already exist, but will not update an existing host.e'
+            - Will only create a host in Zabbix if it does not already exist, but will not update an existing host
         required: false
         default: false
 '''


### PR DESCRIPTION
Prevent Zabbix config from getting overwritten by providing an create_only optional parameter
