### PR TITLE
Allow relative path for bower executable

### DIFF
--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -51,6 +51,7 @@ options:
   localexec:
     description:
       - Relative path to bower executable from install path
+    default: false
     required: false
   state:
     description:
@@ -176,7 +177,7 @@ def main():
         offline=dict(default='no', type='bool'),
         production=dict(default='no', type='bool'),
         path=dict(required=True),
-        localexec=dict(required=False),
+        localexec=dict(default=False, required=False),
         state=dict(default='present', choices=['present', 'absent', 'latest', ]),
         version=dict(default=None),
     )

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -103,9 +103,9 @@ class Bower(object):
             cmd = []
 
             if self.relative_execpath:
-                if not os.path.isdir(os.path.join(self.path, self.relative_execpath)):
-                    self.module.fail_json(msg="relative path %s is not a directory" % self.relative_execpath)
                 cmd.append(os.path.join(self.path, self.relative_execpath, "bower"))
+                if not os.path.isfile(cmd[-1]):
+                    self.module.fail_json(msg="bower not found at relative path %s" % self.relative_execpath)
             else:
                 cmd.append("bower")
 

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -80,6 +80,10 @@ description: Install packages based on bower.json.
 
 description: Update packages based on bower.json to their latest version.
 - bower: path=/app/location state=latest
+
+description: install bower locally and run from there
+- npm: path=/app/location name=bower global=no
+- bower: path=/app/location localexec=node_modules/.bin
 '''
 
 

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -51,7 +51,7 @@ options:
   relative_execpath:
     description:
       - Relative path to bower executable from install path
-    default: false
+    default: null
     required: false
   state:
     description:

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -53,6 +53,7 @@ options:
       - Relative path to bower executable from install path
     default: null
     required: false
+    version_added: "2.0"
   state:
     description:
       - The state of the bower package

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -48,7 +48,7 @@ options:
     description:
       - The base path where to install the bower packages
     required: true
-  localexec:
+  relative_execpath:
     description:
       - Relative path to bower executable from install path
     default: false
@@ -90,7 +90,7 @@ class Bower(object):
         self.offline = kwargs['offline']
         self.production = kwargs['production']
         self.path = kwargs['path']
-        self.localexec = kwargs['localexec']
+        self.relative_execpath = kwargs['relative_execpath']
         self.version = kwargs['version']
 
         if kwargs['version']:
@@ -102,10 +102,10 @@ class Bower(object):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
             cmd = []
 
-            if self.localexec:
-                if not os.path.isdir(os.path.join(self.path, self.localexec)):
-                    self.module.fail_json(msg="relative path %s is not a directory" % self.localexec)
-                cmd.append(os.path.join(self.path, self.localexec, "bower"))
+            if self.relative_execpath:
+                if not os.path.isdir(os.path.join(self.path, self.relative_execpath)):
+                    self.module.fail_json(msg="relative path %s is not a directory" % self.relative_execpath)
+                cmd.append(os.path.join(self.path, self.relative_execpath, "bower"))
             else:
                 cmd.append("bower")
 
@@ -177,7 +177,7 @@ def main():
         offline=dict(default='no', type='bool'),
         production=dict(default='no', type='bool'),
         path=dict(required=True),
-        localexec=dict(default=False, required=False),
+        relative_execpath=dict(default=False, required=False),
         state=dict(default='present', choices=['present', 'absent', 'latest', ]),
         version=dict(default=None),
     )
@@ -189,14 +189,14 @@ def main():
     offline = module.params['offline']
     production = module.params['production']
     path = os.path.expanduser(module.params['path'])
-    localexec = os.path.expanduser(module.params['localexec'])
+    relative_execpath = os.path.expanduser(module.params['relative_execpath'])
     state = module.params['state']
     version = module.params['version']
 
     if state == 'absent' and not name:
         module.fail_json(msg='uninstalling a package is only available for named packages')
 
-    bower = Bower(module, name=name, offline=offline, production=production, path=path, localexec=localexec, version=version)
+    bower = Bower(module, name=name, offline=offline, production=production, path=path, relative_execpath=relative_execpath, version=version)
 
     changed = False
     if state == 'present':

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -193,7 +193,7 @@ def main():
     offline = module.params['offline']
     production = module.params['production']
     path = os.path.expanduser(module.params['path'])
-    relative_execpath = os.path.expanduser(module.params['relative_execpath'])
+    relative_execpath = module.params['relative_execpath']
     state = module.params['state']
     version = module.params['version']
 

--- a/packaging/language/bower.py
+++ b/packaging/language/bower.py
@@ -83,7 +83,7 @@ description: Update packages based on bower.json to their latest version.
 
 description: install bower locally and run from there
 - npm: path=/app/location name=bower global=no
-- bower: path=/app/location localexec=node_modules/.bin
+- bower: path=/app/location relative_execpath=node_modules/.bin
 '''
 
 


### PR DESCRIPTION
When bower is installed locally with the npm module, the binary is not globally accessible. This PR allows to specify a relative path to bower executable from the directory where bower packages will be installed.
