### PR TITLE
cloudstack: fix templates not always have checksums

### DIFF
--- a/cloud/cloudstack/cs_template.py
+++ b/cloud/cloudstack/cs_template.py
@@ -501,7 +501,7 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
                 return templates['template'][0]
             else:
                 for i in templates['template']:
-                    if i['checksum'] == checksum:
+                    if 'checksum' in i and i['checksum'] == checksum:
                         return i
         return None
 


### PR DESCRIPTION
It is not documented but it seems only registered templates have checksums. Templates created from VMs and snapshot don't.

This change fixes the traceback. But we must re-thinking, if it still makes sense to look for the checksum.
