### PR TITLE
Fixing Issue #1236

### DIFF
--- a/windows/win_regedit.ps1
+++ b/windows/win_regedit.ps1
@@ -31,8 +31,6 @@ $state = Get-Attr -obj $params -name "state" -validateSet "present","absent" -de
 $registryData = Get-Attr -obj $params -name "data" -default $null
 $registryDataType = Get-Attr -obj $params -name "datatype" -validateSet "binary","dword","expandstring","multistring","string","qword" -default "string"
 
-$registryKey = "Registry::" + $registryKey
-
 If ($state -eq "present" -and $registryData -eq $null -and $registryValue -ne $null)
 {
     Fail-Json $result "missing required argument: data"


### PR DESCRIPTION
Regarding Issue #1107 - Appending "Registry::" no longer works correctly.  I think it has to do with updates to "Get-Attr".  The error I receive when appending "Registry::" and attempting to create a key:

```
{"changed": false, "failed": true, "msg": "Cannot process argument because the value of argument \"path\" is not valid. Change the value of the \"path\" argument and run the operation again."}
```

I have tested this on Windows 7, 8.1, 10, and Server 2012.  With "Registry::" appended, the script failed to create registry keys as well as delete them.  If there are errors regarding interactive mode, it is how the account is authenticating / account permissions.

Removing the appended "Registry::" has corrected all functionality when testing locally.

Fix for: #1236 
@jhawkesworth Please let me know if this fixes the issue for you!
