### PR TITLE
Fix hang at creation of detached ENIs

### DIFF
--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -213,9 +213,9 @@ def create_eni(connection, module):
                 except BotoServerError as ex:
                     eni.delete()
                     raise
+                # Wait to allow creation / attachment to finish
+                wait_for_eni(eni, "attached")
             changed = True
-            # Wait to allow creation / attachment to finish
-            wait_for_eni(eni, "attached")
             eni.update()
             
     except BotoServerError as e:


### PR DESCRIPTION
`ec2_eni` currently waits forever for an ENI's `attachment.status` to be `attached` even if the ENI was specified as being created without being attached to an instance. This PR corrects the hang by only waiting for that status if `instance_id` is set.

@wimnat @evanccnyc @rickmendes
