### PR TITLE
Adding check mode to bigip_facts module

### DIFF
--- a/network/f5/bigip_facts.py
+++ b/network/f5/bigip_facts.py
@@ -1576,7 +1576,8 @@ def main():
             session = dict(type='bool', default=False),
             include = dict(type='list', required=True),
             filter = dict(type='str', required=False),
-        )
+        ),
+        supports_check_mode = True
     )
 
     if not bigsuds_found:


### PR DESCRIPTION
Is there any reason not to enable check mode on this module?  This allows me to run check mode successfully against subsequent bigip modules that rely on the output of `bigip_facts`.
