### PR TITLE
Doc fix on route53_health_check.py and ec2_vpc_route_table.py.

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -77,8 +77,8 @@ EXAMPLES = '''
     tags:
       Name: Public
     subnets:
-      - "{{ jumpbox_subnet.subnet_id }}"
-      - "{{ frontend_subnet.subnet_id }}"
+      - "{{ jumpbox_subnet.subnet.id }}"
+      - "{{ frontend_subnet.subnet.id }}"
       - "{{ vpn_subnet.subnet_id }}"
     routes:
       - dest: 0.0.0.0/0
@@ -92,7 +92,7 @@ EXAMPLES = '''
     tags:
       Name: Internal
     subnets:
-      - "{{ application_subnet.subnet_id }}"
+      - "{{ application_subnet.subnet.id }}"
       - 'Database Subnet'
       - '10.0.0.0/8'
     routes:

--- a/cloud/amazon/route53_health_check.py
+++ b/cloud/amazon/route53_health_check.py
@@ -104,7 +104,7 @@ EXAMPLES = '''
     string_match: "Hello"
     request_interval: 10
     failure_threshold: 2
-  record: my_health_check
+  register: my_health_check
 
 - route53:
     action: create


### PR DESCRIPTION
Found issue in the doc examples. In the first example there is "record: my_health_check" instead of "register: my_health_check"

Doc Fix ec2_vpc_route_table.py.
The way you can get the subnet id is with: 
"{{ jumpbox_subnet.subnet.id }}" instead of :"{{ jumpbox_subnet.subnet_id }}"
