### PR TITLE
Fixed call to module.log

### DIFF
--- a/network/openvswitch_port.py
+++ b/network/openvswitch_port.py
@@ -140,7 +140,7 @@ class OVSPort(object):
 
     def set(self, set_opt):
         """ Set attributes on a port. """
-        self.module("set called %s" % set_opt)
+        self.module.log("set called %s" % set_opt)
         if (not set_opt):
             return False
 


### PR DESCRIPTION
The module in its current state fails when running a play against an existing port. For instance, when running the module with these arguments:
            "bridge=br-ex port=eth2 state=present",
the play will fail if the port already exists with the message "AnsibleModule' object is not callable" because line 143 is calling self.module() rather than self.module.log().
