### PR TITLE
Switch from old style replacer code to new style for ansible.module_utils.basic

### DIFF
--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -192,7 +192,6 @@ def main():
 
     module.exit_json(ansible=data)
 
-# this is magic, see lib/ansible/module_common.py
-#<<INCLUDE_ANSIBLE_MODULE_COMMON>>
+from ansible.module_utils.basic import *
 
 main()


### PR DESCRIPTION
The `xenserver_facts` module was using the old style module replacer block.  This PR switches it over to use the new style (import) replacer.
