### PR TITLE
Fixing empty tags check on rabbitmq_user

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -108,7 +108,7 @@ class RabbitMqUser(object):
         self.username = username
         self.password = password
         self.node = node
-        if tags is None:
+        if not tags:
             self.tags = list()
         else:
             self.tags = tags.split(',')


### PR DESCRIPTION
Right now even if you pass in an empty `tags` list to the module (either with  an empty string or null) it will erroneously think the tags list have changed and re-apply the tags on every run.

This happens because the default value of `None` is not used, and it tries to split the string by commas generating `['']` as a tags list, instead of an empty list.
