### PR TITLE
Fix win_regedit present fails on create new entry of registry

### DIFF
--- a/windows/win_regedit.ps1
+++ b/windows/win_regedit.ps1
@@ -107,7 +107,7 @@ if($state -eq "present") {
             $result.changed = $true
 
             if($registryValue -ne $null) {
-                $newRegistryKey | New-ItemProperty -Name $registryValue -Value $registryData -Force -PropertyType $registryDataType
+                $newRegistryKey | New-ItemProperty -Name $registryValue -Value $registryData -Force -PropertyType $registryDataType | Out-Null
                 $result.changed = $true
             }
         }


### PR DESCRIPTION
The win_regedit module in its current state fails when specified registry key does not exist.
This was due to `New-ItemProperty` prints extra message like below, and then ansible could not parse json in it.

```
{20D04FE0-3AEA-1069-A2D8-08002B30309D} : 0
PSPath                                 : Microsoft.PowerShell.Core\Registry::HK
                                         CU\Software\Microsoft\Windows\CurrentV
                                         ersion\Explorer\HideDesktopIcons\NewSt
                                         artPanel
PSParentPath                           : Microsoft.PowerShell.Core\Registry::HK
                                         CU\Software\Microsoft\Windows\CurrentV
                                         ersion\Explorer\HideDesktopIcons
PSChildName                            : NewStartPanel
PSProvider                             : Microsoft.PowerShell.Core\Registry

{"changed":true}

```
