### PR TITLE
homebrew: Add explicit documentation for 'path' argument (with expected default)

### DIFF
--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -69,10 +69,22 @@ options:
 notes:  []
 '''
 EXAMPLES = '''
+# Install formula foo with 'brew' in default path (C(/usr/local/bin))
 - homebrew: name=foo state=present
+
+# Install formula foo with 'brew' in alternate path C(/my/other/location/bin)
+- homebrew: name=foo path=/my/other/location/bin state=present
+
+# Update homebrew first and install formula foo with 'brew' in default path
 - homebrew: name=foo state=present update_homebrew=yes
+
+# Update homebrew first and upgrade formula foo to latest available with 'brew' in default path
 - homebrew: name=foo state=latest update_homebrew=yes
+
+# Update homebrew and upgrade all packages
 - homebrew: update_homebrew=yes upgrade_all=yes
+
+# Miscellaneous other examples
 - homebrew: name=foo state=head
 - homebrew: name=foo state=linked
 - homebrew: name=foo state=absent

--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -37,6 +37,11 @@ options:
             - name of package to install/remove
         required: false
         default: None
+    path:
+        description:
+            - ':' separated list of paths to search for 'brew' executable. Since A package (I(formula) in homebrew parlance) location is prefixed relative to the actual path of I(brew) command, providing an alternative I(brew) path enables managing different set of packages in an alternative location in the system.
+        required: false
+        default: '/usr/local/bin'
     state:
         description:
             - state of the package
@@ -303,7 +308,7 @@ class Homebrew(object):
             return package
     # /class properties -------------------------------------------- }}}
 
-    def __init__(self, module, path=None, packages=None, state=None,
+    def __init__(self, module, path, packages=None, state=None,
                  update_homebrew=False, upgrade_all=False,
                  install_options=None):
         if not install_options:
@@ -329,12 +334,7 @@ class Homebrew(object):
             setattr(self, key, val)
 
     def _prep(self):
-        self._prep_path()
         self._prep_brew_path()
-
-    def _prep_path(self):
-        if not self.path:
-            self.path = ['/usr/local/bin']
 
     def _prep_brew_path(self):
         if not self.module:
@@ -770,7 +770,10 @@ def main():
                 required=False,
                 type='list',
             ),
-            path=dict(required=False),
+            path=dict(
+                default="/usr/local/bin",
+                required=False,
+            ),
             state=dict(
                 default="present",
                 choices=[
@@ -808,8 +811,6 @@ def main():
     path = p['path']
     if path:
         path = path.split(':')
-    else:
-        path = ['/usr/local/bin']
 
     state = p['state']
     if state in ('present', 'installed'):


### PR DESCRIPTION
In Homebew, a formula is installed in a location relative to the actual
`brew` command. The documentation clarifies that.

Additionally, removed redundant 'path' reconstruction in multiple places.

See: [Homebrew documentation](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Installation.md#multiple-installations) for more.

/cc @ashmckenzie since this is related to PR #173. Would be great if you can quickly try this out.
