### PR TITLE
Fix return documentation

### DIFF
--- a/cloud/openstack/os_project.py
+++ b/cloud/openstack/os_project.py
@@ -88,14 +88,6 @@ project:
     returned: On success when I(state) is 'present'
     type: dictionary
     contains:
-        description:
-            description: Project description
-            type: string
-            sample: "demodescription"
-        domain_id:
-            description: Project domain ID. Only present with Keystone >= v3.
-            type: string
-            sample: "default"
         id:
             description: Project ID
             type: string
@@ -104,6 +96,14 @@ project:
             description: Project name
             type: string
             sample: "demoproject"
+        description:
+            description: Project description
+            type: string
+            sample: "demodescription"
+        enabled:
+            description: Boolean to indicate if project is enabled
+            type: bool
+            sample: True
 '''
 
 def _needs_update(module, project):


### PR DESCRIPTION
Fix returned attributes documentation to match those defined here:
https://github.com/openstack/python-keystoneclient/blob/master/keystoneclient/v3/projects.py#L26

Parents/hierarchy attributes have been omitted since this module currently does not support them.

@j2sol
