### PR TITLE
Fix documentation, the correct parameter is "name"

### DIFF
--- a/clustering/znode.py
+++ b/clustering/znode.py
@@ -26,7 +26,7 @@ options:
         description:
             - A list of ZooKeeper servers (format '[server]:[port]').
         required: true
-    path:
+    name:
         description:
             - The path of the znode.
         required: true


### PR DESCRIPTION
This confused me a bit until I read how the module is implemented. This PR corrects the documentation to avoid confusion.
