### PR TITLE
Fix interpreter line in a few vmware modules

### DIFF
--- a/cloud/vmware/vmware_cluster.py
+++ b/cloud/vmware/vmware_cluster.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Joseph Callen <jcallen () csc.com>

--- a/cloud/vmware/vmware_target_canonical_facts.py
+++ b/cloud/vmware/vmware_target_canonical_facts.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 # (c) 2015, Joseph Callen <jcallen () csc.com>


### PR DESCRIPTION
A few vmware modules had their interpreter line set to `/bin/python` instead of `/usr/bin/python`.

This PR addresses both of these issues.
