### PR TITLE
Fix capitalization in nagios 'services' parameter comment

### DIFF
--- a/monitoring/nagios.py
+++ b/monitoring/nagios.py
@@ -76,7 +76,7 @@ options:
   servicegroup:
     version_added: "2.0"
     description:
-      - the Servicegroup we want to set downtimes/alerts for.
+      - The Servicegroup we want to set downtimes/alerts for.
         B(Required) option when using the C(servicegroup_service_downtime) amd C(servicegroup_host_downtime).
   command:
     description:
@@ -86,7 +86,7 @@ options:
     required: true
     default: null
 
-author: "Tim Bielawa (@tbielawa)" 
+author: "Tim Bielawa (@tbielawa)"
 requirements: [ "Nagios" ]
 '''
 


### PR DESCRIPTION
Saw that the 'services' param comment didn't start with a Capital 'T'.

Also cleaned up a line of trailing whitespace.
