### PR TITLE
add proper 'changed' return, add support for partitioned netscaler

### DIFF
--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -232,7 +232,7 @@ def main():
     rc = 0
     try:
         rc, result = core(module)
-    except urllib2.HTTPError as he:
+    except urllib2.HTTPError, he:
         module.fail_json(msg = he.reason, code = he.code, ns_api_error = json.loads(he.read()))
     except Exception, e:
         module.fail_json(msg=str(e))


### PR DESCRIPTION
Adds partition support. In order to do this, the module has to maintain a session with the netscaler, hence the introduction of a custom urllib2 opener which has cookie support added. As a by-product, it was fairly trivial to add a status check on the netscaler resource being managed and, therefore, a proper 'changed' status return.

Also adds improved error reporting from netscaler.
