### PR TITLE
return as unchanged if macro update is unnecessary

### DIFF
--- a/monitoring/zabbix_hostmacro.py
+++ b/monitoring/zabbix_hostmacro.py
@@ -149,6 +149,8 @@ class HostMacro(object):
     # update host macro
     def update_host_macro(self, host_macro_obj, macro_name, macro_value):
         host_macro_id = host_macro_obj['hostmacroid']
+        if host_macro_obj['macro'] == '{$'+macro_name+'}' and host_macro_obj['value'] == macro_value:
+            self._module.exit_json(changed=False, result="Host macro %s already up to date" % macro_name)
         try:
             if self._module.check_mode:
                 self._module.exit_json(changed=True)


### PR DESCRIPTION
Currently even unchanged macros return with changed=true. This patch avoids that.
