### PR TITLE
Fix IIS module null refs when removing objects on a server running PowerShell 4

### DIFF
--- a/windows/win_iis_webapppool.ps1
+++ b/windows/win_iis_webapppool.ps1
@@ -101,12 +101,15 @@ try {
 
 # Result
 $pool = Get-Item IIS:\AppPools\$name
-$result.info = @{
-  name = $pool.Name
-  state = $pool.State
-  attributes =  New-Object psobject @{}
-};
-
-$pool.Attributes | ForEach { $result.info.attributes.Add($_.Name, $_.Value)};
+if ($pool)
+{
+  $result.info = @{
+    name = $pool.Name
+    state = $pool.State
+    attributes =  New-Object psobject @{}
+  };
+  
+  $pool.Attributes | ForEach { $result.info.attributes.Add($_.Name, $_.Value)};
+}
 
 Exit-Json $result


### PR DESCRIPTION
Certain IIS modules fail on servers running PowerShell 4 when removing objects (`state=absent`). This change adds checks that verify the objects are not null before trying to dereference properties.
