### PR TITLE
monit: Add retry for pending/initializing services

### DIFF
--- a/monitoring/monit.py
+++ b/monitoring/monit.py
@@ -45,6 +45,7 @@ options:
         many times to perform the requested action. Between each retry Ansible will sleep for 1 second.
     required: false
     default: 10
+    version_added: "2.0"
 requirements: [ ]
 author: "Darryl Stoflet (@dstoflet)" 
 '''
@@ -57,7 +58,7 @@ EXAMPLES = '''
 def main():
     arg_spec = dict(
         name=dict(required=True),
-        max_retries=dict(default=10),
+        max_retries=dict(default=10, type='int'),
         state=dict(required=True, choices=['present', 'started', 'restarted', 'stopped', 'monitored', 'unmonitored', 'reloaded'])
     )
 


### PR DESCRIPTION
This is the same as the pull request for #572. :)
ping @bcoca @gregdek

> If there are already ongoing actions for a process managed by monit, the
> module would exit unsuccessfully. It could also give off false positives
> because it did not determine whether the service was started/stopped
> when it was in a pending state. Which might be turning the service off,
> but the action was to start it.
> 
> For example "Running - pending stop" would be regarded as the service
> running and "state=enabled" would do nothing.
> 
> This will make Ansible wait for the state to finalize, or a timeout decided
> by the new `max_retries` option, before it decides what to do.
> 
> This fixes issue #244.
