### PR TITLE
Check sooner for connectivity, before we call fw.getDefaultZone

### DIFF
--- a/system/firewalld.py
+++ b/system/firewalld.py
@@ -282,14 +282,6 @@ def main():
     immediate = module.params['immediate']
     timeout = module.params['timeout']
 
-    ## Check for firewalld running
-    try:
-        if fw.connected == False:
-            module.fail_json(msg='firewalld service must be running')
-    except AttributeError:
-        module.fail_json(msg="firewalld connection can't be established,\
-                version likely too old. Requires firewalld >= 2.0.11")
-
     modification_count = 0
     if service != None:
         modification_count += 1


### PR DESCRIPTION
Fix #1138.

Also drop the check for AttributeError since that's already tested
anyway with if FW_VERSION < "0.2.11".
