### PR TITLE
virt: remove BabyJSON

### DIFF
--- a/cloud/misc/virt.py
+++ b/cloud/misc/virt.py
@@ -93,8 +93,9 @@ import sys
 try:
     import libvirt
 except ImportError:
-    print "failed=True msg='libvirt python module unavailable'"
-    sys.exit(1)
+    HAS_VIRT = False
+else:
+    HAS_VIRT = True
 
 ALL_COMMANDS = []
 VM_COMMANDS = ['create','status', 'start', 'stop', 'pause', 'unpause',
@@ -480,6 +481,11 @@ def main():
         uri = dict(default='qemu:///system'),
         xml = dict(),
     ))
+
+    if not HAS_VIRT:
+        module.fail_json(
+            msg='The `libvirt` module is not importable. Check the requirements.'
+        )
 
     rc = VIRT_SUCCESS
     try:


### PR DESCRIPTION
Removed the usage of baby json. This is in response to the fact
that the baby json functionality was removed in Ansible 1.8

Ref: #430
