### PR TITLE
Fix 'An error occurred while looking up _xmpp-client._tcp.10.100.1.10…8' when IP host is configured

### DIFF
--- a/notification/jabber.py
+++ b/notification/jabber.py
@@ -134,7 +134,7 @@ def main():
     msg = xmpp.protocol.Message(body=module.params['msg'])
 
     try:
-        conn=xmpp.Client(server)
+        conn=xmpp.Client(server, debug=[])
         if not conn.connect(server=(host,port)):
             module.fail_json(rc=1, msg='Failed to connect to server: %s' % (server))
         if not conn.auth(user,password,'Ansible'):


### PR DESCRIPTION
jabber_notification.yml
...
    jabber: user=ansible@mydomain.tld
            host=10.100.1.108
...

fatal: [bruce.mess.cz] => failed to parse: Invalid debugflag given: always
Invalid debugflag given: nodebuilder
