### PR TITLE
.exists() deprecated in zabbix 3.0 API calls have been removed

### DIFF
--- a/monitoring/zabbix_group.py
+++ b/monitoring/zabbix_group.py
@@ -130,11 +130,10 @@ def delete_group(zbx, group_id):
 
 def check_group(zbx, host_group):
     try:
-        result = zbx.hostgroup.exists(
-            {
-                'name': host_group
-            }
-        )
+        if zbx.get({'filter': {'name': group_name},'countOutput': True}):
+            result = True
+        else:
+            result = False
     except BaseException as e:
         return 1, None, str(e)
     return 0, result, None


### PR DESCRIPTION
There is a deprecated zabbix api function call in the zabbix-group.py code. Ansible module doesn't work with Zabbix 3.0 server. hostgroup.exists call must be droped according to [ ZBXNEXT-2724](https://support.zabbix.com/browse/ZBXNEXT-2724).
