### PR TITLE
exchanged all json imports with a fail safe variant for simplejson

### DIFF
--- a/cloud/amazon/ecs_cluster.py
+++ b/cloud/amazon/ecs_cluster.py
@@ -101,7 +101,25 @@ status:
     type: string
 '''
 try:
-    import json, time
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
+try:
+    time
     import boto
     HAS_BOTO = True
 except ImportError:

--- a/cloud/amazon/ecs_task.py
+++ b/cloud/amazon/ecs_task.py
@@ -99,6 +99,23 @@ task:
 '''
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
+try:
     import boto
     import botocore
     HAS_BOTO = True

--- a/cloud/amazon/ecs_taskdefinition.py
+++ b/cloud/amazon/ecs_taskdefinition.py
@@ -96,6 +96,23 @@ taskdefinition:
 '''
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
+try:
     import boto
     import botocore
     HAS_BOTO = True

--- a/cloud/amazon/route53_facts.py
+++ b/cloud/amazon/route53_facts.py
@@ -161,6 +161,23 @@ EXAMPLES = '''
 '''
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
+try:
     import boto
     import botocore
     HAS_BOTO = True

--- a/cloud/amazon/sns_topic.py
+++ b/cloud/amazon/sns_topic.py
@@ -73,10 +73,26 @@ EXAMPLES = """
         protocol: "sms"
 
 """
-
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import sys
 import time
-import json
 import re
 
 try:

--- a/cloud/docker/docker_login.py
+++ b/cloud/docker/docker_login.py
@@ -97,9 +97,25 @@ Login to a Docker registry without performing any other action. Make sure that t
     dockercfg_path: /tmp/.mydockercfg
 
 '''
-
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import os.path
-import json
 import base64
 from urlparse import urlparse
 from distutils.version import LooseVersion

--- a/cloud/vmware/vca_nat.py
+++ b/cloud/vmware/vca_nat.py
@@ -129,8 +129,25 @@ EXAMPLES = '''
 
 '''
 
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import time
-import json
 import xmltodict
 
 VALID_RULE_KEYS = ['rule_type', 'original_ip', 'original_port',

--- a/clustering/consul.py
+++ b/clustering/consul.py
@@ -192,9 +192,22 @@ import sys
 
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-    import simplejson as json
-
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 try:
     import consul
     from requests.exceptions import ConnectionError

--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -124,9 +124,22 @@ import sys
 
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-    import simplejson as json
-
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 try:
     import consul
     from requests.exceptions import ConnectionError

--- a/database/misc/riak.py
+++ b/database/misc/riak.py
@@ -102,9 +102,22 @@ import socket
 import sys
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-    import simplejson as json
-
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def ring_check(module, riak_admin_bin):
     cmd = '%s ringready' % riak_admin_bin

--- a/messaging/rabbitmq_binding.py
+++ b/messaging/rabbitmq_binding.py
@@ -102,7 +102,24 @@ EXAMPLES = '''
 
 import requests
 import urllib
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def main():
     module = AnsibleModule(

--- a/messaging/rabbitmq_exchange.py
+++ b/messaging/rabbitmq_exchange.py
@@ -108,7 +108,24 @@ EXAMPLES = '''
 
 import requests
 import urllib
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def main():
     module = AnsibleModule(

--- a/messaging/rabbitmq_policy.py
+++ b/messaging/rabbitmq_policy.py
@@ -105,7 +105,24 @@ class RabbitMqPolicy(object):
         return False
 
     def set(self):
-        import json
+        try:
+            import json
+            # Detect the python-json library which is incompatible
+            # Look for simplejson if that's the case
+            try:
+                if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+                    raise ImportError
+                except AttributeError:
+                    raise ImportError
+                except ImportError:
+            try:
+                import simplejson as json
+            except ImportError:
+                print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+                sys.exit(1)
+            except SyntaxError:
+                print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+                sys.exit(1)
         args = ['set_policy']
         args.append(self._name)
         args.append(self._pattern)

--- a/messaging/rabbitmq_queue.py
+++ b/messaging/rabbitmq_queue.py
@@ -122,7 +122,24 @@ EXAMPLES = '''
 
 import requests
 import urllib
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def main():
     module = AnsibleModule(

--- a/monitoring/boundary_meter.py
+++ b/monitoring/boundary_meter.py
@@ -22,7 +22,24 @@ You should have received a copy of the GNU General Public License
 along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import datetime
 import base64
 import os

--- a/monitoring/circonus_annotation.py
+++ b/monitoring/circonus_annotation.py
@@ -19,7 +19,24 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 import requests
 import time
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 DOCUMENTATION = '''
 ---

--- a/monitoring/sensu_check.py
+++ b/monitoring/sensu_check.py
@@ -179,10 +179,24 @@ def sensu_check(module, path, name, state='present', backup=False):
     changed = False
     reasons = []
 
-    try:
-        import json
-    except ImportError:
-        import simplejson as json
+   try:
+       import json
+       # Detect the python-json library which is incompatible
+       # Look for simplejson if that's the case
+       try:
+           if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+               raise ImportError
+       except AttributeError:
+           raise ImportError
+   except ImportError:
+       try:
+           import simplejson as json
+       except ImportError:
+           print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+           sys.exit(1)
+       except SyntaxError:
+           print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+           sys.exit(1)    
 
     stream = None
     try:

--- a/monitoring/stackdriver.py
+++ b/monitoring/stackdriver.py
@@ -93,9 +93,23 @@ EXAMPLES = '''
 # Stackdriver module specific support methods.
 #
 try:
-  import json
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-  import simplejson as json
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def send_deploy_event(module, key, revision_id, deployed_by='Ansible', deployed_to=None, repository=None):
     """Send a deploy event to Stackdriver"""

--- a/monitoring/uptimerobot.py
+++ b/monitoring/uptimerobot.py
@@ -64,7 +64,24 @@ EXAMPLES = '''
 
 '''
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import urllib
 import time
 

--- a/network/ipify_facts.py
+++ b/network/ipify_facts.py
@@ -58,8 +58,22 @@ ipify_public_ip:
 
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-    import simplejson as json
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 class IpifyFacts(object):
 

--- a/notification/typetalk.py
+++ b/notification/typetalk.py
@@ -51,12 +51,22 @@ import urllib
 
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
     try:
         import simplejson as json
     except ImportError:
-        json = None
-
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def do_request(module, url, params, headers=None):
     data = urllib.urlencode(params)

--- a/packaging/language/composer.py
+++ b/packaging/language/composer.py
@@ -127,8 +127,22 @@ import re
 
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-    import simplejson as json
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 def parse_out(string):
     return re.sub("\s+", " ", string).strip()

--- a/packaging/language/npm.py
+++ b/packaging/language/npm.py
@@ -106,8 +106,22 @@ import os
 
 try:
     import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
 except ImportError:
-    import simplejson as json
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 
 class Npm(object):
     def __init__(self, module, **kwargs):

--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -109,7 +109,24 @@ EXAMPLES = '''
 - pacman: name=baz state=absent force=yes
 '''
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import shlex
 import os
 import re

--- a/packaging/os/pkgin.py
+++ b/packaging/os/pkgin.py
@@ -62,8 +62,24 @@ EXAMPLES = '''
 - pkgin: name=foo,bar state=absent
 '''
 
-
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import shlex
 import os
 import sys

--- a/packaging/os/pkgng.py
+++ b/packaging/os/pkgng.py
@@ -85,7 +85,24 @@ EXAMPLES = '''
 '''
 
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import shlex
 import os
 import re

--- a/packaging/os/portinstall.py
+++ b/packaging/os/portinstall.py
@@ -58,7 +58,24 @@ EXAMPLES = '''
 '''
 
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import shlex
 import os
 import sys

--- a/packaging/os/urpmi.py
+++ b/packaging/os/urpmi.py
@@ -73,7 +73,24 @@ EXAMPLES = '''
 '''
 
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import shlex
 import os
 import sys

--- a/source_control/github_hooks.py
+++ b/source_control/github_hooks.py
@@ -18,7 +18,24 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import base64
 
 DOCUMENTATION = '''

--- a/system/puppet.py
+++ b/system/puppet.py
@@ -15,6 +15,29 @@
 # You should have received a copy of the GNU General Public License
 # along with this software.  If not, see <http://www.gnu.org/licenses/>.
 
+try:
+    import json
+except ImportError:
+    import simplejson as json
+
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import os
 import pipes
 import stat

--- a/web_infrastructure/jira.py
+++ b/web_infrastructure/jira.py
@@ -160,7 +160,24 @@ EXAMPLES = """
         issue={{issue.meta.key}} operation=transition status="Done"
 """
 
-import json
+try:
+    import json
+    # Detect the python-json library which is incompatible
+    # Look for simplejson if that's the case
+    try:
+        if not isinstance(json.loads, types.FunctionType) or not isinstance(json.dumps, types.FunctionType):
+            raise ImportError
+    except AttributeError:
+        raise ImportError
+except ImportError:
+    try:
+        import simplejson as json
+    except ImportError:
+        print('{"msg": "Error: ansible requires the stdlib json or simplejson module, neither was found!", "failed": true}')
+        sys.exit(1)
+    except SyntaxError:
+        print('{"msg": "SyntaxError: probably due to installed simplejson being for a different python version", "failed": true}')
+        sys.exit(1)
 import base64
 
 def request(url, user, passwd, data=None, method=None):


### PR DESCRIPTION
See also pull request #1284.
import code is taken from module_utils/basic.py
redundancy is wanted as stated in above pull request notes.
