### PR TITLE
cloudstack: cs_account improvements

### DIFF
--- a/cloud/cloudstack/cs_account.py
+++ b/cloud/cloudstack/cs_account.py
@@ -85,9 +85,10 @@ options:
   state:
     description:
       - State of the account.
+      - C(unlocked) is an alias for C(enabled).
     required: false
     default: 'present'
-    choices: [ 'present', 'absent', 'enabled', 'disabled', 'locked' ]
+    choices: [ 'present', 'absent', 'enabled', 'disabled', 'locked', 'unlocked' ]
   poll_async:
     description:
       - Poll async jobs until job has finished.
@@ -350,7 +351,7 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True),
-            state = dict(choices=['present', 'absent', 'enabled', 'disabled', 'locked' ], default='present'),
+            state = dict(choices=['present', 'absent', 'enabled', 'disabled', 'locked', 'unlocked'], default='present'),
             account_type = dict(choices=['user', 'root_admin', 'domain_admin'], default='user'),
             network_domain = dict(default=None),
             domain = dict(default='ROOT'),
@@ -385,7 +386,7 @@ def main():
         if state in ['absent']:
             account = acs_acc.absent_account()
 
-        elif state in ['enabled']:
+        elif state in ['enabled', 'unlocked']:
             account = acs_acc.enable_account()
 
         elif state in ['disabled']:

--- a/cloud/cloudstack/cs_account.py
+++ b/cloud/cloudstack/cs_account.py
@@ -277,21 +277,16 @@ class AnsibleCloudStackAccount(AnsibleCloudStack):
     def present_account(self):
         missing_params = []
 
-        if not self.module.params.get('email'):
-            missing_params.append('email')
-
-        if not self.module.params.get('username'):
-            missing_params.append('username')
-
-        if not self.module.params.get('password'):
-            missing_params.append('password')
-
-        if not self.module.params.get('first_name'):
-            missing_params.append('first_name')
-
-        if not self.module.params.get('last_name'):
-            missing_params.append('last_name')
-
+        missing_params = []
+        for required_params in [
+            'email',
+            'username',
+            'password',
+            'first_name',
+            'last_name',
+        ]:
+            if not self.module.params.get(required_params):
+                missing_params.append(required_params)
         if missing_params:
             self.module.fail_json(msg="missing required arguments: %s" % ','.join(missing_params))
 

--- a/cloud/cloudstack/cs_account.py
+++ b/cloud/cloudstack/cs_account.py
@@ -221,7 +221,7 @@ class AnsibleCloudStackAccount(AnsibleCloudStack):
     def enable_account(self):
         account = self.get_account()
         if not account:
-            self.module.fail_json(msg="Failed: account not present")
+            account = self.present_account()
 
         if account['state'].lower() != 'enabled':
             self.result['changed'] = True
@@ -248,7 +248,7 @@ class AnsibleCloudStackAccount(AnsibleCloudStack):
     def lock_or_disable_account(self, lock=False):
         account = self.get_account()
         if not account:
-            self.module.fail_json(msg="Failed: account not present")
+            account = self.present_account()
 
         # we need to enable the account to lock it.
         if lock and account['state'].lower() == 'disabled':


### PR DESCRIPTION
Identical handling of states as in `cs_user` https://github.com/ansible/ansible-modules-extras/pull/941

Integration tests passed.
