### PR TITLE
Hipchat uses incorrect variable name.

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -71,10 +71,10 @@ EXAMPLES = '''
 
 # Use Hipchat API version 2
 
-- hipchat: 
+- hipchat:
     api: "https://api.hipchat.com/v2/"
     token: OAUTH2_TOKEN
-    room: notify 
+    room: notify
     msg: "Ansible task finished"
 '''
 
@@ -103,7 +103,7 @@ def send_msg_v1(module, token, room, msg_from, msg, msg_format='text',
     params['color'] = color
     params['api'] = api
     params['notify'] = int(notify)
-  
+
     url = api + MSG_URI_V1 + "?auth_token=%s" % (token)
     data = urllib.urlencode(params)
 
@@ -129,10 +129,10 @@ def send_msg_v2(module, token, room, msg_from, msg, msg_format='text',
     body['message'] = msg
     body['color'] = color
     body['message_format'] = msg_format
-    params['notify'] = notify
+    body['notify'] = notify
 
     POST_URL = api + NOTIFY_URI_V2
-    
+
     url = POST_URL.replace('{id_or_name}', room)
     data = json.dumps(body)
 


### PR DESCRIPTION
I think a bad copy 'n' paste introduced a bug when using v2.
