### PR TITLE
Change show_diff to default to yes, to match what puppet agent --test…

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -45,9 +45,9 @@ options:
     default: None
   show_diff:
     description:
-      - Should puppet return diffs of changes applied. Defaults to off to avoid leaking secret changes by default.
+      - Should puppet return diffs of changes applied. Defaults to yes, to match puppet agent --test. Change to no to avoid leaking secret changes.
     required: false
-    default: no
+    default: yes
     choices: [ "yes", "no" ]
   facts:
     description:
@@ -109,7 +109,7 @@ def main():
             puppetmaster=dict(required=False, default=None),
             manifest=dict(required=False, default=None),
             show_diff=dict(
-                default=False, aliases=['show-diff'], type='bool'),
+                default=True, aliases=['show-diff'], type='bool'),
             facts=dict(default=None),
             facter_basename=dict(default='ansible'),
             environment=dict(required=False, default=None),


### PR DESCRIPTION
… is, since the rest of the options defaulted to on are grabbed from --test

@emonty What do you think. From the puppet-agent man page.

```
 --test Enable  the most common options used for testing. These are ´onetime´, ´verbose´, ´ignorecache´, ´no-daemonize´, ´no-usecacheonfailure´, ´detailed-exit-codes´, ´no-splay´,
              and ´show_diff´.
```
