### PR TITLE
seport requires 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - python2.4
       - python2.6
 script:
-  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/consul.*\.py|notification/pushbullet\.py' .
+  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/consul.*\.py|notification/pushbullet\.py|system/seport\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
   #- ./test-docs.sh extras


### PR DESCRIPTION
The system/seport.py module requires Python 2.6, it is not Python 2.4 safe.
