### PR TITLE
Fix errors in sensu_check

### DIFF
--- a/monitoring/sensu_check.py
+++ b/monitoring/sensu_check.py
@@ -186,7 +186,7 @@ def sensu_check(module, path, name, state='present', backup=False):
     try:
         try:
             stream = open(path, 'r')
-            config = json.load(stream.read())
+            config = json.load(stream)
         except IOError, e:
             if e.errno is 2:  # File not found, non-fatal
                 if state == 'absent':

--- a/monitoring/sensu_check.py
+++ b/monitoring/sensu_check.py
@@ -182,6 +182,7 @@ def sensu_check(module, path, name, state='present', backup=False):
     except ImportError:
         import simplejson as json
 
+    stream = None
     try:
         try:
             stream = open(path, 'r')


### PR DESCRIPTION
Fixes `UnboundLocalError: local variable 'stream' referenced before assignment` when the check path doesn't exist, and `AttributeError: 'str' object has no attribute 'read'` when the path _does_ exist
