### PR TITLE
postgresql_ext: bugfix - change check mode call db_exists() -> ext_exists()

### DIFF
--- a/database/postgresql/postgresql_ext.py
+++ b/database/postgresql/postgresql_ext.py
@@ -137,7 +137,7 @@ def main():
     state = module.params["state"]
     changed = False
 
-    # To use defaults values, keyword arguments must be absent, so 
+    # To use defaults values, keyword arguments must be absent, so
     # check which values are empty and don't include in the **kw
     # dictionary
     params_map = {
@@ -146,7 +146,7 @@ def main():
         "login_password":"password",
         "port":"port"
     }
-    kw = dict( (params_map[k], v) for (k, v) in module.params.iteritems() 
+    kw = dict( (params_map[k], v) for (k, v) in module.params.iteritems()
               if k in params_map and v != '' )
     try:
         db_connection = psycopg2.connect(database=db, **kw)
@@ -165,9 +165,9 @@ def main():
     try:
         if module.check_mode:
             if state == "absent":
-                changed = not db_exists(cursor, ext)
+                changed = not ext_exists(cursor, ext)
             elif state == "present":
-                changed = db_exists(cursor, ext)
+                changed = ext_exists(cursor, ext)
             module.exit_json(changed=changed,ext=ext)
 
         if state == "absent":


### PR DESCRIPTION
When in check mode, we want to check if the module exists
right here, not the database. If we are at this line,
we are connected to the database already so a db_exists
is not only redundant, but an error, because the db_exists()
function is undefined. Changing db_exists() to ext_exists()
is the only logical choice I could see to make this run
correctly in check mode.

As of now, check mode for this module doesn't work because db_exists() is undefined.
