### PR TITLE
typetalk module does not work

### DIFF
--- a/notification/typetalk.py
+++ b/notification/typetalk.py
@@ -72,14 +72,14 @@ def do_request(module, url, params, headers=None):
         raise exc
     return r
 
-def get_access_token(client_id, client_secret):
+def get_access_token(module, client_id, client_secret):
     params = {
         'client_id': client_id,
         'client_secret': client_secret,
         'grant_type': 'client_credentials',
         'scope': 'topic.post'
     }
-    res = do_request('https://typetalk.in/oauth2/access_token', params)
+    res = do_request(module, 'https://typetalk.in/oauth2/access_token', params)
     return json.load(res)['access_token']
 
 
@@ -88,7 +88,7 @@ def send_message(module, client_id, client_secret, topic, msg):
     send message to typetalk
     """
     try:
-        access_token = get_access_token(client_id, client_secret)
+        access_token = get_access_token(module, client_id, client_secret)
         url = 'https://typetalk.in/api/v1/topics/%d' % topic
         headers = {
             'Authorization': 'Bearer %s' % access_token,


### PR DESCRIPTION
not enough arguments.

```
Traceback (most recent call last):
  File "<stdin>", line 2514, in <module>
  File "<stdin>", line 122, in main
  File "<stdin>", line 91, in send_message
  File "<stdin>", line 82, in get_access_token
TypeError: do_request() takes at least 3 arguments (2 given)
```
