### PR TITLE
Fix argument type for zabbix_screen

### DIFF
--- a/monitoring/zabbix_screen.py
+++ b/monitoring/zabbix_screen.py
@@ -319,7 +319,7 @@ def main():
             login_user=dict(required=True),
             login_password=dict(required=True, no_log=True),
             timeout=dict(type='int', default=10),
-            screens=dict(type='dict', required=True)
+            screens=dict(type='list', required=True)
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
It looks like the `screens` parameter in `zabbix_screen.py` requires `list` type, not `dict`. And also this is written in [the example doc section](https://github.com/ansible/ansible-modules-extras/blob/devel/monitoring/zabbix_screen.py#L67).

My test environment is here.
- mysql.yml

``` yaml
- name: Register MySQL screen
  zabbix_screen:
    server_url: <server_url>
    login_user: <login_user>
    login_password: <login_password>
    screens:
      - screen_name: MySQL-Test-Servers
        host_group: MySQL-Test-Servers
        state: present
        graph_names:
          - CPU Average
        graph_width: 400
        graph_height: 100
  delegate_to: localhost
  tags:
    - mysql
```
- error message

``` bash
$ ansible-playbook --version
ansible-playbook 2.0.0 (devel cc6627cdd6) last updated 2015/09/18 18:19:54 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 22d25de23c) last updated 2015/09/18 18:21:43 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 840ce26093) last updated 2015/09/18 18:22:36 (GMT +900)
<snip>
$ which python
/Users/knakayama/.pyenv/shims/python
$ python --version
Python 2.7.10
$ ansible-playbook -i hosts.ini site.yml --vault-password-file ./bin/vault-pass.sh --tags mysql -vvv -e 'ansible_python_interpreter=/Users/knakayama/.pyenv/shims/python'
Using <snip>/ansible.cfg as config file
1 plays in site.yml

PLAY [Register new servers to zabbix] ******************************************

TASK [zabbix : include] ********************************************************
included: mysql.yml for 127.0.0.1

TASK [zabbix : Register MySQL screen] ******************************************
ESTABLISH LOCAL CONNECTION FOR USER: None
localhost EXEC (umask 22 && mkdir -p "$HOME/.ansible/tmp/ansible-tmp-1442740163.23-159118074575081" && echo "$HOME/.ansible/tmp/ansible-tmp-1442740163.23-159118074575081")
localhost PUT /var/folders/dj/mhrchhn16zz9cg1hrv1y2y7w0000gp/T/tmplP9Tlc TO /Users/knakayama/.ansible/tmp/ansible-tmp-1442740163.23-159118074575081/zabbix_screen
localhost EXEC LANG=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /Users/knakayama/.pyenv/shims/python /Users/knakayama/.ansible/tmp/ansible-tmp-1442740163.23-159118074575081/zabbix_screen; rm -rf "/Users/knakayama/.ansible/tmp/ansible-tmp-1442740163.23-159118074575081/" > /dev/null 2>&1
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "argument screens is of type <type 'list'> and we were unable to convert to dict"}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=1    changed=0    unreachable=0    failed=1
```
