### PR TITLE
subnets associated with route table need to be removed before route t…

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
+
 DOCUMENTATION = '''
 ---
 module: ec2_vpc_route_table
@@ -377,6 +378,11 @@ def ensure_subnet_associations(vpc_conn, vpc_id, route_table, subnets,
 
     return {'changed': changed}
 
+def remove_subnet_associations(vpc_conn, vpc_id, route_table, check_mode):
+    for a_id in [a.id for a in route_table.associations]:
+        changed = True
+        vpc_conn.disassociate_route_table(a_id, dry_run=check_mode)
+
 
 def ensure_propagation(vpc_conn, route_table, propagating_vgw_ids,
                        check_mode):
@@ -427,6 +433,7 @@ def ensure_route_table_absent(connection, module):
     if route_table is None:
         return {'changed': False}
 
+    remove_subnet_associations(connection, vpc_id, route_table, check_mode)
     try:
         connection.delete_route_table(route_table.id, dry_run=check_mode)
     except EC2ResponseError as e:


### PR DESCRIPTION
When trying to delete a route table it fails as subnets are still associated with it.

If I have this in route-test.yml

``` yaml
- ec2_vpc_route_table:
        state: absent
        vpc_id: "{{ vpc_id }}"
        subnets: "{{ subnets }}"
        routes: "{{ routes }}"
        resource_tags:
          Name: test
```

And then run:

``` bash
$ ansible-playbook route-test.yml -vvv
PLAY [test deleting a route with ec2_vpc_route_table] **************************

TASK [ec2_vpc_route_table subnets={{ subnets }} state=absent resource_tags={u'Name': u'test'} routes={{ routes }} vpc_id={{ vpc_id }} region={{ region }}] ***
task path: /Users/mschurenko/git/mschurenko/aws_accounts/route-test.yml:13
ESTABLISH LOCAL CONNECTION FOR USER: mschurenko
localhost EXEC (umask 22 && mkdir -p "`echo $HOME/.ansible/tmp/ansible-tmp-1447808165.89-163262947445826`" && echo "`echo $HOME/.ansible/tmp/ansible-tmp-1447808165.89-163262947445826`")
localhost PUT /var/folders/fl/zr66x4cd3xz_l08tsdmhj6080000gq/T/tmppnHfTX TO /Users/mschurenko/.ansible/tmp/ansible-tmp-1447808165.89-163262947445826/ec2_vpc_route_table
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /Users/mschurenko/.ansible/tmp/ansible-tmp-1447808165.89-163262947445826/ec2_vpc_route_table; rm -rf "/Users/mschurenko/.ansible/tmp/ansible-tmp-1447808165.89-163262947445826/" > /dev/null 2>&1
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"region": "us-west-2", "resource_tags": {"Name": "test"}, "routes": [{"dest": "0.0.0.0/0", "gateway_id": "igw-7fb12b1a"}], "state": "absent", "subnets": "subnet-019ed676", "vpc_id": "vpc-0394b066"}, "module_name": "ec2_vpc_route_table"}, "msg": "The routeTable 'rtb-0e0e396b' has dependencies and cannot be deleted."}

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1
```

This PR runs disassociate_route_table to remove all the existing associated subnets first.
