### PR TITLE
open_iscsi: return devicenodes as empty list if no LUN's

### DIFF
--- a/system/open_iscsi.py
+++ b/system/open_iscsi.py
@@ -108,6 +108,7 @@ import time
 
 ISCSIADM = 'iscsiadm'
 
+
 def compare_nodelists(l1, l2):
 
     l1.sort()
@@ -159,7 +160,7 @@ def target_loggedon(module, target):
 
     cmd = '%s --mode session' % iscsiadm_cmd
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc == 0:
         return target in out
     elif rc == 21:
@@ -186,7 +187,7 @@ def target_login(module, target):
 
     cmd = '%s --mode node --targetname %s --login' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -195,7 +196,7 @@ def target_logout(module, target):
 
     cmd = '%s --mode node --targetname %s --logout' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -221,7 +222,7 @@ def target_isauto(module, target):
 
     cmd = '%s --mode node --targetname %s' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc == 0:
         lines = out.splitlines()
         for line in lines:
@@ -236,7 +237,7 @@ def target_setauto(module, target):
 
     cmd = '%s --mode node --targetname %s --op=update --name node.startup --value automatic' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -245,7 +246,7 @@ def target_setmanual(module, target):
 
     cmd = '%s --mode node --targetname %s --op=update --name node.startup --value manual' % (iscsiadm_cmd, target)
     (rc, out, err) = module.run_command(cmd)
-    
+
     if rc > 0:
         module.fail_json(cmd=cmd, rc=rc, msg=err)
 
@@ -256,7 +257,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
 
-            # target 
+            # target
             portal = dict(required=False, aliases=['ip']),
             port = dict(required=False, default=3260),
             target = dict(required=False, aliases=['name', 'targetname']),
@@ -269,14 +270,14 @@ def main():
             auto_node_startup = dict(type='bool', aliases=['automatic']),
             discover = dict(type='bool', default=False),
             show_nodes = dict(type='bool', default=False)
-        ),  
+        ),
 
         required_together=[['discover_user', 'discover_pass'],
                            ['node_user', 'node_pass']],
         supports_check_mode=True
     )
 
-    global iscsiadm_cmd 
+    global iscsiadm_cmd
     iscsiadm_cmd = module.get_bin_path('iscsiadm', required=True)
 
     # parameters
@@ -292,7 +293,7 @@ def main():
 
     cached = iscsi_get_cached_nodes(module, portal)
 
-    # return json dict 
+    # return json dict
     result = {}
     result['changed'] = False
 
@@ -330,17 +331,17 @@ def main():
         result['nodes'] = nodes
 
     if login is not None:
-        loggedon = target_loggedon(module,target)
+        loggedon = target_loggedon(module, target)
         if (login and loggedon) or (not login and not loggedon):
             result['changed'] |= False
             if login:
-                result['devicenodes'] = target_device_node(module,target)
+                result['devicenodes'] = target_device_node(module, target)
         elif not check:
             if login:
                 target_login(module, target)
                 # give udev some time
                 time.sleep(1)
-                result['devicenodes'] = target_device_node(module,target)
+                result['devicenodes'] = target_device_node(module, target)
             else:
                 target_logout(module, target)
             result['changed'] |= True
@@ -366,7 +367,6 @@ def main():
             result['automatic_changed'] = True
 
     module.exit_json(**result)
-
 
 
 # import module snippets

--- a/system/open_iscsi.py
+++ b/system/open_iscsi.py
@@ -206,18 +206,15 @@ def target_device_node(module, target):
     # a given target...
 
     devices = glob.glob('/dev/disk/by-path/*%s*' % target)
-    if len(devices) == 0:
-        return None
-    else:
-        devdisks = []
-        for dev in devices:
-            # exclude partitions
-            if "-part" not in dev:
-                devdisk = os.path.realpath(dev)
-                # only add once (multi-path?)
-                if devdisk not in devdisks:
-                    devdisks.append(devdisk)
-        return devdisks
+    devdisks = []
+    for dev in devices:
+        # exclude partitions
+        if "-part" not in dev:
+            devdisk = os.path.realpath(dev)
+            # only add once (multi-path?)
+            if devdisk not in devdisks:
+                devdisks.append(devdisk)
+    return devdisks
 
 
 def target_isauto(module, target):


### PR DESCRIPTION
got connected. It is possible for an intiator to successfully connect to a
target, whilst getting no LUN's back. If no devicenodes get detected, it makes
more sense to return an empty list than plainly None.

This potentially avoids further tasks to have to check if devicenodes is
iterable.
