### PR TITLE
Update small typo error on documentation of gluster_volume module, param is brick and not bricks

### DIFF
--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -62,7 +62,7 @@ options:
     default: 'tcp'
     description:
       - Transport type for volume
-  bricks:
+  brick:
     required: false
     default: null
     description:
@@ -108,7 +108,7 @@ author: "Taneli Leppä (@rosmo)"
 
 EXAMPLES = """
 - name: create gluster volume
-  gluster_volume: state=present name=test1 bricks=/bricks/brick1/g1 rebalance=yes cluster="192.168.1.10,192.168.1.11"
+  gluster_volume: state=present name=test1 brick=/bricks/brick1/g1 rebalance=yes cluster="192.168.1.10,192.168.1.11"
   run_once: true
 
 - name: tune
@@ -127,7 +127,7 @@ EXAMPLES = """
   gluster_volume: state=absent name=test1
 
 - name: create gluster volume with multiple bricks
-  gluster_volume: state=present name=test2 bricks="/bricks/brick1/g2,/bricks/brick2/g2" cluster="192.168.1.10,192.168.1.11"
+  gluster_volume: state=present name=test2 brick="/bricks/brick1/g2,/bricks/brick2/g2" cluster="192.168.1.10,192.168.1.11"
   run_once: true
 """
 


### PR DESCRIPTION
Hi,

Here is a small pull request on documentation typo error about gluster_volume module. In fact "bricks" is not a param when using is ansible will complain with : "msg: unsupported parameter for module: bricks".

And ansible-doc gluster_volume give this documentation : 

> GLUSTER_VOLUME

  Create, remove, start, stop and tune GlusterFS volumes

Options (= is mandatory):
- brick
      Brick path on servers [Default: None]

Hope it helps regards.
