### PR TITLE
Do not assume that /var/lib/locales/supported.d/local exist

### DIFF
--- a/system/locale_gen.py
+++ b/system/locale_gen.py
@@ -176,7 +176,7 @@ def main():
     state = module.params['state']
 
     if not os.path.exists("/etc/locale.gen"):
-        if os.path.exists("/var/lib/locales/supported.d/local"):
+        if os.path.exists("/var/lib/locales/supported.d/"):
             # Ubuntu created its own system to manage locales.
             ubuntuMode = True
         else:


### PR DESCRIPTION
Since people can generate their own image with debootstrap, and
this wouldn't create a file /var/lib/locales/supported.d/local,
better check if it exist and work if it doesn't.

Fix #656
