### PR TITLE
monitoring/nagios bug: nagios/icinga error due to extraneous space at end of command string

### DIFF
--- a/monitoring/nagios.py
+++ b/monitoring/nagios.py
@@ -873,7 +873,7 @@ class Nagios(object):
         pre = '[%s]' % int(time.time())
 
         post = '\n'
-        cmdstr = '%s %s %s' % (pre, cmd, post)
+        cmdstr = '%s %s%s' % (pre, cmd, post)
         self._write_command(cmdstr)
 
     def act(self):


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 1.9.4 (czen-1.9.4-1 b8987ca055) last updated 2015/10/27 15:25:01 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 71228f86c4) last updated 2015/10/27 15:28:22 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD b9103a4d9c) last updated 2015/10/27 15:28:27 (GMT +000)
##### Ansible Configuration:

n/a
##### Environment:

n/a
##### Summary:

When submitting a raw nagios command via the nagios module, nagios/icinga always complains because of an extraneous space added to the command string. The function `nagios_cmd` adds this extra space when packaging up the command to send it to nagios/icinga.  This pull request simply removes that one extraneous space.
##### Steps To Reproduce:

Invoke a task like this:

```
- nagios: action=command  command='DISABLE_HOST_SVC_NOTIFICATIONS;some_host'
```

The following error appears in the nagios/icinga error log:

> [2015-12-11 16:01:36 +0000] warning/ExternalCommandListener: External command failed.Error: Cannot disable notifications for all services  for non-existent host 'some_host '

Note that there is an extraneous space at the end of the quoted hostname.
##### Expected Results:

Nagios/Icinga should disable all service notifications for the specified host.
##### Actual Results:

Nothing happens in Nagios/Icinga due to the malformed command.

Note: I am running icinga 2.3.11 
