### PR TITLE
Adding comment support for iptables module

### DIFF
--- a/system/iptables.py
+++ b/system/iptables.py
@@ -199,6 +199,10 @@ options:
         rule also specifies one of the following protocols: tcp, udp, dccp or
         sctp."
     required: false
+  comment:
+    description:
+      - "This specifies a comment that will be added to the rule"
+    required: false
 '''
 
 EXAMPLES = '''
@@ -207,7 +211,7 @@ EXAMPLES = '''
   become: yes
 
 # Forward port 80 to 8600
-- iptables: table=nat chain=PREROUTING in_interface=eth0 protocol=tcp match=tcp destination_port=80 jump=REDIRECT to_ports=8600
+- iptables: table=nat chain=PREROUTING in_interface=eth0 protocol=tcp match=tcp destination_port=80 jump=REDIRECT to_ports=8600 comment="Redirect web traffic to port 8600"
   become: yes
 '''
 
@@ -219,6 +223,11 @@ def append_param(rule, param, flag, is_list):
     else:
         if param is not None:
             rule.extend([flag, param])
+
+def append_comm(rule, param):
+    if param:
+    	    rule.extend(['-m'])
+    	    rule.extend(['comment'])
 
 
 def construct_rule(params):
@@ -236,6 +245,8 @@ def construct_rule(params):
     append_param(rule, params['source_port'], '--source-port', False)
     append_param(rule, params['destination_port'], '--destination-port', False)
     append_param(rule, params['to_ports'], '--to-ports', False)
+    append_comm(rule, params['comment'])
+    append_param(rule, params['comment'], '--comment', False)
     return rule
 
 
@@ -284,6 +295,7 @@ def main():
             source_port=dict(required=False, default=None, type='str'),
             destination_port=dict(required=False, default=None, type='str'),
             to_ports=dict(required=False, default=None, type='str'),
+	    comment=dict(required=False, default=None, type='str'),
         ),
     )
     args = dict(


### PR DESCRIPTION
This PR is meant to support using comments inside iptables rules as :

```
-m comment --comment "test comment"
```

Please comment if you have a cleaner way to do this.
Pinging @LinusU as he is the author of the iptables module.
