### PR TITLE
win_acl: windows 2008 fix + special account fix + strict fix

### DIFF
--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -2,6 +2,8 @@
 # This file is part of Ansible
 #
 # Copyright 2015, Phil Schwartz <schwartzmx@gmail.com>
+# Copyright 2015, Trond Hindenes
+# Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
 #
 # Ansible is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -51,8 +51,7 @@ Function UserSearch
         $accountname = $env:COMPUTERNAME + "\" + $AccountName
         $IsLocalAccount = $true
     }
- 
- 
+
     if ($IsLocalAccount -eq $true)
     {
         # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
@@ -62,13 +61,19 @@ Function UserSearch
             return $localaccount.SID
         }
     }
-    ElseIf (($IsDomainAccount -eq $true) -and ($IsUpn -eq $false))
+    ElseIf ($IsDomainAccount -eq $true)
     {
         #Search by samaccountname
         $Searcher = [adsisearcher]""
-        $Searcher.Filter = "sAMAccountName=$($accountname.split("\")[1])"
-        $result = $Searcher.FindOne()
- 
+
+        If ($IsUpn -eq $false) {
+            $Searcher.Filter = "sAMAccountName=$($accountname.split("\")[1])"
+        }
+        Else {
+            $Searcher.Filter = "userPrincipalName=$($accountname)"
+        }
+
+        $result = $Searcher.FindOne() 
         if ($result)
         {
             $user = $result.GetDirectoryEntry()
@@ -80,7 +85,6 @@ Function UserSearch
             return (New-Object System.Security.Principal.SecurityIdentifier($binarySID,0)).Value
         }
     }
- 
 }
  
 $params = Parse-Args $args;

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -88,84 +88,36 @@ Function UserSearch
 }
  
 $params = Parse-Args $args;
- 
-$result = New-Object psobject @{
-    win_acl = New-Object psobject
-    changed = $false
+
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+$path = Get-Attr $params "path" -failifempty $true
+$user = Get-Attr $params "user" -failifempty $true
+$rights = Get-Attr $params "rights" -failifempty $true
+
+$type = Get-Attr $params "type" -validateSet "allow","deny" -resultobj $result
+$state = Get-Attr $params "state" "present" -validateSet "present","absent" -resultobj $result
+
+$inherit = Get-Attr $params "inherit" ""
+$propagation = Get-Attr $params "propagation" "None" -validateSet "None","NoPropagateInherit","InheritOnly" -resultobj $result
+
+If (-Not (Test-Path -Path $path)) {
+    Fail-Json $result "$path file or directory does not exist on the host"
 }
- 
-If ($params.path) {
-    $path = $params.path.toString()
- 
-    If (-Not (Test-Path -Path $path)) {
-        Fail-Json $result "$path file or directory does not exist on the host"
-    }
+
+# Test that the user/group is resolvable on the local machine
+$sid = UserSearch -AccountName ($user)
+if (!$sid)
+{
+    Fail-Json $result "$user is not a valid user or group on the host machine or domain"
 }
-Else {
-    Fail-Json $result "missing required argument: path"
+
+If (Test-Path -Path $path -PathType Leaf) {
+    $inherit = "None"
 }
- 
-If ($params.user) {
-    $sid = UserSearch -AccountName ($Params.User)
- 
-    # Test that the user/group is resolvable on the local machine
-    if (!$sid)
-    {
-          Fail-Json $result "$($Params.User) is not a valid user or group on the host machine or domain"
-    }    
-}
-Else {
-    Fail-Json $result "missing required argument: user.  specify the user or group to apply permission changes."
-}
- 
-If ($params.type -eq "allow") {
-    $type = $true
-}
-ElseIf ($params.type -eq "deny") {
-    $type = $false
-}
-Else {
-    Fail-Json $result "missing required argument: type. specify whether to allow or deny the specified rights."
-}
- 
-If ($params.inherit) {
-    # If it's a file then no flags can be set or an exception will be thrown
-    If (Test-Path -Path $path -PathType Leaf) {
-        $inherit = "None"
-    }
-    Else {
-        $inherit = $params.inherit.toString()
-    }
-}
-Else {
-    # If it's a file then no flags can be set or an exception will be thrown
-    If (Test-Path -Path $path -PathType Leaf) {
-        $inherit = "None"
-    }
-    Else {
-        $inherit = "ContainerInherit, ObjectInherit"
-    }
-}
- 
-If ($params.propagation) {
-    $propagation = $params.propagation.toString()
-}
-Else {
-    $propagation = "None"
-}
- 
-If ($params.rights) {
-    $rights = $params.rights.toString()
-}
-Else {
-    Fail-Json $result "missing required argument: rights"
-}
- 
-If ($params.state -eq "absent") {
-    $state = "remove"
-}
-Else {
-    $state = "add"
+ElseIf ($inherit -eq "") {
+    $inherit = "ContainerInherit, ObjectInherit"
 }
  
 Try {
@@ -173,7 +125,7 @@ Try {
     $InheritanceFlag = [System.Security.AccessControl.InheritanceFlags]$inherit
     $PropagationFlag = [System.Security.AccessControl.PropagationFlags]$propagation
  
-    If ($type) {
+    If ($type -eq "allow") {
         $objType =[System.Security.AccessControl.AccessControlType]::Allow
     }
     Else {
@@ -193,22 +145,22 @@ Try {
             Break
         } 
     }
- 
-    If ($state -eq "add" -And $match -eq $false) {
+
+    If ($state -eq "present" -And $match -eq $false) {
         Try {
             $objACL.AddAccessRule($objACE)
             Set-ACL $path $objACL
-            $result.changed = $true
+            Set-Attr $result "changed" $true;
         }
         Catch {
             Fail-Json $result "an exception occured when adding the specified rule"
         }
     }
-    ElseIf ($state -eq "remove" -And $match -eq $true) {
+    ElseIf ($state -eq "absent" -And $match -eq $true) {
         Try {
             $objACL.RemoveAccessRule($objACE)
             Set-ACL $path $objACL
-            $result.changed = $true
+            Set-Attr $result "changed" $true;
         }
         Catch {
             Fail-Json $result "an exception occured when removing the specified rule"
@@ -226,7 +178,7 @@ Try {
     }
 }
 Catch {
-    Fail-Json $result "an error occured when attempting to $state $rights permission(s) on $path for $($Params.User)"
+    Fail-Json $result "an error occured when attempting to $state $rights permission(s) on $path for $user"
 }
  
 Exit-Json $result

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -27,52 +27,49 @@
 #Functions
 Function UserSearch
 {
-    Param ([string]$AccountName)
+    Param ([string]$accountName)
     #Check if there's a realm specified
-    if ($AccountName.Split("\").count -gt 1)
+
+    $searchDomain = $false
+    $searchDomainUPN = $false
+    if ($accountName.Split("\").count -gt 1)
     {
-        if ($AccountName.Split("\")[0] -eq $env:COMPUTERNAME)
+        if ($accountName.Split("\")[0] -ne $env:COMPUTERNAME)
         {
-            $IsLocalAccount = $true
+            $searchDomain = $true
+            $accountName = $accountName.split("\")[1]
         }
-        Else
-        {
-            $IsDomainAccount = $true
-            $IsUpn = $false
-        }
- 
     }
-    Elseif ($AccountName.contains("@"))
+    Elseif ($accountName.contains("@"))
     {
-        $IsDomainAccount = $true
-        $IsUpn = $true
+        $searchDomain = $true
+        $searchDomainUPN = $true
     }
     Else
     {
         #Default to local user account
-        $accountname = $env:COMPUTERNAME + "\" + $AccountName
-        $IsLocalAccount = $true
+        $accountName = $env:COMPUTERNAME + "\" + $accountName
     }
 
-    if ($IsLocalAccount -eq $true)
+    if ($searchDomain -eq $false)
     {
         # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
-        $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $AccountName}
+        $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $accountName}
         if ($localaccount)
         {
             return $localaccount.SID
         }
     }
-    ElseIf ($IsDomainAccount -eq $true)
+    Else
     {
         #Search by samaccountname
         $Searcher = [adsisearcher]""
 
-        If ($IsUpn -eq $false) {
-            $Searcher.Filter = "sAMAccountName=$($accountname.split("\")[1])"
+        If ($searchDomainUPN -eq $false) {
+            $Searcher.Filter = "sAMAccountName=$($accountName)"
         }
         Else {
-            $Searcher.Filter = "userPrincipalName=$($accountname)"
+            $Searcher.Filter = "userPrincipalName=$($accountName)"
         }
 
         $result = $Searcher.FindOne() 

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -42,7 +42,7 @@ Function UserSearch
         }
  
     }
-    Elseif ($AccountName -contains "@")
+    Elseif ($AccountName.contains("@"))
     {
         $IsDomainAccount = $true
         $IsUpn = $true

--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -98,7 +98,7 @@ $path = Get-Attr $params "path" -failifempty $true
 $user = Get-Attr $params "user" -failifempty $true
 $rights = Get-Attr $params "rights" -failifempty $true
 
-$type = Get-Attr $params "type" -validateSet "allow","deny" -resultobj $result
+$type = Get-Attr $params "type" -failifempty $true -validateSet "allow","deny" -resultobj $result
 $state = Get-Attr $params "state" "present" -validateSet "present","absent" -resultobj $result
 
 $inherit = Get-Attr $params "inherit" ""

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# (c) 2015, Phil Schwartz <schwartzmx@gmail.com>
+# Copyright 2015, Phil Schwartz <schwartzmx@gmail.com>
+# Copyright 2015, Trond Hindenes
+# Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
 #
 # This file is part of Ansible
 #
@@ -40,7 +42,7 @@ options:
     default: none
   state:
     description:
-      - Specify whether to add (present) or remove (absent) the specified access rule
+      - Specify whether to add C(present) or remove C(absent) the specified access rule
     required: no
     choices:
       - present
@@ -99,7 +101,7 @@ options:
       - NoPropagateInherit
       - InheritOnly
     default: "None"
-author: Phil Schwartz (@schwartzmx), Trond Hindenes (@trondhindenes)
+author: Phil Schwartz (@schwartzmx), Trond Hindenes (@trondhindenes), Hans-Joachim Kliemeck (@h0nIg)
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
there are problems related to windows 2008 and using special accounts like SYSTEM.
- SID is used instead of full computername\accountname or domain\accountname
- use account table instead of useraccount / group table, since it contains all accounts
