### PR TITLE
Doc string fix for vsphere_copy

### DIFF
--- a/cloud/vmware/vsphere_copy.py
+++ b/cloud/vmware/vsphere_copy.py
@@ -22,7 +22,8 @@ DOCUMENTATION = '''
 ---
 module: vsphere_copy
 short_description: Copy a file to a vCenter datastore
-description: Upload files to a vCenter datastore
+description: 
+    - Upload files to a vCenter datastore
 version_added: 2.0
 author: Dag Wieers (@dagwieers) <dag@wieers.com>
 options:


### PR DESCRIPTION
Current doc string makes the docsite for vsphere_copy in the Synopsis area look dumb http://docs.ansible.com/ansible/vsphere_copy_module.html

This makes it as it should be.
