### PR TITLE
Ensure tag values get updated in ec2_vpc_subnet

### DIFF
--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -163,7 +163,7 @@ def ensure_tags(vpc_conn, resource_id, tags, add_only, check_mode):
         if to_delete and not add_only:
             vpc_conn.delete_tags(resource_id, to_delete, dry_run=check_mode)
 
-        to_add = dict((k, tags[k]) for k in tags if k not in cur_tags)
+        to_add = dict((k, tags[k]) for k in tags if k not in cur_tags or cur_tags[k] != tags[k])
         if to_add:
             vpc_conn.create_tags(resource_id, to_add, dry_run=check_mode)
 


### PR DESCRIPTION
This minor fix ensures that tag values are updated for a VPC subnet, when tags already exist but the values differ. Previously, if you updated a tag value, the module would report a change but the value would not be updated.

For example, if you were to run the following task, then update either the `Name` or `env` tags, and run it again, would report that the subnet was updated but the tag values would stay the same.

``` yaml
- ec2_vpc_subnet:
    region: us-west-2
    az: us-west-2a
    cidr: 10.0.1.0/24
    state: present
    tags:
      Name: "my subnet"
      env: "production"
    vpc_id: vpc-12345678
```

Mentioning @erydo as the module author
