### PR TITLE
Enable stdout and stderr on sucessful runs, making show_diff useable

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -171,8 +171,8 @@ def main():
 
     if not p['manifest']:
         cmd = ("%(base_cmd)s agent --onetime"
-               " --ignorecache --no-daemonize --no-usecacheonfailure"
-               " --no-splay --detailed-exitcodes --verbose") % dict(
+               " --ignorecache --no-daemonize --no-usecacheonfailure --no-splay"
+               " --detailed-exitcodes --verbose --color 0") % dict(
                    base_cmd=base_cmd,
                    )
         if p['puppetmaster']:
@@ -198,7 +198,7 @@ def main():
 
     if rc == 0:
         # success
-        module.exit_json(rc=rc, changed=False, stdout=stdout)
+        module.exit_json(rc=rc, changed=False, stdout=stdout, stderr=stderr)
     elif rc == 1:
         # rc==1 could be because it's disabled
         # rc==1 could also mean there was a compilation failure


### PR DESCRIPTION
This adds stdout and stderr to the module, which makes the show_diff choice useful, as it will print it out now.

@emonty Let me know what you think
