### PR TITLE
win_iis_website: Workaround bug in Get-Website cmdlet.

### DIFF
--- a/windows/win_iis_website.ps1
+++ b/windows/win_iis_website.ps1
@@ -70,7 +70,7 @@ $result = New-Object psobject @{
 };
 
 # Site info
-$site = Get-Website -Name $name
+$site = Get-Website | Where { $_.Name -eq $name }
 
 Try {
   # Add site
@@ -113,7 +113,7 @@ Try {
     $result.changed = $true
   }
 
-  $site = Get-Website -Name $name
+  $site = Get-Website | Where { $_.Name -eq $name }
   If($site) {
     # Change Physical Path if needed
     if($physical_path) {
@@ -165,7 +165,7 @@ Catch
   Fail-Json (New-Object psobject) $_.Exception.Message
 }
 
-$site = Get-Website -Name $name
+$site = Get-Website | Where { $_.Name -eq $name }
 $result.site = New-Object psobject @{
   Name = $site.Name
   ID = $site.ID


### PR DESCRIPTION
Workaround for issue described here: http://stackoverflow.com/questions/4170530/powershell-get-website-name-parameter-is-ignored
