### PR TITLE
Use ansible-testing project to validate basic module requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,5 @@ script:
   - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
-  - ansible-validate-modules --exclude 'cloud/amazon/route53_zone\.py|network/snmp_facts\.py|notification/sns\.py|windows/win_iis_virtualdirectory\.py' .
+  - ansible-validate-modules --exclude 'cloud/amazon/route53_zone\.py|cloud/amazon/sns_topic\.py|messaging/rabbitmq_binding\.py|messaging/rabbitmq_exchange\.py|messaging/rabbitmq_queue\.py|monitoring/circonus_annotation\.py|network/snmp_facts\.py|notification/sns\.py' .
   #- ./test-docs.sh extras

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,12 @@ addons:
     packages:
       - python2.4
       - python2.6
+install:
+  - pip install git+https://github.com/ansible/ansible.git@devel#egg=ansible
+  - pip install git+https://github.com/sivel/ansible-testing.git#egg=ansible_testing
 script:
   - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
+  - ansible-validate-modules --exclude 'cloud/amazon/route53_zone\.py|network/snmp_facts\.py|notification/sns\.py|windows/win_iis_virtualdirectory\.py' .
   #- ./test-docs.sh extras

--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -312,9 +312,9 @@ class HAProxy(object):
         Figure out what you want to do from ansible, and then do it.
         """
 
-	self.get_current_state(self.host, self.backend)
-	self.previous_states = ','.join(self.status_server)
-	self.previous_weights = ','.join(self.status_weight)
+        self.get_current_state(self.host, self.backend)
+        self.previous_states = ','.join(self.status_server)
+        self.previous_weights = ','.join(self.status_weight)
 
         # toggle enable/disbale server
         if self.state == 'enabled':

--- a/packaging/os/pkgutil.py
+++ b/packaging/os/pkgutil.py
@@ -2,8 +2,8 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Alexander Winkler <mail () winkler-alexander.de>
-# 	based on svr4pkg by
-# 		Boyd Adamson <boyd () boydadamson.com> (2012)
+# based on svr4pkg by
+#  Boyd Adamson <boyd () boydadamson.com> (2012)
 #
 # This file is part of Ansible
 #

--- a/system/iptables.py
+++ b/system/iptables.py
@@ -18,9 +18,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
-# import module snippets
-from ansible.module_utils.basic import *
-
 BINS = dict(
     ipv4='iptables',
     ipv6='ip6tables',
@@ -362,6 +359,9 @@ def main():
         remove_rule(iptables_path, module, module.params)
 
     module.exit_json(**args)
+
+# import module snippets
+from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()

--- a/system/ohai.py
+++ b/system/ohai.py
@@ -54,5 +54,3 @@ def main():
 from ansible.module_utils.basic import *
 
 main()
-
-


### PR DESCRIPTION
This PR introduces using https://github.com/sivel/ansible-testing to the extras modules.  We can look at extending to core after successful testing on extras.

As of now there are some excluded modules, as they are currently failing the checks.

There are a few PRs/Issues recently opened to address a few of the failures:

~~https://github.com/ansible/ansible-modules-extras/pull/1059~~
~~https://github.com/ansible/ansible-modules-extras/pull/1060~~
~~https://github.com/ansible/ansible-modules-extras/pull/1058~~
~~https://github.com/ansible/ansible-modules-extras/pull/1057~~
~~https://github.com/ansible/ansible-modules-extras/issues/1061~~

cc @gregdek 
