### PR TITLE
Fix broken examples in docs

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -99,11 +99,11 @@ options:
 '''
 
 EXAMPLES = '''
-# Download the latest version of the commons-collections artifact from Maven Central
-- maven_artifact: group_id=org.apache.commons artifact_id=commons-collections dest=/tmp/commons-collections-latest.jar
+# Download the latest version of the JUnit framework artifact from Maven Central
+- maven_artifact: group_id=junit artifact_id=junit dest=/tmp/junit-latest.jar
 
-# Download Apache Commons-Collections 3.2 from Maven Central
-- maven_artifact: group_id=org.apache.commons artifact_id=commons-collections version=3.2 dest=/tmp/commons-collections-3.2.jar
+# Download JUnit 4.11 from Maven Central
+- maven_artifact: group_id=junit artifact_id=junit version=4.11 dest=/tmp/junit-4.11.jar
 
 # Download an artifact from a private repository requiring authentication
 - maven_artifact: group_id=com.company artifact_id=library-name repository_url=https://repo.company.com/maven username=user password=pass dest=/tmp/library-name-latest.jar


### PR DESCRIPTION
**Docs Pull Request**
The first two examples in documentation were broken cause now artifact for common collections is called **commons-collections4**. The examples failed with 404 error message (not found in maven central). I was very confusing especially for newbies. I decided to use JUnit in example. It's the most popular one according to the central stats. It's shorter also.
