### PR TITLE
strange results with services=all

### DIFF
--- a/monitoring/nagios.py
+++ b/monitoring/nagios.py
@@ -913,6 +913,8 @@ class Nagios(object):
         elif self.action == 'enable_alerts':
             if self.services == 'host':
                 self.enable_host_notifications(self.host)
+            elif self.services == 'all':
+                self.enable_host_svc_notifications(self.host)
             else:
                 self.enable_svc_notifications(self.host,
                                               services=self.services)
@@ -920,6 +922,8 @@ class Nagios(object):
         elif self.action == 'disable_alerts':
             if self.services == 'host':
                 self.disable_host_notifications(self.host)
+            elif self.services == 'all':
+                self.disable_host_svc_notifications(self.host)
             else:
                 self.disable_svc_notifications(self.host,
                                                services=self.services)


### PR DESCRIPTION
I issued a command with action=disable_alerts host=webserver services=all set and get this results:

```
"nagios_commands": [
    "[1438593631] DISABLE_SVC_NOTIFICATIONS;webserver;a", 
    "[1438593631] DISABLE_SVC_NOTIFICATIONS;webserver;l", 
    "[1438593631] DISABLE_SVC_NOTIFICATIONS;webserver;l"
]
```

This is not a big deal because i have just overlooked the action=silence command. Nevertheless a more predictable result would be a nice thing to have.
