### PR TITLE
zypper: Fix installation from paths/urls

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -237,12 +237,9 @@ def package_latest(m, name, installed_state, package_type, disable_gpg_check, di
     if disable_gpg_check:
         cmd.append('--no-gpg-checks')
 
-    if old_zypper:
-        cmd.extend(['install', '--auto-agree-with-licenses', '-t', package_type])
-    else:
-        cmd.extend(['update', '--auto-agree-with-licenses', '-t', package_type])
+    cmd.extend(['install', '--auto-agree-with-licenses', '-t', package_type])
 
-    cmd.extend(name)
+    cmd.extend(names_to_paths(name, paths))
     rc, stdout, stderr = m.run_command(cmd, check_rc=False)
 
     # if we've already made a change, we don't have to check whether a version changed


### PR DESCRIPTION
Currently s.th. like:
- name: Install Ansible RPM from local filesystem
  zypper:
    name='/vagrant/rpms/ansible-2.0.0-0.git201511170838.9a5342f.devel.noarch.rpm'

fails like:

  TASK [foo_ansible : Install Ansible RPM from local filesystem] ****************
  fatal: [foo.local]: FAILED! => {"changed": false, "failed": true, "msg": "No provider of 'ansible' found.\n"}

This happens since the actual name element is being ovewritten in
get_package_state. To fix this keep the real path in an extra dictionary so we
can reference it when we need to install the package.

Signed-off-by: Guido Günther agx@sigxcpu.org
