### PR TITLE
Check that the current output from 'list_users' command contains a '\t'.

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -136,6 +136,9 @@ class RabbitMqUser(object):
         users = self._exec(['list_users'], True)
 
         for user_tag in users:
+            if '\t' not in user_tag:
+                continue
+
             user, tags = user_tag.split('\t')
 
             if user == self.username:


### PR DESCRIPTION
The `rabbitmqctl list_users` command will list the user's last login time
which does not include `\t` character. This is causing a ValueError exception
when attempting to split a user and its tags from the command output. This
fix will check for a `\t` in the current line of the output before splitting.
