### PR TITLE
Return actual queue attributes with result from sqs_queue creation/update

### DIFF
--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -107,13 +107,14 @@ def create_or_update_sqs_queue(connection, module):
     result = dict(
         region=module.params.get('region'),
         name=queue_name,
+        attributes=dict(),
     )
-    result.update(queue_attributes)
 
     try:
         queue = connection.get_queue(queue_name)
         if queue:
             # Update existing
+            result['attributes'].update(connection.get_queue_attributes(queue))
             result['changed'] = update_sqs_queue(queue, check_mode=module.check_mode, **queue_attributes)
 
         else:
@@ -121,6 +122,7 @@ def create_or_update_sqs_queue(connection, module):
             if not module.check_mode:
                 queue = connection.create_queue(queue_name)
                 update_sqs_queue(queue, **queue_attributes)
+                result['attributes'].update(connection.get_queue_attributes(queue))
             result['changed'] = True
 
     except BotoServerError:

--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -66,6 +66,41 @@ extends_documentation_fragment:
     - ec2
 """
 
+RETURN = '''
+default_visibility_timeout: 
+    description: The default visibility timeout in seconds.
+    returned: always
+    sample: 30
+delivery_delay: 
+    description: The delivery delay in seconds.
+    returned: always
+    sample: 0
+maximum_message_size: 
+    description: The maximum message size in bytes.
+    returned: always
+    sample: 262144
+message_retention_period: 
+    description: The message retention period in seconds.
+    returned: always
+    sample: 345600
+name:
+    description: Name of the SQS Queue
+    returned: always
+    sample: "queuename-987d2de0"
+queue_arn:
+    description: The queue's Amazon resource name (ARN).
+    returned: on successful creation or update of the queue
+    sample: 'arn:aws:sqs:us-east-1:199999999999:queuename-987d2de0'
+receive_message_wait_time: 
+    description: The receive message wait time in seconds.
+    returned: always
+    sample: 0
+region:
+    description: Region that the queue was created within
+    returned: always
+    sample: 'us-east-1'
+'''
+
 EXAMPLES = '''
 # Create SQS queue
 - sqs_queue:
@@ -107,22 +142,32 @@ def create_or_update_sqs_queue(connection, module):
     result = dict(
         region=module.params.get('region'),
         name=queue_name,
-        attributes=dict(),
     )
+    result.update(queue_attributes)
 
     try:
         queue = connection.get_queue(queue_name)
         if queue:
-            # Update existing
-            result['attributes'].update(connection.get_queue_attributes(queue))
+            # Update existing            
             result['changed'] = update_sqs_queue(queue, check_mode=module.check_mode, **queue_attributes)
+            result['queue_arn'] = queue.get_attributes('QueueArn')['QueueArn']
+            result['default_visibility_timeout'] = queue.get_attributes('VisibilityTimeout')['VisibilityTimeout']
+            result['message_retention_period'] = queue.get_attributes('MessageRetentionPeriod')['MessageRetentionPeriod']
+            result['maximum_message_size'] = queue.get_attributes('MaximumMessageSize')['MaximumMessageSize']
+            result['delivery_delay'] = queue.get_attributes('DelaySeconds')['DelaySeconds']
+            result['receive_message_wait_time'] = queue.get_attributes('ReceiveMessageWaitTimeSeconds')['ReceiveMessageWaitTimeSeconds']
 
         else:
             # Create new
             if not module.check_mode:
                 queue = connection.create_queue(queue_name)
                 update_sqs_queue(queue, **queue_attributes)
-                result['attributes'].update(connection.get_queue_attributes(queue))
+                result['queue_arn'] = queue.get_attributes('QueueArn')['QueueArn']
+                result['default_visibility_timeout'] = queue.get_attributes('VisibilityTimeout')['VisibilityTimeout']
+                result['message_retention_period'] = queue.get_attributes('MessageRetentionPeriod')['MessageRetentionPeriod']
+                result['maximum_message_size'] = queue.get_attributes('MaximumMessageSize')['MaximumMessageSize']
+                result['delivery_delay'] = queue.get_attributes('DelaySeconds')['DelaySeconds']
+                result['receive_message_wait_time'] = queue.get_attributes('ReceiveMessageWaitTimeSeconds')['ReceiveMessageWaitTimeSeconds']
             result['changed'] = True
 
     except BotoServerError:


### PR DESCRIPTION
Previously sqs_queue was only returning the requested queue attributes, and not even returning the QueueARN for use elsewhere.  Now it will return the actual attributes in 'results.attributes', which is retrieved with boto's get_queue_attributes() after the queue has been created or updated.
