### PR TITLE
Fix for - Firewalld traces with ALREADY_ENABLED when using port name or re-ordered rich rule

### DIFF
--- a/system/firewalld.py
+++ b/system/firewalld.py
@@ -95,6 +95,7 @@ try:
     import firewall.config
     FW_VERSION = firewall.config.VERSION
 
+    from firewall.client import Rich_Rule
     from firewall.client import FirewallClient
     fw = FirewallClient()
     HAS_FIREWALLD = True
@@ -199,6 +200,9 @@ def set_service_disabled_permanent(zone, service):
 # rich rule handling
 #
 def get_rich_rule_enabled(zone, rule):
+    # Convert the rule string to standard format
+    # before checking whether it is present
+    rule = str(Rich_Rule(rule_str=rule))
     if rule in fw.getRichRules(zone):
         return True
     else:
@@ -213,6 +217,9 @@ def set_rich_rule_disabled(zone, rule):
 def get_rich_rule_enabled_permanent(zone, rule):
     fw_zone = fw.config().getZoneByName(zone)
     fw_settings = fw_zone.getSettings()
+    # Convert the rule string to standard format
+    # before checking whether it is present
+    rule = str(Rich_Rule(rule_str=rule))
     if rule in fw_settings.getRichRules():
         return True
     else:


### PR DESCRIPTION
Fixes ansible-modules-extras issue #1080
