### PR TITLE
update current_link without downtime

### DIFF
--- a/web_infrastructure/deploy_helper.py
+++ b/web_infrastructure/deploy_helper.py
@@ -308,12 +308,27 @@ class DeployHelper(object):
                 self.module.fail_json(msg="%s exists but is not a symbolic link" % path)
 
     def create_link(self, source, link_name):
-        if not self.module.check_mode:
-            if os.path.islink(link_name):
-                os.unlink(link_name)
-            os.symlink(source, link_name)
+        changed = False
 
-        return True
+        if os.path.islink(link_name):
+            norm_link = os.path.normpath(os.path.realpath(link_name))
+            norm_source = os.path.normpath(os.path.realpath(source))
+            if norm_link == norm_source:
+                changed = False
+            else:
+                changed = True
+                if not self.module.check_mode:
+                    tmp_link_name = link_name + '.' + self.unfinished_filename
+                    if os.path.islink(tmp_link_name):
+                        os.unlink(tmp_link_name)
+                    os.symlink(source, tmp_link_name)
+                    os.rename(tmp_link_name, link_name)
+        else:
+            changed = True
+            if not self.module.check_mode:
+                os.symlink(source, link_name)
+
+        return changed
 
     def remove_unfinished_file(self, new_release_path):
         changed = False
@@ -329,13 +344,23 @@ class DeployHelper(object):
         changes = 0
 
         for release in os.listdir(releases_path):
-            if (os.path.isfile(os.path.join(releases_path, release, self.unfinished_filename))):
+            if os.path.isfile(os.path.join(releases_path, release, self.unfinished_filename)):
                 if self.module.check_mode:
                     changes += 1
                 else:
                     changes += self.delete_path(os.path.join(releases_path, release))
 
         return changes
+
+    def remove_unfinished_link(self, path):
+        changed = False
+
+        tmp_link_name = os.path.join(path, self.release + '.' + self.unfinished_filename)
+        if not self.module.check_mode and os.path.exists(tmp_link_name):
+            changed = True
+            os.remove(tmp_link_name)
+
+        return changed
 
     def cleanup(self, releases_path):
         changes = 0
@@ -415,10 +440,12 @@ def main():
         changes += deploy_helper.remove_unfinished_file(facts['new_release_path'])
         changes += deploy_helper.create_link(facts['new_release_path'], facts['current_path'])
         if deploy_helper.clean:
+            changes += deploy_helper.remove_unfinished_link(facts['path'])
             changes += deploy_helper.remove_unfinished_builds(facts['releases_path'])
             changes += deploy_helper.cleanup(facts['releases_path'])
 
     elif deploy_helper.state == 'clean':
+        changes += deploy_helper.remove_unfinished_link(facts['path'])
         changes += deploy_helper.remove_unfinished_builds(facts['releases_path'])
         changes += deploy_helper.cleanup(facts['releases_path'])
 


### PR DESCRIPTION
if `current_path` is a link, `deploy_helper` will unlink it and re-link it. That will cause downtime, such as http 404 error.

`os.rename` can avoid this downtime.
