### PR TITLE
Fix open_iscsi EXAMPLES section

### DIFF
--- a/system/open_iscsi.py
+++ b/system/open_iscsi.py
@@ -84,23 +84,22 @@ options:
         description:
         - whether the list of nodes in the persistent iscsi database should be
           returned by the module
+'''
 
-examples:
-    - description: perform a discovery on 10.1.2.3 and show available target
-                   nodes
-      code: >
-        open_iscsi: show_nodes=yes discover=yes portal=10.1.2.3
-    - description: discover targets on portal and login to the one available
-                   (only works if exactly one target is exported to the initiator)
-      code: >
-        open_iscsi: portal={{iscsi_target}} login=yes discover=yes
-    - description: connect to the named target, after updating the local
-                   persistent database (cache)
-      code: >
-        open_iscsi: login=yes target=iqn.1986-03.com.sun:02:f8c1f9e0-c3ec-ec84-c9c9-8bfb0cd5de3d
-    - description: discconnect from the cached named target
-      code: >
-        open_iscsi: login=no target=iqn.1986-03.com.sun:02:f8c1f9e0-c3ec-ec84-c9c9-8bfb0cd5de3d"
+EXAMPLES = '''
+# perform a discovery on 10.1.2.3 and show available target nodes
+- open_iscsi: show_nodes=yes discover=yes portal=10.1.2.3
+
+# discover targets on portal and login to the one available
+# (only works if exactly one target is exported to the initiator)
+- open_iscsi: portal={{iscsi_target}} login=yes discover=yes
+
+# description: connect to the named target, after updating the local
+# persistent database (cache)
+- open_iscsi: login=yes target=iqn.1986-03.com.sun:02:f8c1f9e0-c3ec-ec84-c9c9-8bfb0cd5de3d
+
+# description: discconnect from the cached named target
+- open_iscsi: login=no target=iqn.1986-03.com.sun:02:f8c1f9e0-c3ec-ec84-c9c9-8bfb0cd5de3d"
 '''
 
 import glob


### PR DESCRIPTION
This PR moves the examples for `open_iscsi` into an `EXAMPLES` section, and reformats to follow standards.

cc @srvg 
