### PR TITLE
win_acl_inheritance

### DIFF
--- a/windows/win_acl_inheritance.ps1
+++ b/windows/win_acl_inheritance.ps1
@@ -26,7 +26,7 @@ $result = New-Object PSObject;
 Set-Attr $result "changed" $false;
 
 $path = Get-Attr $params "path" -failifempty $true
-$copy = Get-Attr $params "copy" "no" -validateSet "no","yes" -resultobj $result
+$copy = Get-Attr $params "copy" "no" -validateSet "no","yes" -resultobj $result | ConvertTo-Bool
 
 If (-Not (Test-Path -Path $path)) {
     Fail-Json $result "$path file or directory does not exist on the host"
@@ -36,7 +36,7 @@ Try {
     $objACL = Get-ACL $path
     $alreadyDisabled = !$objACL.AreAccessRulesProtected
 
-    If ($copy -eq "yes") {
+    If ($copy) {
         $objACL.SetAccessRuleProtection($True, $True)
     } Else {
         $objACL.SetAccessRuleProtection($True, $False)

--- a/windows/win_acl_inheritance.ps1
+++ b/windows/win_acl_inheritance.ps1
@@ -27,7 +27,8 @@ Set-Attr $result "changed" $false;
 
 $path = Get-Attr $params "path" -failifempty $true
 $state = Get-Attr $params "state" "absent" -validateSet "present","absent" -resultobj $result
-$reorganize = Get-Attr $params "reorganize" "no" -validateSet "no","yes" -resultobj $result | ConvertTo-Bool
+$reorganize = Get-Attr $params "reorganize" "no" -validateSet "no","yes" -resultobj $result
+$reorganize = $reorganize | ConvertTo-Bool
 
 If (-Not (Test-Path -Path $path)) {
     Fail-Json $result "$path file or directory does not exist on the host"

--- a/windows/win_acl_inheritance.ps1
+++ b/windows/win_acl_inheritance.ps1
@@ -1,0 +1,55 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+
+$params = Parse-Args $args;
+
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+$path = Get-Attr $params "path" -failifempty $true
+$copy = Get-Attr $params "copy" "no" -validateSet "no","yes" -resultobj $result
+
+If (-Not (Test-Path -Path $path)) {
+    Fail-Json $result "$path file or directory does not exist on the host"
+}
+ 
+Try {
+    $objACL = Get-ACL $path
+    $alreadyDisabled = !$objACL.AreAccessRulesProtected
+
+    If ($copy -eq "yes") {
+        $objACL.SetAccessRuleProtection($True, $True)
+    } Else {
+        $objACL.SetAccessRuleProtection($True, $False)
+    }
+
+    If ($alreadyDisabled) {
+        Set-Attr $result "changed" $true;
+    }
+
+    Set-ACL $path $objACL
+}
+Catch {
+    Fail-Json $result "an error occured when attempting to disable inheritance"
+}
+ 
+Exit-Json $result

--- a/windows/win_acl_inheritance.py
+++ b/windows/win_acl_inheritance.py
@@ -43,7 +43,8 @@ options:
     default: absent
   reorganize:
     description:
-      - For P(state) = I(absent), indicates if the inherited ACE's should be copied. For P(state) = I(present), indicates if the inherited ACE's should be simplified.
+      - For P(state) = I(absent), indicates if the inherited ACE's should be copied from the parent directory. This is necessary (in combination with removal) for a simple ACL instead of using multiple ACE deny entries.
+      - For P(state) = I(present), indicates if the inherited ACE's should be deduplicated compared to the parent directory. This removes complexity of the ACL structure.
     required: false
     choices:
       - no

--- a/windows/win_acl_inheritance.py
+++ b/windows/win_acl_inheritance.py
@@ -27,7 +27,7 @@ module: win_acl_inheritance
 version_added: "2.0"
 short_description: Disable ACL inheritance
 description:
-    - Disable ACL inheritance and optionally converts ACE to dedicated ACE
+    - Disable ACL (Access Control List) inheritance and optionally converts ACE (Access Control Entry) to dedicated ACE
 options:
   path:
     description:
@@ -48,12 +48,12 @@ EXAMPLES = '''
 # Playbook example
 ---
 - name: Disable and copy
-  win_owner:
+  win_acl_inheritance:
     path: 'C:\\apache\\'
     copy: yes
 
 - name: Disable
-  win_owner:
+  win_acl_inheritance:
     path: 'C:\\apache\\'
     copy: no
 '''

--- a/windows/win_acl_inheritance.py
+++ b/windows/win_acl_inheritance.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_acl_inheritance
-version_added: "2.0"
+version_added: "2.1"
 short_description: Change ACL inheritance
 description:
     - Change ACL (Access Control List) inheritance and optionally copy inherited ACE's (Access Control Entry) to dedicated ACE's or vice versa.
@@ -71,4 +71,8 @@ EXAMPLES = '''
     path: 'C:\\apache\\'
     state: present
     reorganize: yes
+'''
+
+RETURN = '''
+
 '''

--- a/windows/win_acl_inheritance.py
+++ b/windows/win_acl_inheritance.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2015, Hans-Joachim Kliemeck <git@kliemeck.de>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_acl_inheritance
+version_added: "2.0"
+short_description: Disable ACL inheritance
+description:
+    - Disable ACL inheritance and optionally converts ACE to dedicated ACE
+options:
+  path:
+    description:
+      - Path to be used for disabling
+    required: true
+  copy:
+    description:
+      - Indicates if the inherited ACE should be copied to dedicated ACE
+    required: false
+    choices:
+      - no
+      - yes
+    default: no
+author: Hans-Joachim Kliemeck (@h0nIg)
+'''
+
+EXAMPLES = '''
+# Playbook example
+---
+- name: Disable and copy
+  win_owner:
+    path: 'C:\\apache\\'
+    copy: yes
+
+- name: Disable
+  win_owner:
+    path: 'C:\\apache\\'
+    copy: no
+'''

--- a/windows/win_acl_inheritance.py
+++ b/windows/win_acl_inheritance.py
@@ -25,17 +25,25 @@ DOCUMENTATION = '''
 ---
 module: win_acl_inheritance
 version_added: "2.0"
-short_description: Disable ACL inheritance
+short_description: Change ACL inheritance
 description:
-    - Disable ACL (Access Control List) inheritance and optionally converts ACE (Access Control Entry) to dedicated ACE
+    - Change ACL (Access Control List) inheritance and optionally copy inherited ACE's (Access Control Entry) to dedicated ACE's or vice versa.
 options:
   path:
     description:
-      - Path to be used for disabling
+      - Path to be used for changing inheritance
     required: true
-  copy:
+  state:
     description:
-      - Indicates if the inherited ACE should be copied to dedicated ACE
+      - Specify whether to enable I(present) or disable I(absent) ACL inheritance
+    required: false
+    choices:
+      - present
+      - absent
+    default: absent
+  reorganize:
+    description:
+      - For P(state) = I(absent), indicates if the inherited ACE's should be copied. For P(state) = I(present), indicates if the inherited ACE's should be simplified.
     required: false
     choices:
       - no
@@ -47,13 +55,20 @@ author: Hans-Joachim Kliemeck (@h0nIg)
 EXAMPLES = '''
 # Playbook example
 ---
-- name: Disable and copy
+- name: Disable inherited ACE's
   win_acl_inheritance:
     path: 'C:\\apache\\'
-    copy: yes
+    state: absent
 
-- name: Disable
+- name: Disable and copy inherited ACE's
   win_acl_inheritance:
     path: 'C:\\apache\\'
-    copy: no
+    state: absent
+    reorganize: yes
+
+- name: Enable and remove dedicated ACE's
+  win_acl_inheritance:
+    path: 'C:\\apache\\'
+    state: present
+    reorganize: yes
 '''


### PR DESCRIPTION
added dedicated module to disable ACL inheritance. this could be merged into win_acl, but windows acl are ways more complex than linux permissions/ACL and therefore the module is already very complex (e.g. lot of parameters). this is just an addon to win_acl and focused on removing the inheritance.

future: maybe additional parameter could be added to reconvert ACL to enabled inheritance
