### PR TITLE
Fixes multiple param handling by modprobe.py

### DIFF
--- a/system/modprobe.py
+++ b/system/modprobe.py
@@ -57,6 +57,9 @@ EXAMPLES = '''
 - modprobe: name=dummy state=present params="numdummies=2"
 '''
 
+import shlex
+
+
 def main():
     module = AnsibleModule(
         argument_spec={
@@ -100,7 +103,9 @@ def main():
     # Add/remove module as needed
     if args['state'] == 'present':
         if not present:
-            rc, _, err = module.run_command([module.get_bin_path('modprobe', True), args['name'], args['params']])
+            command = [module.get_bin_path('modprobe', True), args['name']]
+            command.extend(shlex.split(args['params']))
+            rc, _, err = module.run_command(command)
             if rc != 0:
                 module.fail_json(msg=err, **args)
             args['changed'] = True


### PR DESCRIPTION
This fixes #634 where the modprobe module is unable to handle more than one parameter. This fix also supports parameters whose values contain spaces.
