### PR TITLE
win_updates: fix race condition and missing property

### DIFF
--- a/windows/win_updates.ps1
+++ b/windows/win_updates.ps1
@@ -337,7 +337,7 @@ Function RunAsScheduledJob {
   $sw = [System.Diagnostics.Stopwatch]::StartNew()
 
   # NB: output from scheduled jobs is delayed after completion (including the sub-objects after the primary Output object is available)
-  While (($job.Output -eq $null -or -not $job.Output.Keys.Contains('job_output')) -and $sw.ElapsedMilliseconds -lt 15000) {
+  While (($job.Output -eq $null -or -not ($job.Output | Get-Member -Name Keys) -or -not $job.Output.Keys.Contains('job_output')) -and $sw.ElapsedMilliseconds -lt 15000) {
     Write-DebugLog "Waiting for job output to populate..."
     Start-Sleep -Milliseconds 500
   }


### PR DESCRIPTION
Hey,

i'm using win 2012 R2 and ansible v2.0.0-0.5.beta3, sometimes the update task fails with the following message:

```
TASK [win_updates state=searched category_names={{ categories }}] **************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
fatal: [xxxxxxx]: FAILED! => {"changed": false, "failed": true, "msg": "Die Eigenschaft \"Keys\" wurde für dieses Objekt nicht gefunden. Vergewissern Sie sich, dass die Eigenschaft vorhanden ist."}
```

The error message is german and means something like: "The property Keys does not exists on this object...." and it seems that the property is not fully populated

the full error message is:

```
PS C:\Users\XXXXXXX\AppData\Local\Temp\ansible-tmp-1448005811.92-116284583592689> .\win_updates.ps1

Name                           Value
----                           -----
state                          searched
category_names                 {Application, Connectors, CriticalUpdates, DefinitionUpdates...}
DEBUG: 2015-11-20 08:52:14Z Arguments: System.Collections.Hashtable | out-string
DEBUG: 2015-11-20 08:52:14Z OS Version:
Major  Minor  Build  Revision
-----  -----  -----  --------
6      3      9600   0


DEBUG: 2015-11-20 08:52:14Z Running as user: XXXXXXX
DEBUG: 2015-11-20 08:52:14Z Starting scheduled job with args:
Name                           Value


----                           -----


state                          searched


category_names                 {Application, Connectors, CriticalUpdates, DefinitionUpdates...}




DEBUG: 2015-11-20 08:52:14Z Registering scheduled job with args
Name                           Value


----                           -----


ScheduledJobOption             {RunElevated}


ArgumentList                   {System.Collections.Hashtable}


InitializationScript           ...


Name                           ansible-win-updates


ScriptBlock                    ...


ErrorAction                    Stop




DEBUG: 2015-11-20 08:52:14Z Starting scheduled job (PS4 method)
DEBUG: 2015-11-20 08:52:14Z Waiting for job completion...
Die Eigenschaft "Keys" wurde für dieses Objekt nicht gefunden. Vergewissern Sie sich, dass die Eigenschaft vorhanden
ist.
In C:\Users\XXXXXX\AppData\Local\Temp\ansible-tmp-1448005811.92-116284583592689\win_updates.ps1:566 Zeichen:10
+   While (($job.Output -eq $null -or -not $job.Output.Keys.Contains('job_output') ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [], ParentContainsErrorRecordException
    + FullyQualifiedErrorId : PropertyNotFoundStrict
```
