### PR TITLE
Backport pacman updates to 1.9 [take 2]

### DIFF
--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -76,7 +76,7 @@ EXAMPLES = '''
 # Recursively remove package baz
 - pacman: name=baz state=absent recurse=yes
 
-# Run the equivalent of "pacman -Syy" as a separate step
+# Run the equivalent of "pacman -Sy" as a separate step
 - pacman: update_cache=yes
 '''
 
@@ -122,7 +122,7 @@ def query_package(module, name, state="present"):
 
 
 def update_package_db(module):
-    cmd = "pacman -Syy"
+    cmd = "pacman -Sy"
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
     if rc == 0:

--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -61,6 +61,13 @@ options:
         required: false
         default: "no"
         choices: ["yes", "no"]
+
+    upgrade
+        description:
+            - Whether or not to upgrade whole system
+        required: false
+        default: "no"
+        choices: ["yes", "no"]
 '''
 
 EXAMPLES = '''
@@ -78,6 +85,9 @@ EXAMPLES = '''
 
 # Run the equivalent of "pacman -Sy" as a separate step
 - pacman: update_cache=yes
+
+# Run the equivalent of "pacman -Su" as a separate step
+- pacman: upgrade=yes
 '''
 
 import json
@@ -130,6 +140,27 @@ def update_package_db(module):
     else:
         module.fail_json(msg="could not update package db")
 
+def upgrade(module):
+    cmdupgrade = "pacman -Suq --noconfirm"
+    cmdneedrefresh = "pacman -Supq"
+    rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
+
+def upgrade(module):
+    cmdupgrade = "pacman -Suq --noconfirm"
+    cmdneedrefresh = "pacman -Supq"
+    rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
+
+    if rc == 0:
+        if stdout.count('\n') > 1:
+            rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
+            if rc == 0:
+                module.exit_json(changed=True, msg='System upgraded')
+            else:
+                module.fail_json(msg="could not upgrade")
+        else:
+            module.exit_json(changed=False, msg='Nothing to upgrade')
+    else:
+        module.fail_json(msg="could not list upgrades")
 
 def remove_packages(module, packages):
     if module.params["recurse"]:
@@ -211,8 +242,9 @@ def main():
             name         = dict(aliases=['pkg']),
             state        = dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
             recurse      = dict(default='no', choices=BOOLEANS, type='bool'),
+            upgrade      = dict(default='no', choices=BOOLEANS, type='bool'),
             update_cache = dict(default='no', aliases=['update-cache'], choices=BOOLEANS, type='bool')),
-        required_one_of = [['name', 'update_cache']],
+        required_one_of = [['name', 'update_cache', 'upgrade']],
         supports_check_mode = True)
 
     if not os.path.exists(PACMAN_PATH):
@@ -233,6 +265,9 @@ def main():
 
     if p['update_cache'] and module.check_mode and not p['name']:
         module.exit_json(changed=True, msg='Would have updated the package cache')
+
+    if p['upgrade']:
+        upgrade(module)
 
     if p['name']:
         pkgs = p['name'].split(',')

--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -148,11 +148,14 @@ def upgrade(module, pacman_path):
     rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
 
     if rc == 0:
+        if module.check_mode:
+            data = stdout.split('\n')
+            module.exit_json(changed=True, msg="%s package(s) would be upgraded" % len(data))
         rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
         if rc == 0:
             module.exit_json(changed=True, msg='System upgraded')
         else:
-            module.fail_json(msg="could not upgrade")
+            module.fail_json(msg="Could not upgrade")
     else:
         module.exit_json(changed=False, msg='Nothing to upgrade')
 
@@ -256,10 +259,10 @@ def main():
 
     if p["update_cache"] and not module.check_mode:
         update_package_db(module, pacman_path)
-        if not p['name']:
-            module.exit_json(changed=True, msg='updated the package master lists')
+        if not (p['name'] or p['upgrade']):
+            module.exit_json(changed=True, msg='Updated the package master lists')
 
-    if p['update_cache'] and module.check_mode and not p['name']:
+    if p['update_cache'] and module.check_mode and not (p['name'] or p['upgrade']):
         module.exit_json(changed=True, msg='Would have updated the package cache')
 
     if p['upgrade']:

--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -3,6 +3,7 @@
 
 # (c) 2012, Afterburn <http://github.com/afterburn>
 # (c) 2013, Aaron Bull Schaefer <aaron@elasticdog.com>
+# (c) 2015, Indrajit Raychaudhuri <irc+code@indrajit.com>
 #
 # This file is part of Ansible
 #
@@ -27,7 +28,10 @@ description:
     - Manage packages with the I(pacman) package manager, which is used by
       Arch Linux and its variants.
 version_added: "1.0"
-author: Afterburn
+author:
+    - "Indrajit Raychaudhuri (@indrajitr)"
+    - "'Aaron Bull Schaefer (@elasticdog)' <aaron@elasticdog.com>"
+    - "Afterburn"
 notes: []
 requirements: []
 options:
@@ -50,7 +54,7 @@ options:
               that they are not required by other packages and were not
               explicitly installed by a user.
         required: false
-        default: "no"
+        default: no
         choices: ["yes", "no"]
         version_added: "1.3"
 
@@ -59,14 +63,14 @@ options:
             - Whether or not to refresh the master package lists. This can be
               run as part of a package installation or as a separate step.
         required: false
-        default: "no"
+        default: no
         choices: ["yes", "no"]
 
     upgrade
         description:
             - Whether or not to upgrade whole system
         required: false
-        default: "no"
+        default: no
         choices: ["yes", "no"]
 '''
 
@@ -231,9 +235,9 @@ def main():
         argument_spec    = dict(
             name         = dict(aliases=['pkg']),
             state        = dict(default='present', choices=['present', 'installed', "latest", 'absent', 'removed']),
-            recurse      = dict(default='no', choices=BOOLEANS, type='bool'),
-            upgrade      = dict(default='no', choices=BOOLEANS, type='bool'),
-            update_cache = dict(default='no', aliases=['update-cache'], choices=BOOLEANS, type='bool')),
+            recurse      = dict(default=False, type='bool'),
+            upgrade      = dict(default=False, type='bool'),
+            update_cache = dict(default=False, aliases=['update-cache'], type='bool')),
         required_one_of = [['name', 'update_cache', 'upgrade']],
         supports_check_mode = True)
 

--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -96,8 +96,6 @@ import os
 import re
 import sys
 
-PACMAN_PATH = "/usr/bin/pacman"
-
 def get_version(pacman_output):
     """Take pacman -Qi or pacman -Si output and get the Version"""
     lines = pacman_output.split('\n')
@@ -106,19 +104,19 @@ def get_version(pacman_output):
             return line.split(':')[1].strip()
     return None
 
-def query_package(module, name, state="present"):
+def query_package(module, pacman_path, name, state="present"):
     """Query the package status in both the local system and the repository. Returns a boolean to indicate if the package is installed, and a second boolean to indicate if the package is up-to-date."""
     if state == "present":
-        lcmd = "pacman -Qi %s" % (name)
+        lcmd = "%s -Qi %s" % (pacman_path, name)
         lrc, lstdout, lstderr = module.run_command(lcmd, check_rc=False)
         if lrc != 0:
             # package is not installed locally
             return False, False
-        
+
         # get the version installed locally (if any)
         lversion = get_version(lstdout)
-        
-        rcmd = "pacman -Si %s" % (name)
+
+        rcmd = "%s -Si %s" % (pacman_path, name)
         rrc, rstdout, rstderr = module.run_command(rcmd, check_rc=False)
         # get the version in the repository
         rversion = get_version(rstdout)
@@ -131,8 +129,8 @@ def query_package(module, name, state="present"):
         return False, False
 
 
-def update_package_db(module):
-    cmd = "pacman -Sy"
+def update_package_db(module, pacman_path):
+    cmd = "%s -Sy" % (pacman_path)
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
     if rc == 0:
@@ -140,29 +138,21 @@ def update_package_db(module):
     else:
         module.fail_json(msg="could not update package db")
 
-def upgrade(module):
-    cmdupgrade = "pacman -Suq --noconfirm"
-    cmdneedrefresh = "pacman -Supq"
-    rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
-
-def upgrade(module):
-    cmdupgrade = "pacman -Suq --noconfirm"
-    cmdneedrefresh = "pacman -Supq"
+def upgrade(module, pacman_path):
+    cmdupgrade = "%s -Suq --noconfirm" % (pacman_path)
+    cmdneedrefresh = "%s -Qqu" % (pacman_path)
     rc, stdout, stderr = module.run_command(cmdneedrefresh, check_rc=False)
 
     if rc == 0:
-        if stdout.count('\n') > 1:
-            rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
-            if rc == 0:
-                module.exit_json(changed=True, msg='System upgraded')
-            else:
-                module.fail_json(msg="could not upgrade")
+        rc, stdout, stderr = module.run_command(cmdupgrade, check_rc=False)
+        if rc == 0:
+            module.exit_json(changed=True, msg='System upgraded')
         else:
-            module.exit_json(changed=False, msg='Nothing to upgrade')
+            module.fail_json(msg="could not upgrade")
     else:
-        module.fail_json(msg="could not list upgrades")
+        module.exit_json(changed=False, msg='Nothing to upgrade')
 
-def remove_packages(module, packages):
+def remove_packages(module, pacman_path, packages):
     if module.params["recurse"]:
         args = "Rs"
     else:
@@ -172,11 +162,11 @@ def remove_packages(module, packages):
     # Using a for loop incase of error, we can report the package that failed
     for package in packages:
         # Query the package first, to see if we even need to remove
-        installed, updated = query_package(module, package)
+        installed, updated = query_package(module, pacman_path, package)
         if not installed:
             continue
 
-        cmd = "pacman -%s %s --noconfirm" % (args, package)
+        cmd = "%s -%s %s --noconfirm" % (pacman_path, args, package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:
@@ -191,12 +181,12 @@ def remove_packages(module, packages):
     module.exit_json(changed=False, msg="package(s) already absent")
 
 
-def install_packages(module, state, packages, package_files):
+def install_packages(module, pacman_path, state, packages, package_files):
     install_c = 0
 
     for i, package in enumerate(packages):
         # if the package is installed and state == present or state == latest and is up-to-date then skip
-        installed, updated = query_package(module, package)
+        installed, updated = query_package(module, pacman_path, package)
         if installed and (state == 'present' or (state == 'latest' and updated)):
             continue
 
@@ -205,7 +195,7 @@ def install_packages(module, state, packages, package_files):
         else:
             params = '-S %s' % package
 
-        cmd = "pacman %s --noconfirm" % (params)
+        cmd = "%s %s --noconfirm" % (pacman_path, params)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:
@@ -219,10 +209,10 @@ def install_packages(module, state, packages, package_files):
     module.exit_json(changed=False, msg="package(s) already installed")
 
 
-def check_packages(module, packages, state):
+def check_packages(module, pacman_path, packages, state):
     would_be_changed = []
     for package in packages:
-        installed, updated = query_package(module, package)
+        installed, updated = query_package(module, pacman_path, package)
         if ((state in ["present", "latest"] and not installed) or
                 (state == "absent" and installed) or
                 (state == "latest" and not updated)):
@@ -247,8 +237,10 @@ def main():
         required_one_of = [['name', 'update_cache', 'upgrade']],
         supports_check_mode = True)
 
-    if not os.path.exists(PACMAN_PATH):
-        module.fail_json(msg="cannot find pacman, looking for %s" % (PACMAN_PATH))
+    pacman_path = module.get_bin_path('pacman', True)
+
+    if not os.path.exists(pacman_path):
+        module.fail_json(msg="cannot find pacman, in path %s" % (pacman_path))
 
     p = module.params
 
@@ -259,7 +251,7 @@ def main():
         p['state'] = 'absent'
 
     if p["update_cache"] and not module.check_mode:
-        update_package_db(module)
+        update_package_db(module, pacman_path)
         if not p['name']:
             module.exit_json(changed=True, msg='updated the package master lists')
 
@@ -267,7 +259,7 @@ def main():
         module.exit_json(changed=True, msg='Would have updated the package cache')
 
     if p['upgrade']:
-        upgrade(module)
+        upgrade(module, pacman_path)
 
     if p['name']:
         pkgs = p['name'].split(',')
@@ -283,14 +275,15 @@ def main():
                 pkg_files.append(None)
 
         if module.check_mode:
-            check_packages(module, pkgs, p['state'])
+            check_packages(module, pacman_path, pkgs, p['state'])
 
         if p['state'] in ['present', 'latest']:
-            install_packages(module, p['state'], pkgs, pkg_files)
+            install_packages(module, pacman_path, p['state'], pkgs, pkg_files)
         elif p['state'] == 'absent':
-            remove_packages(module, pkgs)
+            remove_packages(module, pacman_path, pkgs)
 
 # import module snippets
 from ansible.module_utils.basic import *
-    
-main()        
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
~~Backport pacman PRs #1037 to stable-1.9.
Please apply this __after__ #1028.~~
Backport selective pacman PRs #480, #762, #807, #1018 to stable-1.9.
This __replaces__ #1028.

NB: Description updated based on feedback in (https://github.com/ansible/ansible-modules-extras/pull/1038#issuecomment-143894698).
