### PR TITLE
znode requires a minimum of python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       - python2.4
       - python2.6
 script:
-  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/consul.*\.py|notification/pushbullet\.py' .
+  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
   #- ./test-docs.sh extras

--- a/clustering/znode.py
+++ b/clustering/znode.py
@@ -52,6 +52,7 @@ options:
         required: false
 requirements:
     - kazoo >= 2.1
+    - python >= 2.6
 author: "Trey Perry (@treyperry)"
 """
 


### PR DESCRIPTION
the znode module has a dependency on kazoo which requires a minimum python version of 2.6.  Update the requirements accordingly, and exclude from travis python24 tests.
