### PR TITLE
Made win_unzip Powershell Strict Complient

### DIFF
--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -19,6 +19,7 @@
 # WANT_JSON
 # POWERSHELL_COMMON
 
+
 $params = Parse-Args $args;
 
 $result = New-Object psobject @{
@@ -47,7 +48,8 @@ If (-Not (Test-Path $dest -PathType Container)){
         New-Item -itemtype directory -path $dest
     }
     Catch {
-        Fail-Json $result "Error creating $dest directory"
+        $err_msg = $_.Exception.Message
+        Fail-Json $result "Error creating $dest directory! Msg: $err_msg"
     }
 }
 
@@ -63,7 +65,8 @@ If ($ext -eq ".zip" -And $recurse -eq $false) {
         $result.changed = $true
     }
     Catch {
-        Fail-Json $result "Error unzipping $src to $dest"
+        $err_msg = $_.Exception.Message
+        Fail-Json $result "Error unzipping $src to $dest! Msg: $err_msg"
     }
 }
 # Requires PSCX
@@ -107,11 +110,12 @@ Else {
         }
     }
     Catch {
+        $err_msg = $_.Exception.Message
         If ($recurse) {
-            Fail-Json $result "Error recursively expanding $src to $dest"
+            Fail-Json $result "Error recursively expanding $src to $dest! Msg: $err_msg"
         }
         Else {
-            Fail-Json $result "Error expanding $src to $dest"
+            Fail-Json $result "Error expanding $src to $dest! Msg: $err_msg"
         }
     }
 }

--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -26,14 +26,14 @@ $result = New-Object psobject @{
     changed = $false
 }
 
-If ($params.creates) {
+If (Get-Member -InputObject $params -Name creates) {
     If (Test-Path $params.creates) {
         Exit-Json $result "The 'creates' file or directory already exists."
     }
 
 }
 
-If ($params.src) {
+If (Get-Member -InputObject $params -Name src) {
     $src = $params.src.toString()
 
     If (-Not (Test-Path -path $src)){
@@ -62,24 +62,26 @@ Else {
     Fail-Json $result "missing required argument: dest"
 }
 
-If ($params.recurse) {
+If (Get-Member -InputObject $params -Name recurse) {
    $recurse = ConvertTo-Bool ($params.recurse)
 }
 Else {
     $recurse = $false
 }
 
-If ($params.rm) { 
-    $rm = ConvertTo-Bool ($params.rm) 
-} 
-Else { 
-    $rm = $false 
+If (Get-Member -InputObject $params -Name rm) {
+    $rm = ConvertTo-Bool ($params.rm)
+}
+Else {
+    $rm = $false
 }
 
 If ($ext -eq ".zip" -And $recurse -eq $false) {
     Try {
         $shell = New-Object -ComObject Shell.Application
-        $shell.NameSpace($dest).copyhere(($shell.NameSpace($src)).items(), 20)
+        $zipPkg = $shell.NameSpace($src)
+        $destPath = $shell.NameSpace($dest)
+        $destPath.CopyHere($zipPkg.Items())
         $result.changed = $true
     }
     Catch {


### PR DESCRIPTION
I had some issues with win_unzip not playing nice with Ansible 2.0. @jhawkesworth mentioned that it likely had to do with Ansible enforcing Powershell Strict. I logged an issue here: #1072

I'm not a powershell guy, so I'm not super sure why this all fixes it, but it seems to work for me :)
