### PR TITLE
Port librato_annotation to fetch_url

### DIFF
--- a/monitoring/librato_annotation.py
+++ b/monitoring/librato_annotation.py
@@ -105,9 +105,6 @@ EXAMPLES = '''
     end_time: 1395954406
 '''
 
-
-import urllib2
-
 def post_annotation(module):
     user = module.params['user']
     api_key = module.params['api_key']
@@ -134,10 +131,9 @@ def post_annotation(module):
     headers = {}
     headers['Content-Type'] = 'application/json'
     headers['Authorization'] = "Basic " + base64.b64encode(user + ":" + api_key).strip()
-    req = urllib2.Request(url, json_body, headers)
-    try:
-        response = urllib2.urlopen(req)
-    except urllib2.HTTPError, e:
+
+    response, info = fetch_url(module, url, data=json_body, headers=headers)
+    if info['status'] != 200:
         module.fail_json(msg="Request Failed", reason=e.reason)
     response = response.read()
     module.exit_json(changed=True, annotation=response)
@@ -161,4 +157,6 @@ def main():
   post_annotation(module)
 
 from ansible.module_utils.basic import *
-main()
+from ansible.module_utils.urls import *
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
librato_annotation was using raw urllib2 which does not verify the server's SSL certificate.  Ported to ansible's fetch_url() which does certificate checking.

@sedward -  I don't use librato_annotation so if you are able to review this and verify that it still works, that would be greatly appreciated.  Since this change will prevent man-in-the-middle attacks I will merge this even if you don't get back to me but I would vastly prefer you (or someone else using librarto_annotation) take a look to make sure this works.
