### PR TITLE
New VMware Module to support adding distributed portgroups

### DIFF
--- a/cloud/vmware/vmware_dvs_portgroup.py
+++ b/cloud/vmware/vmware_dvs_portgroup.py
@@ -1,0 +1,219 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Joseph Callen <jcallen () csc.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: vmware_dvs_portgroup
+short_description: Create or remove a Distributed vSwitch portgroup
+description:
+    - Create or remove a Distributed vSwitch portgroup
+version_added: 2.0
+author: "Joseph Callen (@jcpowermac)"
+notes:
+    - Tested on vSphere 5.5
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+options:
+    hostname:
+        description:
+            - The hostname or IP address of the vSphere vCenter API server
+        required: True
+    username:
+        description:
+            - The username of the vSphere vCenter
+        required: True
+        aliases: ['user', 'admin']
+    password:
+        description:
+            - The password of the vSphere vCenter
+        required: True
+        aliases: ['pass', 'pwd']
+    portgroup_name:
+        description:
+            - The name of the portgroup that is to be created or deleted
+        required: True
+    switch_name:
+        description:
+            - The name of the distributed vSwitch the port group should be created on.
+        required: True
+    vlan_id:
+        description:
+            - The VLAN ID that should be configured with the portgroup
+        required: True
+    num_ports:
+        description:
+            - The number of ports the portgroup should contain
+        required: True
+    portgroup_type:
+        description:
+            - See VMware KB 1022312 regarding portgroup types
+        required: True
+        choices:
+            - 'earlyBinding'
+            - 'lateBinding'
+            - 'ephemeral'
+'''
+
+EXAMPLES = '''
+   - name: Create Management portgroup
+      local_action:
+        module: vmware_dvs_portgroup
+        hostname: vcenter_ip_or_hostname
+        username: vcenter_username
+        password: vcenter_password
+        portgroup_name: Management
+        switch_name: dvSwitch
+        vlan_id: 123 
+        num_ports: 120
+        portgroup_type: earlyBinding
+        state: present
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+def create_port_group(dv_switch, portgroup_name, vlan_id, num_ports, portgroup_type):
+    config = vim.dvs.DistributedVirtualPortgroup.ConfigSpec()
+
+    config.name = portgroup_name
+    config.numPorts = num_ports
+
+    # vim.VMwareDVSPortSetting() does not exist in the pyvmomi documentation
+    # but this is the correct managed object type.
+
+    config.defaultPortConfig = vim.VMwareDVSPortSetting()
+
+    # vim.VmwareDistributedVirtualSwitchVlanIdSpec() does not exist in the
+    # pyvmomi documentation but this is the correct managed object type
+    config.defaultPortConfig.vlan = vim.VmwareDistributedVirtualSwitchVlanIdSpec()
+    config.defaultPortConfig.vlan.inherited = False
+    config.defaultPortConfig.vlan.vlanId = vlan_id
+    config.type = portgroup_type
+
+    spec = [config]
+    task = dv_switch.AddDVPortgroup_Task(spec)
+    changed, result = wait_for_task(task)
+    return changed, result
+
+
+def state_destroy_dvspg(module):
+    dvs_portgroup = module.params['dvs_portgroup']
+    changed = True
+    result = None
+
+    if not module.check_mode:
+        task = dvs_portgroup.Destroy_Task()
+        changed, result = wait_for_task(task)
+    module.exit_json(changed=changed, result=str(result))
+
+
+def state_exit_unchanged(module):
+    module.exit_json(changed=False)
+
+
+def state_update_dvspg(module):
+    module.exit_json(changed=False, msg="Currently not implemented.")
+    return
+
+
+def state_create_dvspg(module):
+
+    switch_name = module.params['switch_name']
+    portgroup_name = module.params['portgroup_name']
+    dv_switch = module.params['dv_switch']
+    vlan_id = module.params['vlan_id']
+    num_ports = module.params['num_ports']
+    portgroup_type = module.params['portgroup_type']
+    changed = True
+    result = None
+
+    if not module.check_mode:
+        changed, result = create_port_group(dv_switch, portgroup_name, vlan_id, num_ports, portgroup_type)
+    module.exit_json(changed=changed, result=str(result))
+
+
+def check_dvspg_state(module):
+
+    switch_name = module.params['switch_name']
+    portgroup_name = module.params['portgroup_name']
+
+    content = connect_to_api(module)
+    module.params['content'] = content
+
+    dv_switch = find_dvs_by_name(content, switch_name)
+
+    if dv_switch is None:
+        raise Exception("A distributed virtual switch with name %s does not exist" % switch_name)
+
+    module.params['dv_switch'] = dv_switch
+    dvs_portgroup = find_dvspg_by_name(dv_switch, portgroup_name)
+
+    if dvs_portgroup is None:
+        return 'absent'
+    else:
+        module.params['dvs_portgroup'] = dvs_portgroup
+        return 'present'
+
+
+def main():
+
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(portgroup_name=dict(required=True, type='str'),
+                         switch_name=dict(required=True, type='str'),
+                         vlan_id=dict(required=True, type='int'),
+                         num_ports=dict(required=True, type='int'),
+                         portgroup_type=dict(required=True, choices=['earlyBinding', 'lateBinding', 'ephemeral'], type='str'),
+                         state=dict(default='present', choices=['present', 'absent'], type='str')))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    if not HAS_PYVMOMI:
+        module.fail_json(msg='pyvmomi is required for this module')
+
+    try:
+        dvspg_states = {
+            'absent': {
+                'present': state_destroy_dvspg,
+                'absent': state_exit_unchanged,
+            },
+            'present': {
+                'update': state_update_dvspg,
+                'present': state_exit_unchanged,
+                'absent': state_create_dvspg,
+            }
+        }
+        dvspg_states[module.params['state']][check_dvspg_state(module)](module)
+    except vmodl.RuntimeFault as runtime_fault:
+        module.fail_json(msg=runtime_fault.msg)
+    except vmodl.MethodFault as method_fault:
+        module.fail_json(msg=method_fault.msg)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+from ansible.module_utils.vmware import *
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR includes a new module for VMware vSphere to support adding port groups to disributed virtual switches.

We have an end-to-end playbook that performs bare metal provisioning and configuration of vSphere.
The playbooks/tasks and results from that testing is what will be listed in this PR.
If there are any questions please let either @jcpowermac or @mtnbikenc know.

Tested with version

```
$ ansible-playbook --version
ansible-playbook 1.9.2
  configured module search path = None

```

Associated tasks used for testing below

```
    - name: Create Management portgroup
      local_action:
        module: vmware_dvs_portgroup
        hostname: "{{ mgmt_ip_address }}"
        username: "{{ vcsa_user }}"
        password: "{{ vcsa_pass }}"
        portgroup_name: Management
        switch_name: dvSwitch
        vlan_id: "{{ hostvars[groups['foundation_esxi'][0]].mgmt_vlan_id }}"
        num_ports: 120
        portgroup_type: earlyBinding
        state: present
```

Verbose testing output and results

```
2015-08-24 11:22:01,354 p=1210 u=root |  PLAY [Create a Distributed Virtual Switch Networking] ************************* 
2015-08-24 11:22:01,355 p=1210 u=root |  TASK: [Create dvswitch] ******************************************************* 
2015-08-24 11:22:01,370 p=1210 u=root |  <127.0.0.1> REMOTE_MODULE vmware_dvswitch switch_name=dvSwitch discovery_operation=both state=present discovery_proto=lldp hostname=172.17.17.18 datacenter_name=Test-Lab password=VALUE_HIDDEN username=root
2015-08-24 11:22:17,143 p=1210 u=root |  changed: [foundation-vcsa -> 127.0.0.1] => {"changed": true, "result": "'vim.dvs.VmwareDistributedVirtualSwitch:dvs-9'"}
2015-08-24 11:22:17,144 p=1210 u=root |  TASK: [Create Management portgroup] ******************************************* 
2015-08-24 11:22:17,167 p=1210 u=root |  <127.0.0.1> REMOTE_MODULE vmware_dvs_portgroup vlan_id=1801 switch_name=dvSwitch portgroup_type=earlyBinding state=present hostname=172.17.17.18 password=VALUE_HIDDEN portgroup_name=Management username=root
2015-08-24 11:22:33,171 p=1210 u=root |  changed: [foundation-vcsa -> 127.0.0.1] => {"changed": true, "result": "None"}
2015-08-24 11:22:33,172 p=1210 u=root |  TASK: [Create vMotion portgroup] ********************************************** 
2015-08-24 11:22:33,193 p=1210 u=root |  <127.0.0.1> REMOTE_MODULE vmware_dvs_portgroup vlan_id=1802 switch_name=dvSwitch portgroup_type=earlyBinding state=present hostname=172.17.17.18 password=VALUE_HIDDEN portgroup_name=vMotion username=root
2015-08-24 11:22:49,383 p=1210 u=root |  changed: [foundation-vcsa -> 127.0.0.1] => {"changed": true, "result": "None"}
2015-08-24 11:22:49,384 p=1210 u=root |  TASK: [Create vSAN portgroup] ************************************************* 
2015-08-24 11:22:49,405 p=1210 u=root |  <127.0.0.1> REMOTE_MODULE vmware_dvs_portgroup vlan_id=1803 switch_name=dvSwitch portgroup_type=earlyBinding state=present hostname=172.17.17.18 password=VALUE_HIDDEN portgroup_name=vSAN username=root
2015-08-24 11:23:05,426 p=1210 u=root |  changed: [foundation-vcsa -> 127.0.0.1] => {"changed": true, "result": "None"}
```
