### PR TITLE
Fixed #632 added alternatives priority

### DIFF
--- a/system/alternatives.py
+++ b/system/alternatives.py
@@ -47,6 +47,10 @@ options:
       - The path to the symbolic link that should point to the real executable.
       - This option is required on RHEL-based distributions
     required: false
+  priority:
+    description:
+      - The priority of the alternative
+    required: false
 requirements: [ update-alternatives ]
 '''
 
@@ -56,9 +60,10 @@ EXAMPLES = '''
 
 - name: alternatives link created
   alternatives: name=hadoop-conf link=/etc/hadoop/conf path=/etc/hadoop/conf.ansible
-'''
 
-DEFAULT_LINK_PRIORITY = 50
+- name: make java 32 bit an alternative with low priority
+  alternatives: name=java path=/usr/lib/jvm/java-7-openjdk-i386/jre/bin/java priority=-10
+'''
 
 import re
 from ansible.module_utils.basic import *
@@ -72,6 +77,8 @@ def main():
             name = dict(required=True),
             path = dict(required=True, type='path'),
             link = dict(required=False, type='path'),
+            priority = dict(required=False, type='int',
+                            default=50),
         ),
         supports_check_mode=True,
     )
@@ -80,6 +87,7 @@ def main():
     name = params['name']
     path = params['path']
     link = params['link']
+    priority = params['priority']
 
     UPDATE_ALTERNATIVES = module.get_bin_path('update-alternatives',True)
 
@@ -127,7 +135,7 @@ def main():
                     module.fail_json(msg="Needed to install the alternative, but unable to do so as we are missing the link")
 
                 module.run_command(
-                    [UPDATE_ALTERNATIVES, '--install', link, name, path, str(DEFAULT_LINK_PRIORITY)],
+                    [UPDATE_ALTERNATIVES, '--install', link, name, path, str(priority)],
                     check_rc=True
                 )
 


### PR DESCRIPTION
Added an optional priority parameter to the alternatives module. If no priority is given then the default that was used before is still used. Added example and documentation in the comments 
