### PR TITLE
Revert "Change show_diff to default to yes"

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -45,9 +45,9 @@ options:
     default: None
   show_diff:
     description:
-      - Should puppet return diffs of changes applied. Defaults to yes, to match puppet agent --test. Change to no to avoid leaking secret changes.
+      - Should puppet return diffs of changes applied. Defaults to off to avoid leaking secret changes by default.
     required: false
-    default: yes
+    default: no
     choices: [ "yes", "no" ]
   facts:
     description:
@@ -109,7 +109,7 @@ def main():
             puppetmaster=dict(required=False, default=None),
             manifest=dict(required=False, default=None),
             show_diff=dict(
-                default=True, aliases=['show-diff'], type='bool'),
+                default=False, aliases=['show-diff'], type='bool'),
             facts=dict(default=None),
             facter_basename=dict(default='ansible'),
             environment=dict(required=False, default=None),


### PR DESCRIPTION
This was originally to match what puppet agent --test is, since the
rest of the options defaulted to on are grabbed from --test. However,
some security concerns have since been raised - namely that since this
is not the same invocation as --test but instead a remote orchestration
of puppet, the fact that passwords leak into the diff is a dangerous
default.

This reverts commit b86762c1806aa7f021a4780d06db2d3937910a62.
