### PR TITLE
maven_artifact: Set latest as version argument default value

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -294,7 +294,7 @@ def main():
         argument_spec = dict(
             group_id = dict(default=None),
             artifact_id = dict(default=None),
-            version = dict(default=None),
+            version = dict(default="latest"),
             classifier = dict(default=None),
             extension = dict(default='jar'),
             repository_url = dict(default=None),


### PR DESCRIPTION
This fix prevents the following error in case **dest** set to some directory and no value for **version** argument is provided

> dest = dest + "/" + artifact_id + "-" + version + "." + extension
> TypeError: cannot concatenate 'str' and 'NoneType' objects
