### PR TITLE
Add ZFS backing store support to lxc_container

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -454,6 +454,9 @@ LXC_BACKING_STORE = {
     ],
     'overlayfs': [
         'lv_name', 'vg_name', 'fs_type', 'fs_size', 'thinpool', 'zfs_root'
+    ],
+    'zfs': [
+        'lv_name', 'vg_name', 'fs_type', 'fs_size', 'thinpool'
     ]
 }
 


### PR DESCRIPTION
Hi!

Added the `zfs` option to the list of allowed backing stores. This allowed me the create an lxc container with its backing store on a ZFS dataset.

Thanks for the great work!
