### PR TITLE
Add conntrack module ctstate support to iptables

### DIFF
--- a/system/iptables.py
+++ b/system/iptables.py
@@ -203,6 +203,12 @@ options:
     description:
       - "This specifies a comment that will be added to the rule"
     required: false
+  ctstate:
+    description:
+      - "ctstate is a comma separated list of the connection states to match in
+        the conntrack module. Possible states are: 'INVALID', 'NEW',
+        'ESTABLISHED', 'RELATED', 'UNTRACKED', 'SNAT', 'DNAT'"
+    required: false
 '''
 
 EXAMPLES = '''
@@ -212,6 +218,10 @@ EXAMPLES = '''
 
 # Forward port 80 to 8600
 - iptables: table=nat chain=PREROUTING in_interface=eth0 protocol=tcp match=tcp destination_port=80 jump=REDIRECT to_ports=8600 comment="Redirect web traffic to port 8600"
+  become: yes
+
+# Allow related and established connections
+- iptables: chain=INPUT ctstate=ESTABLISHED,RELATED jump=ACCEPT
   become: yes
 '''
 
@@ -228,6 +238,12 @@ def append_comm(rule, param):
     if param:
         rule.extend(['-m'])
         rule.extend(['comment'])
+
+
+def append_conntrack(rule, param):
+    if param:
+        rule.extend(['-m'])
+        rule.extend(['conntrack'])
 
 
 def construct_rule(params):
@@ -247,6 +263,8 @@ def construct_rule(params):
     append_param(rule, params['to_ports'], '--to-ports', False)
     append_comm(rule, params['comment'])
     append_param(rule, params['comment'], '--comment', False)
+    append_conntrack(rule, params['ctstate'])
+    append_param(rule, params['ctstate'], '--ctstate', False)
     return rule
 
 
@@ -296,6 +314,7 @@ def main():
             destination_port=dict(required=False, default=None, type='str'),
             to_ports=dict(required=False, default=None, type='str'),
             comment=dict(required=False, default=None, type='str'),
+            ctstate=dict(required=False, default=None, type='str'),
         ),
     )
     args = dict(


### PR DESCRIPTION
This PR adds support to be able to create rules in iptables associated with specific states in the connection tracking module.
