### PR TITLE
Check mode support for VPC route table creation

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -496,13 +496,13 @@ def ensure_route_table_present(connection, module):
         
     # If no route table returned then create new route table
     if route_table is None:
-        if module.check_mode:
-            module.exit_json(changed=True)
-
         try:
-            route_table = connection.create_route_table(vpc_id)
+            route_table = connection.create_route_table(vpc_id, module.check_mode)
             changed = True
-        except EC2ResponseError, e:
+        except EC2ResponseError as e:
+            if e.error_code == 'DryRunOperation':
+                module.exit_json(changed=True)
+
             module.fail_json(msg=e.message)
         
     if routes is not None:

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -496,8 +496,11 @@ def ensure_route_table_present(connection, module):
         
     # If no route table returned then create new route table
     if route_table is None:
+        if module.check_mode:
+            module.exit_json(changed=True)
+
         try:
-            route_table = connection.create_route_table(vpc_id, check_mode)
+            route_table = connection.create_route_table(vpc_id)
             changed = True
         except EC2ResponseError, e:
             module.fail_json(msg=e.message)


### PR DESCRIPTION
The existing check_mode flag on `create_route_table` triggers and error when sent.  This instead sets `changed` and exits the module if the route table does not already exist.
