### PR TITLE
Update 'patch' documentation for src, remote_src, backup and binary.

### DIFF
--- a/files/patch.py
+++ b/files/patch.py
@@ -46,17 +46,17 @@ options:
   src:
     description:
       - Path of the patch file as accepted by the GNU patch tool. If
-        C(remote_src) is False, the patch source file is looked up from the
+        C(remote_src) is 'no', the patch source file is looked up from the
         module's "files" directory.
     required: true
     aliases: [ "patchfile" ]
   remote_src:
     description:
-      - If False, it will search for src at originating/master machine, if True it will
-        go to the remote/target machine for the src. Default is False.
-    choices: [ "True", "False" ]
+      - If C(no), it will search for src at originating/master machine, if C(yes) it will
+        go to the remote/target machine for the src. Default is C(no).
+    choices: [ "yes", "no" ]
     required: false
-    default: "False"
+    default: "no"
   strip:
     description:
       - Number that indicates the smallest prefix containing leading slashes
@@ -70,15 +70,17 @@ options:
     description:
       - passes --backup --version-control=numbered to patch, 
         producing numbered backup copies
+    choices: [ 'yes', 'no' ]
+    default: 'no'
   binary:
     version_added: "2.0"
     description:
-      - Setting to true will disable patch's heuristic for transforming CRLF
+      - Setting to C(yes) will disable patch's heuristic for transforming CRLF
         line endings into LF. Line endings of src and dest must match. If set to
-        False, patch will replace CRLF in src files on POSIX.
+        C(no), patch will replace CRLF in src files on POSIX.
     required: false
     type: "bool"
-    default: "False"
+    default: "no"
 note:
   - This module requires GNU I(patch) utility to be installed on the remote host.
 '''


### PR DESCRIPTION
The patch module has a few missing items, and inconsistencies, in its
documentation. A few of which are addressed here.

Within Ansible documentation, the choices for boolean values are
commonly 'yes', and 'no'. We standardise the options on that.

'remote_src' documentation uses 'False' and 'True' for its documentation,
so these have been updated in both the choices and default.

'src' documentation refers to 'remote_src', so is updated to use
the 'no' choice.

'backup' did not describe its options and default at all, so we add
them.

'binary' default used 'False', but specified the type as 'bool' which is
implicitly documented as 'yes'/'no', so we make that 'no' as well.
