### PR TITLE
New VMware Module to support configuring a VMware vmkernel IP Address

### DIFF
--- a/cloud/vmware/vmware_vmkernel_ip_config.py
+++ b/cloud/vmware/vmware_vmkernel_ip_config.py
@@ -1,0 +1,136 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2015, Joseph Callen <jcallen () csc.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: vmware_vmkernel_ip_config
+short_description: Configure the VMkernel IP Address
+description:
+    - Configure the VMkernel IP Address
+version_added: 2.0
+author: "Joseph Callen (@jcpowermac), Russell Teague (@mtnbikenc)"
+notes:
+    - Tested on vSphere 5.5
+requirements:
+    - "python >= 2.6"
+    - PyVmomi
+options:
+    hostname:
+        description:
+            - The hostname or IP address of the ESXi server
+        required: True
+    username:
+        description:
+            - The username of the ESXi server
+        required: True
+        aliases: ['user', 'admin']
+    password:
+        description:
+            - The password of the ESXi server
+        required: True
+        aliases: ['pass', 'pwd']
+    vmk_name:
+        description:
+            - VMkernel interface name
+        required: True
+    ip_address:
+        description:
+            - IP address to assign to VMkernel interface
+        required: True
+    subnet_mask:
+        description:
+            - Subnet Mask to assign to VMkernel interface
+        required: True
+'''
+
+EXAMPLES = '''
+# Example command from Ansible Playbook
+
+- name: Configure IP address on ESX host
+  local_action:
+    module: vmware_vmkernel_ip_config
+    hostname: esxi_hostname
+    username: esxi_username
+    password: esxi_password
+    vmk_name: vmk0
+    ip_address: 10.0.0.10
+    subnet_mask: 255.255.255.0
+'''
+
+try:
+    from pyVmomi import vim, vmodl
+    HAS_PYVMOMI = True
+except ImportError:
+    HAS_PYVMOMI = False
+
+
+def configure_vmkernel_ip_address(host_system, vmk_name, ip_address, subnet_mask):
+
+    host_config_manager = host_system.configManager
+    host_network_system = host_config_manager.networkSystem
+
+    for vnic in host_network_system.networkConfig.vnic:
+        if vnic.device == vmk_name:
+            spec = vnic.spec
+            if spec.ip.ipAddress != ip_address:
+                spec.ip.dhcp = False
+                spec.ip.ipAddress = ip_address
+                spec.ip.subnetMask = subnet_mask
+                host_network_system.UpdateVirtualNic(vmk_name, spec)
+                return True
+    return False
+
+
+def main():
+
+    argument_spec = vmware_argument_spec()
+    argument_spec.update(dict(vmk_name=dict(required=True, type='str'),
+                         ip_address=dict(required=True, type='str'),
+                         subnet_mask=dict(required=True, type='str')))
+
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=False)
+
+    if not HAS_PYVMOMI:
+        module.fail_json(msg='pyvmomi is required for this module')
+
+    vmk_name = module.params['vmk_name']
+    ip_address = module.params['ip_address']
+    subnet_mask = module.params['subnet_mask']
+
+    try:
+        content = connect_to_api(module, False)
+        host = get_all_objs(content, [vim.HostSystem])
+        if not host:
+            module.fail_json(msg="Unable to locate Physical Host.")
+        host_system = host.keys()[0]
+        changed = configure_vmkernel_ip_address(host_system, vmk_name, ip_address, subnet_mask)
+        module.exit_json(changed=changed)
+    except vmodl.RuntimeFault as runtime_fault:
+        module.fail_json(msg=runtime_fault.msg)
+    except vmodl.MethodFault as method_fault:
+        module.fail_json(msg=method_fault.msg)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+from ansible.module_utils.vmware import *
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR includes a new module for VMware vSphere to configure the IP address of a VMware vmkernel interface.

We have an end-to-end playbook that performs bare metal provisioning and configuration of vSphere.
The playbooks/tasks and results from that testing is what will be listed in this PR.
If there are any questions please let either @jcpowermac or @mtnbikenc know.

Tested with version

```
$ ansible-playbook --version
ansible-playbook 1.9.2
  configured module search path = None
```

Associated tasks used for testing below

```
    - name: Configure static PXE Network IP on host
      local_action:
        module: vmware_vmkernel_ip_config
        hostname: "{{ active_model.node_ip }}"
        username: "{{ esxi_username }}"
        password: "{{ site_passwd }}"
        vmk_name: vmk0
        ip_address: "{{ pxe_ip_address }}"
        subnet_mask: "{{ pxe_subnet_mask }}"
```

Verbose testing output and results

```
TASK: [Configure static PXE Network IP on host] *******************************
<127.0.0.1> REMOTE_MODULE vmware_vmkernel_ip_config ip_address=172.17.16.15 password=VALUE_HIDDEN subnet_mask=255.255.255.0 hostname=172.17.16.24 vmk_name=vmk0 username=root
<127.0.0.1> REMOTE_MODULE vmware_vmkernel_ip_config ip_address=172.17.16.17 password=VALUE_HIDDEN subnet_mask=255.255.255.0 hostname=172.17.16.44 vmk_name=vmk0 username=root
<127.0.0.1> REMOTE_MODULE vmware_vmkernel_ip_config ip_address=172.17.16.16 password=VALUE_HIDDEN subnet_mask=255.255.255.0 hostname=172.17.16.48 vmk_name=vmk0 username=root
changed: [foundation-esxi-01 -> 127.0.0.1] => {"changed": true}
changed: [foundation-esxi-03 -> 127.0.0.1] => {"changed": true}
changed: [foundation-esxi-02 -> 127.0.0.1] => {"changed": true}
```
