### PR TITLE
system: pam_limits: add support for unlimited/infinity/-1

### DIFF
--- a/system/pam_limits.py
+++ b/system/pam_limits.py
@@ -102,7 +102,7 @@ def main():
             domain            = dict(required=True, type='str'),
             limit_type        = dict(required=True, type='str', choices=pam_types),
             limit_item        = dict(required=True, type='str', choices=pam_items),
-            value             = dict(required=True, type='int'),
+            value             = dict(required=True, type='str'),
             use_max           = dict(default=False, type='bool'),
             use_min           = dict(default=False, type='bool'),
             backup            = dict(default=False, type='bool'),
@@ -131,6 +131,9 @@ def main():
 
     if use_max and use_min:
         module.fail_json(msg="Cannot use use_min and use_max at the same time." )
+
+    if not (value in ['unlimited', 'infinity', '-1'] or value.isdigit()):
+        module.fail_json(msg="Argument 'value' can be one of 'unlimited', 'infinity', '-1' or positive number. Refer to manual pages for more details.")
 
     # Backup
     if backup:
@@ -181,7 +184,10 @@ def main():
         line_domain     = line_fields[0]
         line_type       = line_fields[1]
         line_item       = line_fields[2]
-        actual_value    = int(line_fields[3])
+        actual_value    = line_fields[3]
+
+        if not (actual_value in ['unlimited', 'infinity', '-1'] or actual_value.isdigit()):
+            module.fail_json(msg="Invalid configuration of '%s'. Current value of %s is unsupported." % (limits_conf, line_item))
 
         # Found the line
         if line_domain == domain and line_type == limit_type and line_item == limit_item:
@@ -191,11 +197,24 @@ def main():
                 nf.write(line)
                 continue
 
+            actual_value_unlimited = actual_value in ['unlimited', 'infinity', '-1']
+            value_unlimited = value in ['unlimited', 'infinity', '-1']
+
             if use_max:
-                new_value = max(value, actual_value)
+                if value.isdigit() and actual_value.isdigit():
+                    new_value = max(int(value), int(actual_value))
+                elif actual_value_unlimited:
+                    new_value = actual_value
+                else:
+                    new_value = value
 
             if use_min:
-                new_value = min(value,actual_value)
+                if value.isdigit() and actual_value.isdigit():
+                    new_value = min(int(value), int(actual_value))
+                elif value_unlimited:
+                    new_value = actual_value
+                else:
+                    new_value = value
 
             # Change line only if value has changed
             if new_value != actual_value:


### PR DESCRIPTION
Early pam_limits module didn't support special values for items.
This patch is adding support to special values unlimited, infinity and -1.

Issue: https://github.com/ansible/ansible-modules-extras/issues/1033
Signed-off-by: Ondra Machacek machacek.ondra@gmail.com
