### PR TITLE
New VMware Module to support adding a VMware vSAN cluster

### DIFF
--- a/cloud/vmware/vmware_vsan_cluster.py
+++ b/cloud/vmware/vmware_vsan_cluster.py
@@ -1,0 +1,143 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Russell Teague <rteague2 () csc.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: vmware_vsan_cluster
+short_description: Configure VSAN clustering on an ESXi host
+description:
+    - This module can be used to configure VSAN clustering on an ESXi host
+version_added: 2.0
+author: "Russell Teague (@mtnbikenc)"
+notes:
+    - Tested on vSphere 5.5
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+options:
+    hostname:
+        description:
+            - The hostname or IP address of the ESXi Server
+        required: True
+    username:
+        description:
+            - The username of the ESXi Server
+        required: True
+        aliases: ['user', 'admin']
+    password:
+        description:
+            - The password of ESXi Server
+        required: True
+        aliases: ['pass', 'pwd']
+    cluster_uuid:
+        description:
+            - Desired cluster UUID
+        required: False
+'''
+
+EXAMPLES = '''
+# Example command from Ansible Playbook
+
+- name: Configure VMware VSAN Cluster
+  hosts: deploy_node
+  gather_facts: False
+  tags:
+    - vsan
+  tasks:
+    - name: Configure VSAN on first host
+      vmware_vsan_cluster:
+         hostname: "{{ groups['esxi'][0] }}"
+         username: "{{ esxi_username }}"
+         password: "{{ site_password }}"
+      register: vsan_cluster
+
+    - name: Configure VSAN on remaining hosts
+      vmware_vsan_cluster:
+         hostname: "{{ item }}"
+         username: "{{ esxi_username }}"
+         password: "{{ site_password }}"
+         cluster_uuid: "{{ vsan_cluster.cluster_uuid }}"
+      with_items: groups['esxi'][1:]
+
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+def create_vsan_cluster(host_system, new_cluster_uuid):
+    host_config_manager = host_system.configManager
+    vsan_system = host_config_manager.vsanSystem
+
+    vsan_config = vim.vsan.host.ConfigInfo()
+    vsan_config.enabled = True
+
+    if new_cluster_uuid is not None:
+        vsan_config.clusterInfo = vim.vsan.host.ConfigInfo.ClusterInfo()
+        vsan_config.clusterInfo.uuid = new_cluster_uuid
+
+    vsan_config.storageInfo = vim.vsan.host.ConfigInfo.StorageInfo()
+    vsan_config.storageInfo.autoClaimStorage = True
+
+    task = vsan_system.UpdateVsan_Task(vsan_config)
+    changed, result = wait_for_task(task)
+
+    host_status = vsan_system.QueryHostStatus()
+    cluster_uuid = host_status.uuid
+
+    return changed, result, cluster_uuid
+
+
+def main():
+
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(cluster_uuid=dict(required=False, type='str')))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    if not HAS_PYVMOMI:
+        module.fail_json(msg='pyvmomi is required for this module')
+
+    new_cluster_uuid = module.params['cluster_uuid']
+
+    try:
+        content = connect_to_api(module, False)
+        host = get_all_objs(content, [vim.HostSystem])
+        if not host:
+            module.fail_json(msg="Unable to locate Physical Host.")
+        host_system = host.keys()[0]
+        changed, result, cluster_uuid = create_vsan_cluster(host_system, new_cluster_uuid)
+        module.exit_json(changed=changed, result=result, cluster_uuid=cluster_uuid)
+
+    except vmodl.RuntimeFault as runtime_fault:
+        module.fail_json(msg=runtime_fault.msg)
+    except vmodl.MethodFault as method_fault:
+        module.fail_json(msg=method_fault.msg)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+from ansible.module_utils.vmware import *
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR includes a new module for VMware vSphere to configure a host for VMware vSAN clustering.

We have an end-to-end playbook that performs bare metal provisioning and configuration of vSphere.
The playbooks/tasks and results from that testing is what will be listed in this PR.
If there are any questions please let either @jcpowermac or @mtnbikenc know.

Tested with version

```
$ ansible-playbook --version
ansible-playbook 1.9.2
  configured module search path = None
```

Associated tasks used for testing below

```
    - name: Configure VSAN on first host
      vmware_vsan_cluster:
        hostname: "{{ groups['foundation_esxi'][0] }}"
        username: "{{ esxi_username }}"
        password: "{{ site_passwd }}"
      register: vsan_cluster

    - name: Configure VSAN on remaining hosts
      vmware_vsan_cluster:
        hostname: "{{ item }}"
        username: "{{ esxi_username }}"
        password: "{{ site_passwd }}"
        cluster_uuid: "{{ vsan_cluster.cluster_uuid }}"
      with_items: groups['foundation_esxi'][1:]
```

Verbose testing output and results

``````
TASK: [Configure VSAN on first host] ******************************************
<172.17.16.10> REMOTE_MODULE vmware_vsan_cluster hostname=foundation-esxi-01 password=VALUE_HIDDEN username=root
changed: [kragle] => {"changed": true, "cluster_uuid": "52369b3a-802c-e0fc-e176-98e0b530403d", "result": null}

TASK: [Configure VSAN on remaining hosts] *************************************
<172.17.16.10> REMOTE_MODULE vmware_vsan_cluster hostname=foundation-esxi-02 password=VALUE_HIDDEN cluster_uuid=52369b3a-802c-e0fc-e176-98e0b530403d username=root
changed: [kragle] => (item=foundation-esxi-02) => {"changed": true, "cluster_uuid": "52369b3a-802c-e0fc-e176-98e0b530403d", "item": "foundation-esxi-02", "result": null}
<172.17.16.10> REMOTE_MODULE vmware_vsan_cluster hostname=foundation-esxi-03 password=VALUE_HIDDEN cluster_uuid=52369b3a-802c-e0fc-e176-98e0b530403d username=root
changed: [kragle] => (item=foundation-esxi-03) => {"changed": true, "cluster_uuid": "52369b3a-802c-e0fc-e176-98e0b530403d", "item": "foundation-esxi-03", "result": null}```
``````
