### PR TITLE
Homebrew: Allow colons, direct check for outdated formula

### DIFF
--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -119,6 +119,7 @@ class Homebrew(object):
         /                   # slash (for taps)
         \+                  # plusses
         -                   # dashes
+        :                   # colons (for URLs)
     '''
 
     INVALID_PATH_REGEX        = _create_regex_group(VALID_PATH_CHARS)
@@ -394,18 +395,17 @@ class Homebrew(object):
 
         return False
 
-    def _outdated_packages(self):
-        rc, out, err = self.module.run_command([
-            self.brew_path,
-            'outdated',
-        ])
-        return [line.split(' ')[0].strip() for line in out.split('\n') if line]
-
     def _current_package_is_outdated(self):
         if not self.valid_package(self.current_package):
             return False
 
-        return self.current_package in self._outdated_packages()
+        rc, out, err = self.module.run_command([
+            self.brew_path,
+            'outdated',
+            self.current_package,
+        ])
+
+        return rc != 0
 
     def _current_package_is_installed_from_head(self):
         if not Homebrew.valid_package(self.current_package):


### PR DESCRIPTION
See issue #252. Colons should be in the validation filter so that formulas from e.g. gists can be used.

Previously, to determine if a formula is out of date a list of all retrieved formulas is retrieved, and the formula name is checked against that list. A formula name can be passed directly to `brew outdated`, this will return 1 if the formula is out of date or not installed which has the same result as checking if the name is in the list. This works well and is more robust for formulas specified by a URL.
