### PR TITLE
sys.exit removal from various modules

### DIFF
--- a/cloud/google/gce_img.py
+++ b/cloud/google/gce_img.py
@@ -201,7 +201,6 @@ def main():
     changed = delete_image(gce, name, module)
 
   module.exit_json(changed=changed, name=name)
-  sys.exit(0)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/cloud/google/gce_tag.py
+++ b/cloud/google/gce_tag.py
@@ -219,7 +219,6 @@ def main():
         changed, tags_changed = remove_tags(gce, module, instance_name, tags)
 
     module.exit_json(changed=changed, instance_name=instance_name, tags=tags_changed, zone=zone)
-    sys.exit(0)
 
 # import module snippets
 from ansible.module_utils.basic import *

--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -28,7 +28,6 @@ author:
 '''
 
 import platform
-import sys
 import XenAPI
 
 EXAMPLES = '''
@@ -75,12 +74,9 @@ class XenServerFacts:
 
 
 def get_xenapi_session():
-    try:
-        session = XenAPI.xapi_local()
-        session.xenapi.login_with_password('', '')
-        return session
-    except XenAPI.Failure:
-        sys.exit(1)
+    session = XenAPI.xapi_local()
+    session.xenapi.login_with_password('', '')
+    return session
 
 
 def get_networks(session):
@@ -163,8 +159,10 @@ def main():
     module = AnsibleModule({})
 
     obj = XenServerFacts()
-    session = get_xenapi_session()
-
+    try:
+        session = get_xenapi_session()
+    except XenAPI.Failure, e:
+        module.fail_json(msg='%s' % e)
 
     data = {
         'xenserver_version': obj.version,

--- a/notification/mail.py
+++ b/notification/mail.py
@@ -285,7 +285,6 @@ def main():
                 msg.attach(part)
             except Exception, e:
                 module.fail_json(rc=1, msg="Failed to send mail: can't attach file %s: %s" % (file, e))
-                sys.exit()
 
     composed = msg.as_string()
 

--- a/system/capabilities.py
+++ b/system/capabilities.py
@@ -180,7 +180,6 @@ def main():
 
     CapabilitiesModule(module)
 
-    sys.exit(0)
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
This PR removes calls to `sys.exit` from various modules.  Largely all that was needed was to remove the `sys.exit`.  In a few cases, `sys.exit` was being used in place of `module.fail_json`.
