### PR TITLE
Add support for AWS Redshift clusters and snapshots

### DIFF
--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -412,8 +412,8 @@ def create_cluster(module, redshift):
         if prm:
             params[p] = prm
 
-    if check_cluster_exists(identifier):
-        return describe_clusters(module, redshift)
+    if check_cluster_exists(redshift, identifier):
+        return describe_cluster(module, redshift)
 
     if CHECK_MODE:
         return (True, {})
@@ -425,7 +425,7 @@ def create_cluster(module, redshift):
         module.fail_json(msg=json_response_err_msg(e))
 
     if wait:
-        check_exists = partial(check_cluster_exists, redshift, identifier)
+        check_exists = partial(check_resource_status, redshift, identifier)
         if not wait_for_condition(check_exists, wait_timeout):
             module.fail_json(
                 msg='Timed out while creating cluster "{}"'.format(identifier))

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -30,29 +30,24 @@ options:
     description:
       - Specifies the action to take.
     required: true
-    default: null
     choices: [ 'create', 'facts', 'delete', 'modify', 'snapshot', 'restore' ]
   identifier:
     description:
       - Redshift cluster identifier.
     required: true
-    default: null
   node_type:
     description:
       - The node type of the cluster. Must be specified when command=create.
-    required: true
-    default: null
+    required: false
     choices: ['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge', 'dc1.large', 'dc1.8xlarge', 'ds2.xlarge', 'ds2.8xlarge', 'ds1.large', 'ds1.8xlarge']
   username:
     description:
       - Master database username. Used only when command=create.
-    required: true
-    default: null
+    required: false
   password:
     description:
       - Master database password. Used only when command=create.
     required: true
-    default: null
   cluster_type:
     description:
       - The type of cluster.
@@ -174,7 +169,7 @@ options:
     aliases: [ 'ec2_access_key', 'access_key' ]
   wait:
     description:
-      - When command=create, modify or restore then wait for the database to enter the 'available' state. When command=delete wait for the database to be terminated.
+      - When creating, modifying or restoring a cluster, we will wait for the database to enter the 'available' state. When deleting, wait for the database to be terminated.
     required: false
     default: "no"
     choices: [ "yes", "no" ]
@@ -803,85 +798,64 @@ def main():
     global CHECK_MODE
 
     argument_spec = ec2_argument_spec()
-    argument_spec.update({
+    argument_spec.update(dict(
 
-        'command':                      dict(choices=['create',
-                                                      'facts',
-                                                      'delete',
-                                                      'modify',
-                                                      'snapshot',
-                                                      'restore'],
-                                             required=True),
+        command=dict(choices=['create', 'facts', 'delete', 'modify',
+                                'snapshot', 'restore'], required=True),
 
-        'identifier':                   dict(required=True),
+        identifier=dict(required=True),
 
         # NOTE: dw1.* and dw2.* cluster types have been deprecated
-        'node_type':                    dict(choices=['dw1.xlarge',
-                                                      'dw1.8xlarge',
-                                                      'dw2.large',
-                                                      'dw2.8xlarge',
-                                                      'dc1.large',
-                                                      'dc1.8xlarge',
-                                                      'ds2.xlarge',
-                                                      'ds2.8xlarge',
-                                                      'ds1.large',
-                                                      'ds1.8xlarge'],
-                                             required=False),
+        node_type=dict(choices=['dw1.xlarge', 'dw1.8xlarge', 'dw2.large',
+                                  'dw2.8xlarge', 'dc1.large', 'dc1.8xlarge',
+                                  'ds2.xlarge', 'ds2.8xlarge', 'ds1.large',
+                                  'ds1.8xlarge'], required=False),
 
-        'username':                     dict(required=False),
+        username=dict(required=False),
 
-        'password':                     dict(no_log=True, required=False),
+        password=dict(no_log=True, required=False),
 
-        'db_name':                      dict(required=False),
+        db_name=dict(required=False),
 
-        'cluster_type':                 dict(choices=['multi-node',
-                                                      'single-node'],
-                                             default='single-node'),
+        cluster_type=dict(choices=['multi-node', 'single-node'], default='single-node'),  # noqa
 
-        'cluster_security_groups':      dict(aliases=['security_groups'],
-                                             type='list'),
+        cluster_security_groups=dict(aliases=['security_groups'], type='list'),  # noqa
 
-        'vpc_security_group_ids':       dict(aliases=['vpc_security_groups'],
-                                             type='list'),
+        vpc_security_group_ids=dict(aliases=['vpc_security_groups'], type='list'),  # noqa
 
-        'cluster_subnet_group_name':    dict(aliases=['subnet']),
+        cluster_subnet_group_name=dict(aliases=['subnet']),
 
-        'availability_zone':            dict(aliases=['aws_zone', 'zone']),
+        availability_zone=dict(aliases=['aws_zone', 'zone']),
 
-        'preferred_maintenance_window': dict(aliases=['maintance_window',
-                                                      'maint_window']),
+        preferred_maintenance_window=dict(aliases=['maintance_window', 'maint_window']),  # noqa
 
-        'cluster_parameter_group_name': dict(aliases=['param_group_name']),
+        cluster_parameter_group_name=dict(aliases=['param_group_name']),
 
-        'port':                         dict(type='int'),
+        port=dict(type='int'),
 
-        'cluster_version':              dict(aliases=['version'],
-                                             choices=['1.0']),
+        cluster_version=dict(aliases=['version'], choices=['1.0']),
 
-        'allow_version_upgrade':        dict(aliases=['version_upgrade'],
-                                             type='bool'),
+        allow_version_upgrade=dict(aliases=['version_upgrade'], type='bool'),
 
-        'number_of_nodes':              dict(type='int'),
+        number_of_nodes=dict(type='int'),
 
-        'publicly_accessible':          dict(type='bool'),
+        publicly_accessible=dict(type='bool'),
 
-        'encrypted':                    dict(type='bool'),
+        encrypted=dict(type='bool'),
 
-        'elastic_ip':                   dict(required=False),
+        elastic_ip=dict(required=False),
 
-        'new_cluster_identifier':       dict(aliases=['new_identifier']),
+        new_cluster_identifier=dict(aliases=['new_identifier']),
 
-        'snapshot':                     dict(aliases=['final_snapshot'],
-                                             required=False),
+        snapshot=dict(aliases=['final_snapshot'], required=False),
 
-        'wait':                         dict(type='bool', default=False),
+        wait=dict(type='bool', default=False),
 
-        'wait_timeout':                 dict(type='int', default=300),
+        wait_timeout=dict(type='int', default=300),
 
-        'automated_snapshot_retention_period':
-            dict(aliases=['retention_period']),
+        automated_snapshot_retention_period=dict(aliases=['retention_period']),
 
-        }
+        )
     )
 
     module = AnsibleModule(argument_spec=argument_spec,

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -39,7 +39,7 @@ options:
       - The node type of the cluster. Must be specified when command=create.
     required: true
     default: null
-    choices: ['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge', ]
+    choices: ['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge', 'dc1.large', 'dc1.8xlarge', 'ds2.xlarge', 'ds2.8xlarge', 'ds1.large', 'ds1.8xlarge']
   username:
     description:
       - Master database username. Used only when command=create.
@@ -463,7 +463,9 @@ def main():
     argument_spec.update(dict(
             command                             = dict(choices=['create', 'facts', 'delete', 'modify'], required=True),
             identifier                          = dict(required=True),
-            node_type                           = dict(choices=['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge', ], required=False),
+            node_type                           = dict(choices=['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge',
+                                                                'dc1.large', 'dc1.8xlarge', 'ds2.xlarge', 'ds2.8xlarge',
+                                                                'ds1.large', 'ds1.8xlarge'], required=False),
             username                            = dict(required=False),
             password                            = dict(no_log=True, required=False),
             db_name                             = dict(require=False),

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -412,8 +412,12 @@ def create_cluster(module, redshift):
                      'encrypted',
                      'elastic_ip')
 
-    params = {p: module.params[p] for p in create_params
-              if module.params.get(p)}
+    params = {}
+
+    for p in create_params:
+        prm = module.params.get(p)
+        if prm:
+            params[p] = prm
 
     if check_cluster_exists(identifier):
         return describe_clusters(module, redshift)
@@ -514,8 +518,12 @@ def modify_cluster(module, redshift):
                      'number_of_nodes',
                      'new_cluster_identifier')
 
-    params = {p: module.params[p] for p in modify_params
-              if module.params.get(p)}
+    params = {}
+    for p in modify_params:
+        prm = module.params.get(p)
+        if prm:
+            params[p] = prm
+
     try:
         redshift.modify_cluster(identifier, **params)
     except boto.exception.JSONResponseError, e:
@@ -596,7 +604,11 @@ def restore_cluster(module, redshift):
                       'publicly_accessible',
                       'vpc_security_group_ids')
 
-    params = {p: module.params.get(p) for p in restore_params}
+    params = {}
+    for p in restore_params:
+        prm = module.params.get(p)
+        if prm:
+            params[p] = prm
 
     if not snapshot:
         module.fail_json(msg='Snapshot is required')

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -294,7 +294,14 @@ def create_cluster(module, redshift):
     changed = True
     # Package up the optional parameters
     params = {}
-    for p in ( 'db_name', 'cluster_type', 'cluster_security_groups', 'vpc_security_group_ids', 'cluster_subnet_group_name', 'availability_zone', 'preferred_maintenance_window', 'cluster_parameter_group_name', 'automated_snapshot_retention_period', 'port', 'cluster_version', 'allow_version_upgrade', 'number_of_nodes', 'publicly_accessible', 'encrypted', 'elastic_ip' ):
+    for p in ('db_name', 'cluster_type', 'cluster_security_groups',
+              'vpc_security_group_ids', 'cluster_subnet_group_name',
+              'availability_zone', 'preferred_maintenance_window',
+              'cluster_parameter_group_name',
+              'automated_snapshot_retention_period', 'port',
+              'cluster_version', 'allow_version_upgrade',
+              'number_of_nodes', 'publicly_accessible',
+              'encrypted', 'elastic_ip'):
         if module.params.get( p ):
             params[ p ] = module.params.get( p )
 
@@ -396,7 +403,6 @@ def modify_cluster(module, redshift):
 
     module: Ansible module object
     redshift: authenticated redshift connection object
-
     """
 
     identifier   = module.params.get('identifier')
@@ -405,7 +411,12 @@ def modify_cluster(module, redshift):
 
     # Package up the optional parameters
     params = {}
-    for p in ( 'cluster_type', 'cluster_security_groups', 'vpc_security_group_ids', 'cluster_subnet_group_name', 'availability_zone', 'preferred_maintenance_window', 'cluster_parameter_group_name', 'automated_snapshot_retention_period', 'port', 'cluster_version', 'allow_version_upgrade', 'number_of_nodes', 'new_cluster_identifier'):
+    for p in ('cluster_type', 'cluster_security_groups',
+              'vpc_security_group_ids', 'cluster_subnet_group_name',
+              'availability_zone', 'preferred_maintenance_window',
+              'cluster_parameter_group_name',
+              'automated_snapshot_retention_period', 'port', 'cluster_version',
+              'allow_version_upgrade', 'number_of_nodes', 'new_cluster_identifier'):
         if module.params.get( p ):
             params[ p ] = module.params.get( p )
 

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -359,6 +359,7 @@ def _collect_facts(resource):
         'kms_key_id':         resource.get('KmsKeyId'),
         'parameter_groups':   resource.get('ClusterParameterGroups'),
         'security_groups':    resource.get('ClusterSecurityGroups'),
+        'endpoint':           resource.get('Endpoint'),
     }
 
     for node in resource['ClusterNodes']:
@@ -367,9 +368,9 @@ def _collect_facts(resource):
             facts['public_ip_address'] = node.get('PublicIPAddress')
             break
 
-    if resource.get('endpoint') and isinstance(resource['endpoint'], dict):
+    if resource.get('Endpoint') and isinstance(resource['Endpoint'], dict):
         for c in ('Address', 'Port'):
-            facts[c.lower()] = resource.get('endpoint', {}).get(c)
+            facts[c.lower()] = resource.get('Endpoint', {}).get(c)
     return facts
 
 

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -220,18 +220,18 @@ except:
     sys.exit(1)
 
 
-def _collect_facts( resource ):
+def _collect_facts(resource):
     """
     Transfrom cluster inforamtion to dict.
     """
     d = {
-        'identifier'            : resource['ClusterIdentifier'],
-        'create_time'           : resource['ClusterCreateTime'],
-        'status'                : resource['ClusterStatus'],
-        'username'              : resource['MasterUsername'],
-        'db_name'               : resource['DBName'],
-        'availability_zone'     : resource['AvailabilityZone'],
-        'maintenance_window'    : resource['PreferredMaintenanceWindow'],
+        'identifier'        : resource['ClusterIdentifier'],
+        'create_time'       : resource['ClusterCreateTime'],
+        'status'            : resource['ClusterStatus'],
+        'username'          : resource['MasterUsername'],
+        'db_name'           : resource['DBName'],
+        'availability_zone' : resource['AvailabilityZone'],
+        'maintenance_window': resource['PreferredMaintenanceWindow'],
     }
 
     for node in resource['ClusterNodes']:
@@ -252,12 +252,12 @@ def create_cluster(module, redshift):
     Returns:
     """
 
-    identifier      = module.params.get('identifier')
-    node_type       = module.params.get('node_type')
-    username        = module.params.get('username')
-    password        = module.params.get('password')
-    wait            = module.params.get('wait')
-    wait_timeout    = module.params.get('wait_timeout')
+    identifier   = module.params.get('identifier')
+    node_type    = module.params.get('node_type')
+    username     = module.params.get('username')
+    password     = module.params.get('password')
+    wait         = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
 
     changed = True
     # Package up the optional parameters
@@ -301,7 +301,7 @@ def create_cluster(module, redshift):
             # https://github.com/boto/boto/issues/2776 is fixed.
             module.fail_json(msg = e.error_message)
 
-    return( changed, _collect_facts( resource ) )
+    return(changed, _collect_facts(resource))
 
 
 def describe_cluster(module, redshift):
@@ -316,7 +316,7 @@ def describe_cluster(module, redshift):
         # https://github.com/boto/boto/issues/2776 is fixed.
         module.fail_json(msg = 'Redshift cluster %s does not exist' % identifier)
 
-    return( True, _collect_facts( resource ) )
+    return(True, _collect_facts(resource))
 
 
 def delete_cluster(module, redshift):
@@ -327,9 +327,9 @@ def delete_cluster(module, redshift):
     redshift: authenticated redshift connection object
     """
 
-    identifier      = module.params.get('identifier')
-    wait            = module.params.get('wait')
-    wait_timeout    = module.params.get('wait_timeout')
+    identifier   = module.params.get('identifier')
+    wait         = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
 
     try:
         redshift.delete_custer( identifier )
@@ -355,7 +355,7 @@ def delete_cluster(module, redshift):
             # https://github.com/boto/boto/issues/2776 is fixed.
             module.fail_json(msg = e.error_message)
 
-    return( True, {} )
+    return(True, {})
 
 
 def modify_cluster(module, redshift):
@@ -367,9 +367,9 @@ def modify_cluster(module, redshift):
 
     """
 
-    identifier      = module.params.get('identifier')
-    wait            = module.params.get('wait')
-    wait_timeout    = module.params.get('wait_timeout')
+    identifier   = module.params.get('identifier')
+    wait         = module.params.get('wait')
+    wait_timeout = module.params.get('wait_timeout')
 
     # Package up the optional parameters
     params = {}
@@ -412,7 +412,7 @@ def modify_cluster(module, redshift):
             # https://github.com/boto/boto/issues/2776 is fixed.
             module.fail_json(msg = e.error_message)
 
-    return( True, _collect_facts( resource ) )
+    return(True, _collect_facts(resource))
 
 
 def main():

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -539,7 +539,8 @@ def modify_cluster(module, redshift):
             module.fail_json(
                 msg='Timed out waiting for cluster modification to complete.')
 
-    return(True, _collect_facts(resource))
+    (_, cluster) = describe_cluster(module, redshift)
+    return(True, cluster)
 
 
 def snapshot_cluster(module, redshift):

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -155,6 +155,8 @@ options:
     required: false
     aliases: ['final_snapshot']
     default: null
+  owner_account:
+    description: Used when command=restore, this is the account of the snapshot to restore from if this is a snapshot you do not own.
     required: false
     default: null
   wait:
@@ -608,6 +610,7 @@ def restore_cluster(module, redshift):
                       'cluster_security_groups',
                       'cluster_subnet_group_name',
                       'elastic_ip',
+                      'owner_account',
                       'port',
                       'preferred_maintenance_window',
                       'publicly_accessible',
@@ -846,6 +849,8 @@ def main():
         wait=dict(type='bool', default=False),
 
         wait_timeout=dict(type='int', default=300),
+
+        owner_account=dict(require=False),
 
         automated_snapshot_retention_period=dict(aliases=['retention_period']),
 

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -611,11 +611,15 @@ def restore_cluster(module, redshift):
     wait = module.params.get('wait')
     wait_timeout = module.params.get('wait_timeout')
 
-    restore_params = ('availability_zone',
+    restore_params = ('allow_version_upgrade',
+                      'automated_snapshot_retention_period',
+                      'availability_zone',
                       'cluster_parameter_group_name',
+                      'cluster_security_groups',
                       'cluster_subnet_group_name',
                       'elastic_ip',
                       'port',
+                      'preferred_maintenance_window',
                       'publicly_accessible',
                       'vpc_security_group_ids')
 

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -266,34 +266,34 @@ except:
 def _collect_facts(resource):
     """Transfrom cluster information to dict."""
     facts = {
-        'identifier'        : resource['ClusterIdentifier'],
-        'create_time'       : resource['ClusterCreateTime'],
-        'status'            : resource['ClusterStatus'],
-        'username'          : resource['MasterUsername'],
-        'db_name'           : resource['DBName'],
-        'availability_zone' : resource['AvailabilityZone'],
-        'maintenance_window': resource['PreferredMaintenanceWindow'],
-        'node_type'         : resource.get('NodeType'),
-        'public_key'        : resource.get('ClusterPublicKey'),
-        'endpoint'          : resource.get('Endpoint'),
-        'node_count'        : resource.get('NumberOfNodes'),
-        'modify_status'     : resource.get('ModifyStatus'),
-        'restore_status'    : resource.get('RestoreStatus'),
-        'vpc_id'            : resource.get('VpcId'),
-        'tags'              : resource.get('Tags'),
-        'parameter_group'   : resource.get('ParameterGroupName'),
+        'identifier':         resource.get('ClusterIdentifier'),
+        'create_time':        resource.get('ClusterCreateTime'),
+        'status':             resource.get('ClusterStatus'),
+        'username':           resource.get('MasterUsername'),
+        'db_name':            resource.get('DBName'),
+        'availability_zone':  resource.get('AvailabilityZone'),
+        'maintenance_window': resource.get('PreferredMaintenanceWindow'),
+        'node_type':          resource.get('NodeType'),
+        'public_key':         resource.get('ClusterPublicKey'),
+        'node_count':         resource.get('NumberOfNodes'),
+        'modify_status':      resource.get('ModifyStatus'),
+        'restore_status':     resource.get('RestoreStatus'),
+        'vpc_id':             resource.get('VpcId'),
+        'tags':               resource.get('Tags'),
+        'kms_key_id':         resource.get('KmsKeyId'),
+        'parameter_groups':   resource.get('ClusterParameterGroups'),
+        'security_groups':    resource.get('ClusterSecurityGroups'),
     }
 
     for node in resource['ClusterNodes']:
         if node['NodeRole'] in ('SHARED', 'LEADER'):
-            facts['private_ip_address'] = node['PrivateIPAddress']
-            facts['public_ip_address'] = node['PublicIPAddress']
+            facts['private_ip_address'] = node.get('PrivateIPAddress')
+            facts['public_ip_address'] = node.get('PublicIPAddress')
             break
 
-    if facts.get('endpoint') and isinstance(facts['endpoint'], dict):
-        facts['endpoint'] = \
-            {k.lower(): facts['endpoint'][k] for k in facts['endpoint']}
-
+    if resource.get('endpoint') and isinstance(resource['endpoint'], dict):
+        for c in ('Address', 'Port'):
+            facts[c.lower()] = resource.get('endpoint', {}).get(c)
     return facts
 
 

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -1,0 +1,485 @@
+#!/usr/bin/python
+
+# Copyright 2014 Jens Carl, Hothead Games Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: redshift
+short_description: create, delete, or modify an Amazon redshift instance
+description:
+    - Creates, deletes, or modifies redshift instances.
+options:
+  command:
+    description:
+      - Specifies the action to take.
+    required: true
+    default: null
+    aliases: []
+    choices: [ 'create', 'facts', 'delete', 'modify' ]
+  identifier:
+    description:
+      - Redshift cluster identifier.
+    required: true
+    default: null
+    aliases: []
+  node_type:
+    description:
+      - The node type of the cluster. Must be specified when command=create.
+    required: true
+    default: null
+    aliases: []
+    choices: ['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge', ]
+  username:
+    description:
+      - Master database username. Used only when command=create.
+    required: true
+    default: null
+    aliases: []
+  password:
+    description:
+      - Master database password. Used only when command=create.
+    required: true
+    default: null
+    aliases: []
+  cluster_type:
+    description:
+      - The type of cluster.
+    required: false
+    choices: ['multi-node', 'single-node' ]
+    default: 'single-node'
+  db_name:
+    description:
+      - Name of the database.
+    required: False
+    default: null
+    aliases: []
+  availability_zone:
+    description:
+      - availability zone in which to launch cluster
+    required: false
+    default: null
+    aliases: ['zone', 'aws_zone']
+  number_of_nodes:
+    description:
+      - Number of nodes. Only used when cluster_type=multi-node.
+    required: false
+    default: null
+    choices: []
+  cluster_subnet_group_name:
+    description:
+      - which subnet to place the cluster
+    required: false
+    default: null
+    aliases: ['subnet']
+    choices: []
+  cluster_security_groups:
+    description:
+      - in which security group the cluster belongs
+    required: false
+    default: null
+    aliases: ['security_groups']
+    choices: []
+  vpc_security_group_ids:
+    description:
+      - VPC security group
+    required: false
+    aliases: ['vpc_security_groups']
+    choices: []
+    default: null
+  preferred_maintenance_window:
+    description:
+      - maintenance window
+    required: false
+    aliases: ['maintance_window', 'maint_window']
+    default: null
+    choices: []
+  cluster_parameter_group_name:
+    description:
+      - name of the cluster parameter group
+    required: false
+    aliases: ['param_group_name']
+    choices: []
+    default: null
+  automated_snapshot_retention_period:
+    description:
+      - period when the snapshot take place
+    required: false
+    aliases: ['retention_period']
+    choices: []
+    default: null
+  port:
+    description:
+      - which port the cluster is listining
+    required: false
+    default: null
+    choices: []
+  cluster_version:
+    description:
+      - which version the cluster should have
+    required: false
+    aliases: ['version']
+    choices: ['1.0']
+    default: null
+  allow_version_upgrade:
+    description:
+      - flag to determinate if upgrade of version is possible
+    required: false
+    aliases: ['version_upgrade']
+    choices: []
+    default: null
+  number_of_nodes:
+    description:
+      - number of the nodes the cluster should run
+    required: false
+    choices: []
+    default: null
+  publicly_accessible:
+    description:
+      - if the cluster is accessible publicly or not
+    required: false
+    choices: []
+    default: null
+  encrypted:
+    description:
+      -  if the cluster is encrypted or not
+    required: false
+    choices: []
+    default: null
+  elastic_ip:
+    description:
+      - if the cluster has an elastic IP or not
+    required: false
+    choices: []
+    default: null
+  new_cluster_identifier:
+    description:
+      - Only used when command=modify.
+    required: false
+    aliases: ['new_identifier']
+    choices: []
+    default: null
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ 'ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ 'ec2_access_key', 'access_key' ]
+  wait:
+    description:
+      - When command=create, modify or restore then wait for the database to enter the 'available' state. When command=delete wait for the database to be terminated.
+    required: false
+    default: "no"
+    choices: [ "yes", "no" ]
+    aliases: []
+  wait_timeout:
+    description:
+      - how long before wait gives up, in seconds
+    default: 300
+    aliases: []
+
+requirements: [ 'boto' ]
+author: Jens Carl, Hothead Games Inc.
+'''
+
+EXAMPLES = '''
+# Basic cluster provisioning example
+- redshift: >
+    command=create
+    node_type=dw1.xlarge
+    identifier=new_cluster
+    username=cluster_admin
+    password=1nsecure
+'''
+
+import sys
+import time
+
+try:
+    import boto.redshift
+except:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+
+def _collect_facts( resource ):
+    """
+    Transfrom cluster inforamtion to dict.
+    """
+    d = {
+        'identifier'            : resource['ClusterIdentifier'],
+        'create_time'           : resource['ClusterCreateTime'],
+        'status'                : resource['ClusterStatus'],
+        'username'              : resource['MasterUsername'],
+        'db_name'               : resource['DBName'],
+        'availability_zone'     : resource['AvailabilityZone'],
+        'maintenance_window'    : resource['PreferredMaintenanceWindow'],
+    }
+
+    for node in resource['ClusterNodes']:
+        if node['NodeRole'] in ('SHARED', 'LEADER'):
+            d['private_ip_address'] = node['PrivateIPAddress']
+            break
+
+    return d
+
+
+def create_cluster(module, redshift):
+    """
+    Create a new cluster
+
+    module: AnsibleModule object
+    redshift: authenticated redshift connection object
+
+    Returns:
+    """
+
+    identifier      = module.params.get('identifier')
+    node_type       = module.params.get('node_type')
+    username        = module.params.get('username')
+    password        = module.params.get('password')
+    wait            = module.params.get('wait')
+    wait_timeout    = module.params.get('wait_timeout')
+
+    changed = True
+    # Package up the optional parameters
+    params = {}
+    for p in ( 'db_name', 'cluster_type', 'cluster_security_groups', 'vpc_security_group_ids', 'cluster_subnet_group_name', 'availability_zone', 'preferred_maintenance_window', 'cluster_parameter_group_name', 'automated_snapshot_retention_period', 'port', 'cluster_version', 'allow_version_upgrade', 'number_of_nodes', 'publicly_accessible', 'encrypted', 'elastic_ip' ):
+        if module.params.get( p ):
+            params[ p ] = module.params.get( p )
+
+    try:
+        redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+        changed = False
+    except boto.exception.JSONResponseError, e:
+        try:
+            redshift.create_cluster(identifier, node_type, username, password, **params)
+        except boto.exception.JSONResponseError, e:
+            # This won't produce a message, until this error
+            # https://github.com/boto/boto/issues/2776 is fixed.
+            module.fail_json(msg = e.error_message)
+
+    try:
+        resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = e.error_message)
+
+    if wait:
+        try:
+            wait_timeout = time.time() + wait_timeout
+            time.sleep(5)
+
+            while wait_timeout > time.time() and resource['ClusterStatus'] != 'available':
+                time.sleep(5)
+                if wait_timeout <= time.time():
+                    module.fail_json(msg = "Timeout waiting for resource %s" % resource.id)
+
+                resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+
+        except boto.exception.JSONResponseError, e:
+            # This won't produce a message, until this error
+            # https://github.com/boto/boto/issues/2776 is fixed.
+            module.fail_json(msg = e.error_message)
+
+    return( changed, _collect_facts( resource ) )
+
+
+def describe_cluster(module, redshift):
+    """
+    """
+    identifier = module.params.get('identifier')
+
+    try:
+        resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = 'Redshift cluster %s does not exist' % identifier)
+
+    return( True, _collect_facts( resource ) )
+
+
+def delete_cluster(module, redshift):
+    """
+    Delete a cluster.
+
+    module: Ansible module object
+    redshift: authenticated redshift connection object
+    """
+
+    identifier      = module.params.get('identifier')
+    wait            = module.params.get('wait')
+    wait_timeout    = module.params.get('wait_timeout')
+
+    try:
+        redshift.delete_custer( identifier )
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = e.error_message)
+
+    if wait:
+        try:
+            wait_timeout = time.time() + wait_timeout
+            resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+
+            while wait_timeout > time.time() and resource['ClusterStatus'] != 'deleting':
+                time.sleep(5)
+                if wait_timeout <= time.time():
+                    module.fail_json(msg = "Timeout waiting for resource %s" % resource.id)
+
+                resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+
+        except boto.exception.JSONResponseError, e:
+            # This won't produce a message, until this error
+            # https://github.com/boto/boto/issues/2776 is fixed.
+            module.fail_json(msg = e.error_message)
+
+    return( True, {} )
+
+
+def modify_cluster(module, redshift):
+    """
+    Modify an existing cluster.
+
+    module: Ansible module object
+    redshift: authenticated redshift connection object
+
+    """
+
+    identifier      = module.params.get('identifier')
+    wait            = module.params.get('wait')
+    wait_timeout    = module.params.get('wait_timeout')
+
+    # Package up the optional parameters
+    params = {}
+    for p in ( 'cluster_type', 'cluster_security_groups', 'vpc_security_group_ids', 'cluster_subnet_group_name', 'availability_zone', 'preferred_maintenance_window', 'cluster_parameter_group_name', 'automated_snapshot_retention_period', 'port', 'cluster_version', 'allow_version_upgrade', 'number_of_nodes', 'new_cluster_identifier'):
+        if module.params.get( p ):
+            params[ p ] = module.params.get( p )
+
+    try:
+        redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+        changed = False
+    except boto.exception.JSONResponseError, e:
+        try:
+            redshift.modify_cluster(identifier, **params)
+        except boto.exception.JSONResponseError, e:
+            # This won't produce a message, until this error
+            # https://github.com/boto/boto/issues/2776 is fixed.
+            module.fail_json(msg = e.error_message)
+
+    try:
+        resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = e.error_message)
+
+    if wait:
+        try:
+            wait_timeout = time.time() + wait_timeout
+            time.sleep(5)
+
+            while wait_timeout > time.time() and resource['ClusterStatus'] != 'available':
+                time.sleep(5)
+                if wait_timeout <= time.time():
+                    module.fail_json(msg = "Timeout waiting for resource %s" % resource.id)
+
+                resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
+
+        except boto.exception.JSONResponseError, e:
+            # This won't produce a message, until this error
+            # https://github.com/boto/boto/issues/2776 is fixed.
+            module.fail_json(msg = e.error_message)
+
+    return( True, _collect_facts( resource ) )
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+            command                             = dict(choices=['create', 'facts', 'delete', 'modify'], required=True),
+            identifier                          = dict(required=True),
+            node_type                           = dict(choices=['dw1.xlarge', 'dw1.8xlarge', 'dw2.large', 'dw2.8xlarge', ], required=False),
+            username                            = dict(required=False),
+            password                            = dict(no_log=True, required=False),
+            db_name                             = dict(require=False),
+            cluster_type                        = dict(choices=['multi-node', 'single-node', ], default='single-node'),
+            cluster_security_groups             = dict(aliases=['security_groups'], type='list'),
+            vpc_security_group_ids              = dict(aliases=['vpc_security_groups'], type='list'),
+            cluster_subnet_group_name           = dict(aliases=['subnet']),
+            availability_zone                   = dict(aliases=['aws_zone', 'zone']),
+            preferred_maintenance_window        = dict(aliases=['maintance_window', 'maint_window']),
+            cluster_parameter_group_name        = dict(aliases=['param_group_name']),
+            automated_snapshot_retention_period = dict(aliases=['retention_period']),
+            port                                = dict(type='int'),
+            cluster_version                     = dict(aliases=['version'], choices=['1.0']),
+            allow_version_upgrade               = dict(aliases=['version_upgrade'], type='bool'),
+            number_of_nodes                     = dict(type='int'),
+            publicly_accessible                 = dict(type='bool'),
+            encrypted                           = dict(type='bool'),
+            elastic_ip                          = dict(required=False),
+            new_cluster_identifier              = dict(aliases=['new_identifier']),
+            wait                                = dict(type='bool', default=False),
+            wait_timeout                        = dict(default=300),
+        )
+    )
+
+    module = AnsibleModule(
+        argument_spec = argument_spec,
+    )
+
+    command = module.params.get('command')
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    if not region:
+        module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
+
+    # connect to the rds endpoint
+    try:
+        conn = connect_to_aws(boto.redshift, region, **aws_connect_params)
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = e.error_message)
+
+    changed = True
+    if command == 'create':
+        (changed, cluster) = create_cluster(module, conn)
+
+    elif command == 'facts':
+        (changed, cluster) = describe_cluster(module, conn)
+
+    elif command == 'delete':
+        (changed, cluster) = delete_cluster(module, cron)
+
+    elif command == 'modify':
+        (changed, cluster) = modify_cluster(module, conn)
+
+    module.exit_json(changed=changed, cluster=cluster)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+main()

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -155,18 +155,8 @@ options:
     required: false
     aliases: ['final_snapshot']
     default: null
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
     required: false
     default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_access_key', 'access_key' ]
   wait:
     description:
       - When creating, modifying or restoring a cluster, we will wait for the database to enter the 'available' state. When deleting, wait for the database to be terminated.

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -871,7 +871,7 @@ def main():
 
         'wait':                         dict(type='bool', default=False),
 
-        'wait_timeout':                 dict(default=300),
+        'wait_timeout':                 dict(type='int', default=300),
 
         'automated_snapshot_retention_period':
             dict(aliases=['retention_period']),

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -478,7 +478,7 @@ def main():
                                                                 'ds1.large', 'ds1.8xlarge'], required=False),
             username                            = dict(required=False),
             password                            = dict(no_log=True, required=False),
-            db_name                             = dict(require=False),
+            db_name                             = dict(required=False),
             cluster_type                        = dict(choices=['multi-node', 'single-node', ], default='single-node'),
             cluster_security_groups             = dict(aliases=['security_groups'], type='list'),
             vpc_security_group_ids              = dict(aliases=['vpc_security_groups'], type='list'),

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -221,10 +221,8 @@ except:
 
 
 def _collect_facts(resource):
-    """
-    Transfrom cluster inforamtion to dict.
-    """
-    d = {
+    """Transfrom cluster information to dict."""
+    facts = {
         'identifier'        : resource['ClusterIdentifier'],
         'create_time'       : resource['ClusterCreateTime'],
         'status'            : resource['ClusterStatus'],
@@ -236,10 +234,10 @@ def _collect_facts(resource):
 
     for node in resource['ClusterNodes']:
         if node['NodeRole'] in ('SHARED', 'LEADER'):
-            d['private_ip_address'] = node['PrivateIPAddress']
+            facts['private_ip_address'] = node['PrivateIPAddress']
             break
 
-    return d
+    return facts
 
 
 def create_cluster(module, redshift):
@@ -273,16 +271,16 @@ def create_cluster(module, redshift):
         try:
             redshift.create_cluster(identifier, node_type, username, password, **params)
         except boto.exception.JSONResponseError, e:
-            # This won't produce a message, until this error
+            # FIXME: Change this to just set the error message when
             # https://github.com/boto/boto/issues/2776 is fixed.
-            module.fail_json(msg = e.error_message)
+            module.fail_json(msg = str(e))
 
     try:
         resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg = str(e))
 
     if wait:
         try:
@@ -297,9 +295,9 @@ def create_cluster(module, redshift):
                 resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
 
         except boto.exception.JSONResponseError, e:
-            # This won't produce a message, until this error
+            # FIXME: Change this to just set the error message when
             # https://github.com/boto/boto/issues/2776 is fixed.
-            module.fail_json(msg = e.error_message)
+            module.fail_json(msg = str(e))
 
     return(changed, _collect_facts(resource))
 
@@ -312,9 +310,9 @@ def describe_cluster(module, redshift):
     try:
         resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = 'Redshift cluster %s does not exist' % identifier)
+        module.fail_json(msg = str(e))
 
     return(True, _collect_facts(resource))
 
@@ -334,9 +332,9 @@ def delete_cluster(module, redshift):
     try:
         redshift.delete_custer( identifier )
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg = str(e))
 
     if wait:
         try:
@@ -351,9 +349,9 @@ def delete_cluster(module, redshift):
                 resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
 
         except boto.exception.JSONResponseError, e:
-            # This won't produce a message, until this error
+            # FIXME: Change this to just set the error message when
             # https://github.com/boto/boto/issues/2776 is fixed.
-            module.fail_json(msg = e.error_message)
+            module.fail_json(msg = str(e))
 
     return(True, {})
 
@@ -384,16 +382,16 @@ def modify_cluster(module, redshift):
         try:
             redshift.modify_cluster(identifier, **params)
         except boto.exception.JSONResponseError, e:
-            # This won't produce a message, until this error
+            # FIXME: Change this to just set the error message when
             # https://github.com/boto/boto/issues/2776 is fixed.
-            module.fail_json(msg = e.error_message)
+            module.fail_json(msg = str(e))
 
     try:
         resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg = str(e))
 
     if wait:
         try:
@@ -408,9 +406,9 @@ def modify_cluster(module, redshift):
                 resource = redshift.describe_clusters(identifier)['DescribeClustersResponse']['DescribeClustersResult']['Clusters'][0]
 
         except boto.exception.JSONResponseError, e:
-            # This won't produce a message, until this error
+            # FIXME: Change this to just set the error message when
             # https://github.com/boto/boto/issues/2776 is fixed.
-            module.fail_json(msg = e.error_message)
+            module.fail_json(msg = str(e))
 
     return(True, _collect_facts(resource))
 
@@ -459,9 +457,9 @@ def main():
     try:
         conn = connect_to_aws(boto.redshift, region, **aws_connect_params)
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg = str(e))
 
     changed = True
     if command == 'create':

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -365,7 +365,7 @@ def describe_cluster(module, redshift):
         # https://github.com/boto/boto/issues/2776 is fixed.
         module.fail_json(msg = str(e))
 
-    return(True, _collect_facts(resource))
+    return(False, _collect_facts(resource))
 
 
 def delete_cluster(module, redshift):

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -248,7 +248,7 @@ import time
 
 try:
     import boto
-    import redshift from boto
+    from boto import redshift
     HAS_BOTO = True
 except:
     HAS_BOTO = False

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -513,10 +513,10 @@ def modify_cluster(module, redshift):
                      'preferred_maintenance_window',
                      'cluster_parameter_group_name',
                      'automated_snapshot_retention_period',
-                     'port',
                      'cluster_version',
                      'allow_version_upgrade',
                      'number_of_nodes',
+                     'node_type',
                      'new_cluster_identifier')
 
     if CHECK_MODE:
@@ -527,6 +527,9 @@ def modify_cluster(module, redshift):
         prm = module.params.get(p)
         if prm:
             params[p] = prm
+
+    if module.params.get('password'):
+        params['master_user_password'] = module.params.get('password')
 
     try:
         redshift.modify_cluster(identifier, **params)

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -264,11 +264,21 @@ def _collect_facts(resource):
         'db_name'           : resource['DBName'],
         'availability_zone' : resource['AvailabilityZone'],
         'maintenance_window': resource['PreferredMaintenanceWindow'],
+        'node_type'         : resource.get('NodeType'),
+        'public_key'        : resource.get('ClusterPublicKey'),
+        'endpoint'          : resource.get('Endpoint'),
+        'node_count'        : resource.get('NumberOfNodes'),
+        'modify_status'     : resource.get('ModifyStatus'),
+        'restore_status'    : resource.get('RestoreStatus'),
+        'vpc_id'            : resource.get('VpcId'),
+        'tags'              : resource.get('Tags'),
+        'parameter_group'   : resource.get('ParameterGroupName'),
     }
 
     for node in resource['ClusterNodes']:
         if node['NodeRole'] in ('SHARED', 'LEADER'):
             facts['private_ip_address'] = node['PrivateIPAddress']
+            facts['public_ip_address'] = node['PublicIPAddress']
             break
 
     return facts

--- a/cloud/amazon/redshift.py
+++ b/cloud/amazon/redshift.py
@@ -394,6 +394,10 @@ def create_cluster(module, redshift):
     wait = module.params.get('wait')
     wait_timeout = module.params.get('wait_timeout')
 
+    if not node_type:
+        module.fail_json(
+            msg='node_type must be specified when creating a cluster.')
+
     create_params = ('db_name',
                      'cluster_type',
                      'cluster_security_groups',

--- a/cloud/amazon/redshift_snapshots.py
+++ b/cloud/amazon/redshift_snapshots.py
@@ -1,5 +1,7 @@
 #!/usr/bin/python
 
+# Copyright 2015 Herby Gillot
+#
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
 # the Free Software Foundation, either version 3 of the License, or
@@ -29,11 +31,11 @@ options:
         - Specifies the action to take. If none specified, lists snapshots by default.
         - 'list' lists all snapshots, or as per provided filters
         - 'facts' is the same as 'list'
-        - 'tag' ensures that the given tags are present on the named or matching snapshot(s)
+        - 'copy' enables copying an automated snapshot into a new manual snapshot. When a cluster is destroyed, its automated snapshots are usually destroyed with it, so this is useful to back up automated snapshots in such a case.
         - 'delete' deletes the named or matching snapshot(s)
       required: false
       default:  list
-      choices:  [ 'list', 'facts', 'tag', 'delete' ]
+      choices:  [ 'list', 'facts', 'copy', 'delete' ]
     cluster:
       description:
         - The Redshift cluster whose snapshots to use
@@ -44,12 +46,30 @@ options:
       aliases:
         - 'identifier'
         - 'instance'
-    snapshot:
+    cluster_pattern:
+      description:
+        - Filter for snapshots whose origin cluster's name matches this pattern
+      required: false
+      default:  null
+    name:
       description:
         - Redshift snapshot name for operating on a specific snapshot
         - Cannot be specified together with the "cluster" parameter
+      aliases:
+        - 'snapshot'
+        - 'source'
       required: false
       default:  null
+    name_pattern:
+      description:
+        - Regular expression that is used to filter through snapshot names
+      required: false
+      default:  null
+    dest:
+      description:
+        - Name of new snapshot to copy to when command=copy
+      required: false
+      default: null
     snapshot_type:
       description:
         - Filter for only snapshots created from a Redshift cluster of this type
@@ -67,6 +87,11 @@ options:
         - Date and time values should be specified in YYYY-MM-DD format, or YYYY-MM-DD'T'HH:MM
       required: false
       default:  null
+    force:
+      description:
+        - If copying and the destination snapshot exists, delete it so that the copy can proceed
+      required: false
+      default:  false
     greater_than_mb:
       description:
         - Filter for only snapshots larger than the given value in megabytes.
@@ -79,22 +104,215 @@ options:
         - Must be specified as a decimal (1.0, 0.0, 5.5, etc.)
       required: false
       default:  null
+    sort_by:
+      description:
+        - Return field to sort snapshots on.
+      required: false
+      default:  'create_time_epoch'
+    reverse_sort:
+      description:
+        - If set to True, reverses the sort direction
+      required: false
+      default:  false
     tags:
       description:
-        - Dictionary of tags to values.
-        - If command=list, filter for snapshots with these tags.
-        - If command=tag, these are the tags to be applied to the matching snapshots.
+        - Dictionary of tags key/values to filter snapshots by
       required: false
       default:  null
-author: "Herby Gillot"
+    wait:
+      description:
+        - If set to True, waits for operations to complete
+      required: false
+      default:  false
+    wait_timeout:
+      description:
+        - The amount of time in seconds to wait for operations, if wait is enabled
+      required: false
+      default:  300
+author: '"Herby Gillot (@herbygillot)"'
+requirements: [ 'boto' ]
+extends_documentation_fragment: aws
 '''  # noqa
 
 
 EXAMPLES = '''
+# List all Redshift snapshots in us-east-1
+- redshift_snapshots:
+    region:   'us-east-1'
+
+
+# List all snapshots created from cluster "mycluster"
+- redshift_snapshots:
+    cluster:  'mycluster'
+    region:   'us-east-1'
+
+
+# List all snapshots tagged with "environment": "ext11"
+- redshift_snapshots:
+    region:   'us-east-1'
+    tags:
+      environment:  'ext11'
+
+
+# List all snapshots created after Dec. 1, 2015, and larger than 500 gigs
+- redshift_snapshots:
+    region:   'us-east-1'
+    tags:
+      environment:  'ext11'
+    start_time:     '2015-12-01'
+    larger_than_mb: 500000
+
+
+# List all snaphosts whose name starts with "mycluster"
+- name: 'List snapshots'
+  redshift_snapshots:
+    name_pattern:   '^mycluster.*'
+    region:         'us-east-1'
+
+
+- name: Delete snapshot "foobaz"
+  redshift_snapshots:
+    name:    'foobaz'
+    region:  'us-east-1'
+    command: 'delete'
+
+
+# Copy an automated snapshot to 'backup1', forcibly deleting 'backup1' if it
+# already exists.  (Without force, this will fail with an error about 'backup1'
+# being already present.)
+- name: "Copy an automated snapshot from mycluster to 'backup1'"
+  register: copy_snapshot
+  redshift_snapshots:
+      source:       'rs:mycluster-2015-01-01-15-02-41'
+      dest:         'backup1'
+      command:      'copy'
+      force:        True
+      region:       'us-east-1'
+
 '''  # noqa
 
 
 RETURN = '''
+snapshots:
+    description: list containing a facts dict for each affected/matching snapshot
+    returned: success
+    type: list
+    contains:
+        name:
+            description: name of the snapshot
+            returned: success
+            type: string
+            sample: "snapshot1"
+        availability_zone:
+            description: availability zone of this snapshot's source cluster
+            returned: success
+            type: string
+            sample: "us-east-1"
+        cluster:
+            description: name of the cluster this snapshot was created from
+            returned: success
+            type: string
+            sample: "cluster1"
+        snapshot_type:
+            description: type of snapshot (manual or automated)
+            returned: success
+            type: string
+            sample: "manual"
+        tags:
+            description: dictionary of tag key/values for this snapshot
+            returned: success
+            type: dict
+            sample: {'foo': 'bar'}
+        vpc_id:
+            description: ID of VPC of this snapshot's cluster, if it is in one
+            returned: success
+            type: string
+            sample: "vpc-12345672"
+        db_name:
+            description: Name of the database
+            returned: success
+            type: string
+            sample: "maindb"
+        is_encrypted:
+            description: Whether or not the snapshot is of an encrypted cluster
+            returned: success
+            type: boolean
+            sample: True
+        is_encrypted_with_hsm:
+            description: Whether or not the encryption is done with via HSM
+            returned: success
+            type: boolean
+            sample: True
+        node_type:
+            description: Node type of this snapshot's cluster
+            returned: success
+            type: string
+            sample: "ds2.xlarge"
+        node_count:
+            description: Number of nodes in the snapshot's cluster
+            returned: success
+            type: int
+            sample: 25
+        port:
+            description: Service port of the snapshot's cluster
+            returned: success
+            type: int
+            sample: 5439
+        restorable_node_types:
+            description: List of node types this snapshot can restore to
+            returned: success
+            type: list
+            sample: [ "ds2.xlarge", "ds1.xlarge" ]
+        status:
+            description: Status of the snapshot
+            returned: success
+            type: string
+            sample: "available"
+        total_size_mb:
+            description: Size of the snapshot in megabytes
+            returned: success
+            type: float
+            sample: 4231342.50
+        owner_account:
+            description: The ID of the account that owns this snapshot
+            returned: success
+            type: string
+            sample: "123456789123"
+        master_user:
+            description: The name of the database account for this snapshot
+            returned: success
+            type: string
+            sample: "dbadmin"
+        cluster_version:
+            description: The version of the Redshift snapshot's origin cluster
+            returned: success
+            type: string
+            sample: "1.0"
+        kms_key_id:
+            description: The ID of the KMS Key used to encrypt this snapshot
+            returned: success
+            type: string
+            sample: "arn...."
+        elapsed_seconds:
+            description: How many seconds it took to create the snapshot.
+            returned: success
+            type: int
+            sample: 272
+        create_time_epoch:
+            description: The time the snapshot was created, in seconds since epoch
+            returned: success
+            type: float
+            sample: 1449675208.545
+        create_time:
+            description: The time the snapshot was created, as an ISO 8601 timestamp
+            returned: success
+            type: string
+            sample: "2015-12-09T10:33:28.545000"
+        accounts_with_restore_access:
+            description: The list of dictionaries specific accounts that have restore access to this snapshot
+            returned: success
+            type: list
+            example: [ {"AccountId": "123456778901" } ]
 '''  # noqa
 
 
@@ -102,7 +320,8 @@ from datetime import datetime
 from numbers import Number
 from operator import itemgetter
 from types import StringTypes
-
+import time
+import re
 
 try:
     import boto
@@ -115,79 +334,259 @@ except:
 class RedshiftSnapshotsModule(object):
 
     def __init__(self, module):
-        self.changed = False
         self.module = module
+        self.dry_run = self.module.check_mode
         self.params = self.module.params
 
-        self.dry_run = self.module.check_mode
+        self.wait_enabled = self.module.params.get('wait')
+        self.timeout = self.module.params.get('wait_timeout')
+
         region, _, conn_params = get_aws_connection_info(self.module)
 
         if not region:
-            self.fail_json(
+            self.module.fail_json(
                 msg='Region not specified; unable to determine AWS region')
         try:
             self.conn = connect_to_aws(boto.redshift, region, **conn_params)
         except boto.exception.JSONResponseError, e:
-            module.fail_json(msg=json_response_err_msg(e))
+            msg = ('Could create Redshift API connection: {}'
+                   .format(json_response_err_msg(e)))
+            self.module.fail_json(msg=msg)
 
         self._setup_filters()
 
     def _setup_filters(self):
         """
-        Set up snapshot filters as per configured filter criteria
+        Set up snapshot filters as per configured filter options
         """
         self.filters = []
 
         if self.params.get('less_than_mb'):
-            def test(val):
+            def lt_test(val):
                 return val < float(self.params.get('less_than_mb'))
             self.filters.append(
-                create_numeric_field_filter(
-                    'TotalBackupSizeInMegaBytes', test))
+                create_typed_field_filter('total_size_mb', lt_test, float))
 
         if self.params.get('greater_than_mb'):
-            def test(val):
+            def gt_test(val):
                 return val > float(self.params.get('greater_than_mb'))
             self.filters.append(
-                create_numeric_field_filter(
-                    'TotalBackupSizeInMegaBytes', test))
+                create_typed_field_filter('total_size_mb', gt_test, float))
 
-        if (self.params.get('command') in ('list', 'facts')) \
-                and self.params.get('tags'):
+        if self.params.get('tags'):
             tags = self.params.get('tags')
             for tag in tags:
                 self.filters.append(create_tag_filter(tag, tags[tag]))
 
-    def list_snapshots(self):
+        if self.params.get('name_pattern'):
+            self._add_field_pattern_filter('name_pattern', 'name')
+
+        if self.params.get('cluster_pattern'):
+            self._add_field_pattern_filter('cluster_pattern', 'cluster')
+
+    def _add_field_pattern_filter(self, pattern_field, field):
+        pattern = self.params.get(pattern_field)
+        try:
+            pattern_test = create_regex_field_filter(field, pattern)
+        except re.error, e:
+            msg = ('Error using {field} pattern: {error}'
+                   .format(field=field, error=e.message))
+            self.module.fail_json(msg=msg)
+
+        self.filters.append(pattern_test)
+
+    def delete_cmd(self):
         """
-        Return a list of snapshot dictionaries as per configured filters
-        and attributes
+        Deletes snapshots matching configured filters and properties.
+
+        Returns a module results dictionary with the following content:
+        - 'changed': (bool) True if any snapshots were or would be deleted
+        - 'snapshots': (list) list of snapshots affected
         """
-        get_params = ('snapshot_type', 'start_time', 'end_time')
+        snapshots = self.list_matching()
+
+        if not snapshots:
+            return unchanged(snapshots)
+
+        for snapshot in snapshots:
+            self.delete(snapshot['name'])
+
+        if self.wait_enabled:
+            def check(): return self.list_matching() == []
+            if not wait_for_condition(check, self.timeout):
+                self.module.fail_json(
+                    msg='Timed out waiting for snapshots to be deleted.')
+
+        return changed(snapshots)
+
+    def facts_cmd(self):
+        return self.list_cmd()
+
+    def list_cmd(self):
+        """
+        Lists snapshots as per configured filters and properties, sorting them
+        as per 'sort_by'
+
+        Returns a module results dictionary with the following content:
+        - 'changed': (bool) whether any changes were made, always False
+        - 'snapshots': (list) list of snapshot fact dicts
+        """
+        return unchanged(self.list_matching())
+
+    def copy_cmd(self):
+        """
+        Copies an automated snapshot into a manual one
+        """
+        source = self.params.get('name')
+        dest = self.params.get('dest')
+        force = self.params.get('force')
+
+        affected_snapshots = list()
+
+        if not source:
+            self.module.fail_json(
+                msg=('Snapshot name (source or snapshot) was not specified. '
+                     'This parameter is required as the source snapshot to '
+                     'copy from.'))
+
+        if not dest:
+            self.module.fail_json(
+                msg=('Destination (dest) was not specified.  This is required '
+                     'if copying as the destination snapshot to copy to.'))
+
+        try:
+            src_snapshot = self.get(source)
+        except boto.exception.JSONResponseError, e:
+            self.module.fail_json(msg=json_response_err_msg(e))
+
+        dest_snapshot = self.get(dest, ignore_missing=True)
+        src_cluster = src_snapshot.get('cluster')
+
+        if dest_snapshot and force:
+            self.delete(dest)
+
+        if self.dry_run:
+            return changed(affected_snapshots)
+
+        try:
+            self.conn.copy_cluster_snapshot(
+                source, dest, source_snapshot_cluster_identifier=src_cluster)
+        except boto.exception.JSONResponseError, e:
+            msg = ('Error while copying snapshot from "{src}" to "{dst}": {e}'
+                   .format(src=source, dst=dest, e=json_response_err_msg(e)))
+            self.module.fail_json(msg=msg)
+
+        if self.wait_enabled:
+            def check():
+                target = self.get(dest, ignore_missing=True)
+                if target and (target.get('status') == 'available'):
+                    return True
+                return False
+            if not wait_for_condition(check, self.timeout):
+                self.module.fail_json(
+                    msg='Timed out waiting for snapshot copy to complete.')
+
+        affected_snapshots.append(self.get(dest))
+
+        return changed(affected_snapshots)
+
+    def run_command(self):
+        command = self.params.get('command')
+        cmd_call = '{}_cmd'.format(self.params.get('command', ''))
+
+        if hasattr(self, cmd_call):
+            return getattr(self, cmd_call)()
+        else:
+            self.module.fail_json(msg='Unknown cmd_call: {}'.format(command))
+
+    def delete(self, snapshot_id):
+        """
+        Given a snapshot identifier, delete it if we are not running in
+        dry-run mode.
+        """
+        if not self.dry_run:
+            try:
+                self.conn.delete_cluster_snapshot(snapshot_id)
+            except boto.exception.JSONResponseError, e:
+                msg = ('Failed to delete snapshot "{}": {}'
+                       .format(snapshot_id, json_response_err_msg(e)))
+                self.module.fail_json(msg=msg)
+
+    def get(self, snapshot_id, ignore_missing=False):
+        """
+        Given a snapshot identifier, return that snapshot's fact dict.
+
+        If ignore_missing is set to True, returns None instead of raising
+        an exception when the requested snapshot isn't present.
+
+        Returns:
+        - snapshot fact dict
+
+        Raises:
+        - boto.exception.JSONResponseError
+        """
+        snapshot = None
+
+        try:
+            response = self.conn.describe_cluster_snapshots(
+                snapshot_identifier=snapshot_id)
+            snapshot = (response['DescribeClusterSnapshotsResponse']
+                                ['DescribeClusterSnapshotsResult']
+                                ['Snapshots'][0])
+        except boto.exception.JSONResponseError, e:
+            if is_not_found_json_response_error(e) and ignore_missing:
+                pass
+            else:
+                raise
+
+        if snapshot:
+            snapshot = snapshot_fact(snapshot)
+
+        return snapshot
+
+    def exists(self, snapshot_name):
+        """
+        Given a snapshot name, return True if it exists, False otherwise
+
+        Raises:
+        - boto.exception.JSONResponseError
+        """
+        return bool(self.get_snapshot(snapshot_name, ignore_missing=True))
+
+    def list_matching(self):
+        """
+        Return a list of snapshot fact dicts matching configured filters
+        """
+        sort_by = self.params.get('sort_by')
+
+        list_params = ('snapshot_type', 'start_time', 'end_time')
 
         marker = 1  # batch retrieval marker, start at 1 as "default" case,
+
         snapshots = list()
 
         params = \
-            {k: self.params[k] for k in get_params if self.params.get(k)}
+            {k: self.params[k] for k in list_params if self.params.get(k)}
 
         if self.params.get('cluster'):
             params['cluster_identifier'] = self.params['cluster']
 
-        if self.params.get('snapshot'):
-            params['snapshot_identifier'] = self.params['snapshot']
+        if self.params.get('name'):
+            params['snapshot_identifier'] = self.params['name']
 
-        args = params.copy()
         response = None
 
         while marker:
             if marker != 1:
-                args.update({'marker': marker})
+                params.update({'marker': marker})
 
             try:
-                response = self.conn.describe_cluster_snapshots(**args)
+                response = self.conn.describe_cluster_snapshots(**params)
             except boto.exception.JSONResponseError, e:
-                self.module.fail_json(msg=json_response_err_msg(e))
+                if is_not_found_json_response_error(e):
+                    break
+                else:
+                    self.module.fail_json(msg=json_response_err_msg(e))
 
             snapshots.extend((response['DescribeClusterSnapshotsResponse']
                                       ['DescribeClusterSnapshotsResult']
@@ -197,103 +596,69 @@ class RedshiftSnapshotsModule(object):
                               ['DescribeClusterSnapshotsResult']
                               ['Marker'])
 
+        results = map(snapshot_fact, snapshots)
+
         if self.filters:
             def test_snapshot(snapshot):
-                return all(map(lambda f: f(snapshot), self.filters))
-            results = filter(test_snapshot, snapshots)
-        else:
-            results = snapshots
+                return all(map(lambda _filtr: _filtr(snapshot), self.filters))
+            results = filter(test_snapshot, results)
 
-        return results
+        sort_key = itemgetter(sort_by)
 
-    def delete_command(self):
-        """
-        Deletes snapshots matching configured filters and properties.
-
-        Returns a module results dictionary with the following content:
-        - 'changed': (bool) True if any snapshots were or would be deleted
-        - 'snapshots': (list) list of snapshots affected
-        """
-        snapshots = self.list_snapshots()
-
-        if not snapshots:
-            return {'changed': False, 'snapshots': []}
-
-        for snapshot in snapshots:
-            if not self.dry_run:
-                try:
-                    self.conn.delete_cluster_snapshot(snapshot['Identifier'])
-                except boto.exception.JSONResponseError, e:
-                    self.module.fail_json(msg=json_response_err_msg(e))
-
-        return {'changed': True, 'snapshots': get_snapshot_facts(snapshots)}
-
-    def facts_command(self):
-        return self.list_command()
-
-    def list_command(self):
-        """
-        Lists snapshots as per configured filters and properties, sorting them
-        as per 'sort_by'
-
-        Returns a module results dictionary with the following content:
-        - 'changed': (bool) whether any changes were made, always False
-        - 'snapshots': (list) list of snapshot fact dicts
-        """
-        sort_field = self.params.get('sort_by')
-        sort_method = itemgetter(sort_field)
-
-        snapshots = get_snapshot_facts(self.list_snapshots())
         try:
-            results = sorted(snapshots, key=sort_method)
+            results = sorted(results, key=sort_key,
+                             reverse=self.module.params.get('reverse_sort'))
         except KeyError:
             self.module.fail_json(
-                msg='Cannot sort on unknown field: {}'.format(sort_field))
+                msg='Cannot sort on unknown field: {}'.format(sort_by))
 
-        return {'changed': False, 'snapshots': results}
-
-    def tag_command(self):
-        """
-        Adds the given tag to all snapshots matching configured filters
-        and properties
-
-        Returns a module results dictionary with the following content:
-        - 'changed': (bool) True if tags were updated on any snapshots
-        - 'snapshots': (list) list of snapshots changed, if any
-        """
-        pass
-
-    def run(self):
-        command = self.params.get('command')
-        cmd_call = '{}_command'.format(self.params.get('command', ''))
-
-        if hasattr(self, cmd_call):
-            return getattr(self, cmd_call)()
-        else:
-            self.module.fail_json(msg='Unknown cmd_call: {}'.format(command))
+        return results
 
 
 def create_tag_filter(key, value):
     """
-    Given a key and a value, create a callable that returns true if the
+    Given a key and a value, create a callable that returns True if the
     given snapshot contains this key and value in its tags.
     """
     def _filter_tag(snapshot):
-        snap_tags = [frozenset(t.items()) for t in snapshot.get("Tags", [])]
+        snap_tags = [frozenset(t.items()) for t in snapshot.get("tags", [])]
         target = frozenset({"Key": key, "Value": value}.items())
         return target in snap_tags
+
     return _filter_tag
 
 
-def create_numeric_field_filter(field_name, filter_call, field_type=float):
+def create_regex_field_filter(field_name, regex):
+    """
+    Return a callable that checks the value of the given value against the
+    specified regular expression.
+    """
+    pattern = re.compile(regex)
+
+    def _regex_filter(s):
+        return bool(re.search(pattern, s.get(field_name, '')))
+
+    return _regex_filter
+
+
+def create_typed_field_filter(field_name, filter_call, field_type):
     """
     Return a callable that applies the given filter call against the value
-    of the snapshot fact field, after it has been casted to a numeric type
-    (float by default)
+    of the snapshot fact field, after this value has been casted into the
+    specified type
     """
     def _filter(snapshot):
         return filter_call(field_type(snapshot.get(field_name)))
+
     return _filter
+
+
+def is_not_found_json_response_error(error):
+    """
+    Return True if the given JSONResponseError means the resource can't be
+    found
+    """
+    return (error.status == 404) or (error.reason.lower() == 'not found')
 
 
 def json_response_err_msg(json_response_error):
@@ -311,11 +676,11 @@ def json_response_err_msg(json_response_error):
     return err_msg
 
 
-def get_snapshot_facts(snapshots):
-    return map(snapshot_as_fact, snapshots)
-
-
-def snapshot_as_fact(snapshot):
+def snapshot_fact(snapshot):
+    """
+    Given a snapshot dictionary returned by the AWS Redshift API,
+    return a subset to be used as a facts dict
+    """
     facts = {
             'availability_zone':  snapshot.get('AvailabilityZone'),
             'cluster':            snapshot.get('ClusterIdentifier'),
@@ -356,45 +721,129 @@ def to_iso_time_str(timestamp):
         t = timestamp
 
     elif isinstance(timestamp, Number):
-        # assuming that if this is numerical, then it's seconds since epoch
+        # assuming that if this is numeric, then it's seconds since epoch
         t = datetime.fromtimestamp(timestamp)
 
     return t.isoformat()
+
+
+def results_dict(snapshots, changed=False):
+    """
+    Return the Ansible module results dictionary
+    """
+    return {'changed': changed, 'snapshots': snapshots}
+
+
+def changed(snapshots):
+    return results_dict(snapshots, changed=True)
+
+
+def unchanged(snapshots):
+    return results_dict(snapshots, changed=False)
+
+
+def wait_for_condition(condition_check, timeout, interval=3):
+    """
+    Given a callable representing a check for some condition, wait until the
+    condition is met, within some maxiumum amount of time (timeout).
+
+    The given condition_check callable is expected to return True when the
+    condition is met, False otherwise.
+
+    Timeout is the maxiumum number of seconds to wait.
+
+    If timeout is set to 0, then we will wait forever.
+
+    The condition check will be performed every (interval) seconds, which is
+    3 by default.
+
+    Returns:
+    - True: condition was met within the timeout period
+    - False: reached timeout and the condition was still not met
+    """
+    wait_timeout = time.time() + timeout
+
+    if timeout == 0:
+        def time_check(): return True
+    else:
+        def time_check(): return wait_timeout > time.time()
+
+    while time_check():
+        if condition_check():
+            return True
+        time.sleep(interval)
+
+    return False
 
 
 def main():
     argument_spec = ec2_argument_spec()
 
     argument_spec.update({
-            'command':        dict(choices=['list', 'facts', 'tag', 'delete'],
-                                   default='list', required=False),
+            'command':                    dict(choices=['list',
+                                                        'facts',
+                                                        'copy',
+                                                        'delete'],
+                                               default='list',
+                                               required=False),
 
-            'cluster':        dict(aliases=['identifier',
-                                            'instance'], required=False),
+            'cluster':                    dict(required=False,
+                                               aliases=['identifier',
+                                                        'instance']),
 
-            'snapshot':       dict(required=False),
+            'cluster_pattern':            dict(required=False),
 
-            'snapshot_type':  dict(required=False),
+            'name':                       dict(required=False,
+                                               aliases=['snapshot',
+                                                        'source']),
 
-            'start_time':     dict(required=False),
+            'name_pattern':               dict(required=False),
 
-            'end_time':       dict(required=False),
+            'dest':                       dict(required=False,
+                                               aliases=['new_snapshot']),
 
-            'greater_than_mb': dict(type='float', required=False),
+            'force':                      dict(required=False,
+                                               type='bool',
+                                               default=False),
 
-            'less_than_mb':   dict(type='float', required=False),
+            'snapshot_type':              dict(required=False),
 
-            'sort_by':        dict(required=False, default='create_time'),
+            'start_time':                 dict(required=False),
 
-            'tags':           dict(type='dict', required=False),
+            'end_time':                   dict(required=False),
+
+            'greater_than_mb':            dict(required=False,
+                                               type='float'),
+
+            'less_than_mb':               dict(required=False,
+                                               type='float'),
+
+            'sort_by':                    dict(required=False,
+                                               default='create_time_epoch'),
+
+            'reverse_sort':               dict(required=False,
+                                               type='bool',
+                                               default=False),
+
+            'tags':                       dict(required=False,
+                                               type='dict'),
+
+            'wait':                       dict(required=False,
+                                               type='bool',
+                                               default=False),
+
+            'wait_timeout':               dict(required=False,
+                                               type='int',
+                                               default=300),
         })
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,
                            mutually_exclusive=['cluster', 'snapshot'])
 
-    rssmodule = RedshiftSnapshotsModule(module)
-    result_dict = rssmodule.run()
+    redshift_module = RedshiftSnapshotsModule(module)
+
+    result_dict = redshift_module.run_command()
 
     module.exit_json(**result_dict)
 

--- a/cloud/amazon/redshift_snapshots.py
+++ b/cloud/amazon/redshift_snapshots.py
@@ -1,0 +1,408 @@
+#!/usr/bin/python
+
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+
+DOCUMENTATION = '''
+---
+module: redshift_snapshots
+short_description: List, tag and clean up Amazon Redshift snapshots
+description:
+    - This module can list snapshots for Amazon's Redshift service.
+    - Snapshots can be listed by Redshift cluster, creation time, size and/or tags
+    - This module only lists, tags and deletes snapshots.  To create Redshift snapshots, use the redshift module with the "snapshot" command.
+version_added: "2.0"
+options:
+    command:
+      description:
+        - Specifies the action to take. If none specified, lists snapshots by default.
+        - 'list' lists all snapshots, or as per provided filters
+        - 'facts' is the same as 'list'
+        - 'tag' ensures that the given tags are present on the named or matching snapshot(s)
+        - 'delete' deletes the named or matching snapshot(s)
+      required: false
+      default:  list
+      choices:  [ 'list', 'facts', 'tag', 'delete' ]
+    cluster:
+      description:
+        - The Redshift cluster whose snapshots to use
+        - Focuses all actions on only snapshots belonging to this cluster, in addition to other specified filters
+        - Cannot be specified together with the "snapshot" parameter
+      required: false
+      default:  null
+      aliases:
+        - 'identifier'
+        - 'instance'
+    snapshot:
+      description:
+        - Redshift snapshot name for operating on a specific snapshot
+        - Cannot be specified together with the "cluster" parameter
+      required: false
+      default:  null
+    snapshot_type:
+      description:
+        - Filter for only snapshots created from a Redshift cluster of this type
+      required: false
+      default:  null
+    start_time:
+      description:
+        - Filter for only snapshots created after this date
+        - Date and time values should be specified in YYYY-MM-DD format, or YYYY-MM-DD'T'HH:MM
+      required: false
+      default:  null
+    end_time:
+      description:
+        - Filter for only snapshots created before this date
+        - Date and time values should be specified in YYYY-MM-DD format, or YYYY-MM-DD'T'HH:MM
+      required: false
+      default:  null
+    greater_than_mb:
+      description:
+        - Filter for only snapshots larger than the given value in megabytes.
+        - Must be specified as a decimal (1.0, 0.0, 5.5, etc.)
+      required: false
+      default:  null
+    less_than_mb:
+      description:
+        - Filter for only snapshots smaller than the given value in megabytes.
+        - Must be specified as a decimal (1.0, 0.0, 5.5, etc.)
+      required: false
+      default:  null
+    tags:
+      description:
+        - Dictionary of tags to values.
+        - If command=list, filter for snapshots with these tags.
+        - If command=tag, these are the tags to be applied to the matching snapshots.
+      required: false
+      default:  null
+author: "Herby Gillot"
+'''  # noqa
+
+
+EXAMPLES = '''
+'''  # noqa
+
+
+RETURN = '''
+'''  # noqa
+
+
+from datetime import datetime
+from numbers import Number
+from operator import itemgetter
+from types import StringTypes
+
+
+try:
+    import boto
+    import boto.redshift
+    HAS_BOTO = True
+except:
+    HAS_BOTO = False
+
+
+class RedshiftSnapshotsModule(object):
+
+    def __init__(self, module):
+        self.changed = False
+        self.module = module
+        self.params = self.module.params
+
+        self.dry_run = self.module.check_mode
+        region, _, conn_params = get_aws_connection_info(self.module)
+
+        if not region:
+            self.fail_json(
+                msg='Region not specified; unable to determine AWS region')
+        try:
+            self.conn = connect_to_aws(boto.redshift, region, **conn_params)
+        except boto.exception.JSONResponseError, e:
+            module.fail_json(msg=json_response_err_msg(e))
+
+        self._setup_filters()
+
+    def _setup_filters(self):
+        """
+        Set up snapshot filters as per configured filter criteria
+        """
+        self.filters = []
+
+        if self.params.get('less_than_mb'):
+            def test(val):
+                return val < float(self.params.get('less_than_mb'))
+            self.filters.append(
+                create_numeric_field_filter(
+                    'TotalBackupSizeInMegaBytes', test))
+
+        if self.params.get('greater_than_mb'):
+            def test(val):
+                return val > float(self.params.get('greater_than_mb'))
+            self.filters.append(
+                create_numeric_field_filter(
+                    'TotalBackupSizeInMegaBytes', test))
+
+        if (self.params.get('command') in ('list', 'facts')) \
+                and self.params.get('tags'):
+            tags = self.params.get('tags')
+            for tag in tags:
+                self.filters.append(create_tag_filter(tag, tags[tag]))
+
+    def list_snapshots(self):
+        """
+        Return a list of snapshot dictionaries as per configured filters
+        and attributes
+        """
+        get_params = ('snapshot_type', 'start_time', 'end_time')
+
+        marker = 1  # batch retrieval marker, start at 1 as "default" case,
+        snapshots = list()
+
+        params = \
+            {k: self.params[k] for k in get_params if self.params.get(k)}
+
+        if self.params.get('cluster'):
+            params['cluster_identifier'] = self.params['cluster']
+
+        if self.params.get('snapshot'):
+            params['snapshot_identifier'] = self.params['snapshot']
+
+        args = params.copy()
+        response = None
+
+        while marker:
+            if marker != 1:
+                args.update({'marker': marker})
+
+            try:
+                response = self.conn.describe_cluster_snapshots(**args)
+            except boto.exception.JSONResponseError, e:
+                self.module.fail_json(msg=json_response_err_msg(e))
+
+            snapshots.extend((response['DescribeClusterSnapshotsResponse']
+                                      ['DescribeClusterSnapshotsResult']
+                                      ['Snapshots']))
+
+            marker = (response['DescribeClusterSnapshotsResponse']
+                              ['DescribeClusterSnapshotsResult']
+                              ['Marker'])
+
+        if self.filters:
+            def test_snapshot(snapshot):
+                return all(map(lambda f: f(snapshot), self.filters))
+            results = filter(test_snapshot, snapshots)
+        else:
+            results = snapshots
+
+        return results
+
+    def delete_command(self):
+        """
+        Deletes snapshots matching configured filters and properties.
+
+        Returns a module results dictionary with the following content:
+        - 'changed': (bool) True if any snapshots were or would be deleted
+        - 'snapshots': (list) list of snapshots affected
+        """
+        snapshots = self.list_snapshots()
+
+        if not snapshots:
+            return {'changed': False, 'snapshots': []}
+
+        for snapshot in snapshots:
+            if not self.dry_run:
+                try:
+                    self.conn.delete_cluster_snapshot(snapshot['Identifier'])
+                except boto.exception.JSONResponseError, e:
+                    self.module.fail_json(msg=json_response_err_msg(e))
+
+        return {'changed': True, 'snapshots': get_snapshot_facts(snapshots)}
+
+    def facts_command(self):
+        return self.list_command()
+
+    def list_command(self):
+        """
+        Lists snapshots as per configured filters and properties, sorting them
+        as per 'sort_by'
+
+        Returns a module results dictionary with the following content:
+        - 'changed': (bool) whether any changes were made, always False
+        - 'snapshots': (list) list of snapshot fact dicts
+        """
+        sort_field = self.params.get('sort_by')
+        sort_method = itemgetter(sort_field)
+
+        snapshots = get_snapshot_facts(self.list_snapshots())
+        try:
+            results = sorted(snapshots, key=sort_method)
+        except KeyError:
+            self.module.fail_json(
+                msg='Cannot sort on unknown field: {}'.format(sort_field))
+
+        return {'changed': False, 'snapshots': results}
+
+    def tag_command(self):
+        """
+        Adds the given tag to all snapshots matching configured filters
+        and properties
+
+        Returns a module results dictionary with the following content:
+        - 'changed': (bool) True if tags were updated on any snapshots
+        - 'snapshots': (list) list of snapshots changed, if any
+        """
+        pass
+
+    def run(self):
+        command = self.params.get('command')
+        cmd_call = '{}_command'.format(self.params.get('command', ''))
+
+        if hasattr(self, cmd_call):
+            return getattr(self, cmd_call)()
+        else:
+            self.module.fail_json(msg='Unknown cmd_call: {}'.format(command))
+
+
+def create_tag_filter(key, value):
+    """
+    Given a key and a value, create a callable that returns true if the
+    given snapshot contains this key and value in its tags.
+    """
+    def _filter_tag(snapshot):
+        snap_tags = [frozenset(t.items()) for t in snapshot.get("Tags", [])]
+        target = frozenset({"Key": key, "Value": value}.items())
+        return target in snap_tags
+    return _filter_tag
+
+
+def create_numeric_field_filter(field_name, filter_call, field_type=float):
+    """
+    Return a callable that applies the given filter call against the value
+    of the snapshot fact field, after it has been casted to a numeric type
+    (float by default)
+    """
+    def _filter(snapshot):
+        return filter_call(field_type(snapshot.get(field_name)))
+    return _filter
+
+
+def json_response_err_msg(json_response_error):
+    """ Given a JSONResponseError from boto, return the error message. """
+    err_msg = None
+
+    if hasattr(json_response_error, 'body') and json_response_error.body:
+        if type(json_response_error.body) in StringTypes:
+            err_msg = json_response_error.body
+        elif isinstance(json_response_error.body, dict):
+            err_msg = json_response_error.body.get('Error', {}).get('Message')
+
+    if not err_msg:
+        err_msg = str(json_response_error)
+    return err_msg
+
+
+def get_snapshot_facts(snapshots):
+    return map(snapshot_as_fact, snapshots)
+
+
+def snapshot_as_fact(snapshot):
+    facts = {
+            'availability_zone':  snapshot.get('AvailabilityZone'),
+            'cluster':            snapshot.get('ClusterIdentifier'),
+            'name':               snapshot.get('SnapshotIdentifier'),
+            'snapshot_type':      snapshot.get('SnapshotType'),
+            'tags':               snapshot.get('Tags'),
+            'vpc_id':             snapshot.get('VpcId'),
+            'db_name':            snapshot.get('DBName'),
+            'is_encrypted':       snapshot.get('Encrypted'),
+            'is_encrypted_with_hsm': snapshot.get('EncryptedWithHSM'),
+            'node_type':          snapshot.get('NodeType'),
+            'node_count':         snapshot.get('NumberOfNodes'),
+            'port':               snapshot.get('Port'),
+            'restorable_node_types': snapshot.get('RestorableNodeTypes'),
+            'status':             snapshot.get('Status'),
+            'total_size_mb':      snapshot.get('TotalBackupSizeInMegaBytes'),
+            'owner_account':      snapshot.get('OwnerAccount'),
+            'master_user':        snapshot.get('MasterUsername'),
+            'cluster_version':    snapshot.get('ClusterVersion'),
+            'kms_key_id':         snapshot.get('KmsKeyId'),
+            'elapsed_seconds':    snapshot.get('ElapsedTimeInSeconds'),
+            'create_time_epoch':  snapshot.get('SnapshotCreateTime'),
+
+            'create_time': to_iso_time_str(snapshot.get('SnapshotCreateTime')),
+
+            'accounts_with_restore_access':
+                snapshot.get('AccountsWithRestoreAccess'),  # noqa
+        }
+
+    return facts
+
+
+def to_iso_time_str(timestamp):
+    if not timestamp:
+        return
+
+    elif isinstance(timestamp, datetime):
+        t = timestamp
+
+    elif isinstance(timestamp, Number):
+        # assuming that if this is numerical, then it's seconds since epoch
+        t = datetime.fromtimestamp(timestamp)
+
+    return t.isoformat()
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+
+    argument_spec.update({
+            'command':        dict(choices=['list', 'facts', 'tag', 'delete'],
+                                   default='list', required=False),
+
+            'cluster':        dict(aliases=['identifier',
+                                            'instance'], required=False),
+
+            'snapshot':       dict(required=False),
+
+            'snapshot_type':  dict(required=False),
+
+            'start_time':     dict(required=False),
+
+            'end_time':       dict(required=False),
+
+            'greater_than_mb': dict(type='float', required=False),
+
+            'less_than_mb':   dict(type='float', required=False),
+
+            'sort_by':        dict(required=False, default='create_time'),
+
+            'tags':           dict(type='dict', required=False),
+        })
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True,
+                           mutually_exclusive=['cluster', 'snapshot'])
+
+    rssmodule = RedshiftSnapshotsModule(module)
+    result_dict = rssmodule.run()
+
+    module.exit_json(**result_dict)
+
+
+# import module snippets
+from ansible.module_utils.basic import *  # noqa
+from ansible.module_utils.ec2 import *    # noqa
+
+
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/redshift_snapshots.py
+++ b/cloud/amazon/redshift_snapshots.py
@@ -119,6 +119,11 @@ options:
         - Dictionary of tags key/values to filter snapshots by
       required: false
       default:  null
+    owner_account:
+      description:
+        - Filter for snapshots owned by this account
+      required: false
+      default: null
     wait:
       description:
         - If set to True, waits for operations to complete
@@ -559,7 +564,8 @@ class RedshiftSnapshotsModule(object):
         """
         sort_by = self.params.get('sort_by')
 
-        list_params = ('snapshot_type', 'start_time', 'end_time')
+        list_params = ('end_time', 'owner_account', 'snapshot_type',
+                       'start_time')
 
         marker = 1  # batch retrieval marker, start at 1 as "default" case,
 
@@ -813,6 +819,8 @@ def main():
             reverse_sort=dict(required=False, type='bool', default=False),
 
             tags=dict(required=False, type='dict'),
+
+            owner_account=dict(required=False),
 
             wait=dict(required=False, type='bool', default=False),
 

--- a/cloud/amazon/redshift_snapshots.py
+++ b/cloud/amazon/redshift_snapshots.py
@@ -565,8 +565,11 @@ class RedshiftSnapshotsModule(object):
 
         snapshots = list()
 
-        params = \
-            {k: self.params[k] for k in list_params if self.params.get(k)}
+        params = {}
+        for p in list_params:
+            prm = self.params.get(p)
+            if prm:
+                params[p] = prm
 
         if self.params.get('cluster'):
             params['cluster_identifier'] = self.params['cluster']

--- a/cloud/amazon/redshift_snapshots.py
+++ b/cloud/amazon/redshift_snapshots.py
@@ -782,63 +782,42 @@ def wait_for_condition(condition_check, timeout, interval=3):
 def main():
     argument_spec = ec2_argument_spec()
 
-    argument_spec.update({
-            'command':                    dict(choices=['list',
-                                                        'facts',
-                                                        'copy',
-                                                        'delete'],
-                                               default='list',
-                                               required=False),
+    argument_spec.update(dict(
+            command=dict(choices=['list', 'facts', 'copy', 'delete'],
+                         default='list', required=False),
 
-            'cluster':                    dict(required=False,
-                                               aliases=['identifier',
-                                                        'instance']),
+            cluster=dict(required=False, aliases=['identifier', 'instance']),
 
-            'cluster_pattern':            dict(required=False),
+            cluster_pattern=dict(required=False),
 
-            'name':                       dict(required=False,
-                                               aliases=['snapshot',
-                                                        'source']),
+            name=dict(required=False, aliases=['snapshot', 'source']),
 
-            'name_pattern':               dict(required=False),
+            name_pattern=dict(required=False),
 
-            'dest':                       dict(required=False,
-                                               aliases=['new_snapshot']),
+            dest=dict(required=False, aliases=['new_snapshot']),
 
-            'force':                      dict(required=False,
-                                               type='bool',
-                                               default=False),
+            force=dict(required=False, type='bool', default=False),
 
-            'snapshot_type':              dict(required=False),
+            snapshot_type=dict(required=False),
 
-            'start_time':                 dict(required=False),
+            start_time=dict(required=False),
 
-            'end_time':                   dict(required=False),
+            end_time=dict(required=False),
 
-            'greater_than_mb':            dict(required=False,
-                                               type='float'),
+            greater_than_mb=dict(required=False, type='float'),
 
-            'less_than_mb':               dict(required=False,
-                                               type='float'),
+            less_than_mb=dict(required=False, type='float'),
 
-            'sort_by':                    dict(required=False,
-                                               default='create_time_epoch'),
+            sort_by=dict(required=False, default='create_time_epoch'),
 
-            'reverse_sort':               dict(required=False,
-                                               type='bool',
-                                               default=False),
+            reverse_sort=dict(required=False, type='bool', default=False),
 
-            'tags':                       dict(required=False,
-                                               type='dict'),
+            tags=dict(required=False, type='dict'),
 
-            'wait':                       dict(required=False,
-                                               type='bool',
-                                               default=False),
+            wait=dict(required=False, type='bool', default=False),
 
-            'wait_timeout':               dict(required=False,
-                                               type='int',
-                                               default=300),
-        })
+            wait_timeout=dict(required=False, type='int', default=300),
+        ))
 
     module = AnsibleModule(argument_spec=argument_spec,
                            supports_check_mode=True,

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -58,6 +58,7 @@ options:
     default: null
     aliases: [ 'ec2_access_key', 'access_key' ]
 requirements: [ 'boto' ]
+extends_documentation_fragment: aws
 '''
 
 EXAMPLES = '''

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -45,18 +45,6 @@ options:
     required: false
     default: null
     aliases: ['subnets']
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_access_key', 'access_key' ]
 requirements: [ 'boto' ]
 extends_documentation_fragment: aws
 '''

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -137,7 +137,7 @@ def main():
         except boto.exception.JSONResponseError, e:
             # This is a workaround, until this error
             # https://github.com/boto/boto/issues/2776 is fixed.
-            if e.body.find('ClusterSubnetGroupNotFoundFault') == -1:
+            if e.body['Error']['Code'] != 'ClusterSubnetGroupNotFoundFault'):
             #if e.code != 'ClusterSubnetGroupNotFoundFault':
                 module.fail_json(msg = str(e))
 

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -1,0 +1,166 @@
+#!/usr/bin/python
+
+# Copyright 2014 Jens Carl, Hothead Games Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: redshift_subnet_group
+short_description: mange Redshift cluster subnet groups
+description:
+    - Create, modifies, and deletes Redshift cluster subnet groups. This module has a dependency on python-boto.
+
+options:
+  state:
+    description:
+      - Specifies whether the subnet should be present or absent.
+    required: true
+    default: present
+    aliases: []
+    choices: ['present', 'absent' ]
+  name:
+    description:
+      - Cluster subnet group name.
+    required: true
+    default: null
+    aliases: []
+  description:
+    description:
+      - Database subnet group description.
+    required: false
+    default: null
+    aliases: []
+  subnets:
+    description:
+      - List of subnet IDs that make up the cluster subnet group.
+    required: false
+    default: null
+    aliases: []
+  aws_secret_key:
+    description:
+      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ 'ec2_secret_key', 'secret_key' ]
+  aws_access_key:
+    description:
+      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
+    required: false
+    default: null
+    aliases: [ 'ec2_access_key', 'access_key' ]
+requirements: [ 'boto' ]
+author: Jens Carl, Hothead Games Inc.
+'''
+
+EXAMPLES = '''
+# Create a Redshift subnet group
+- local_action:
+    module: redshift_subnet_group
+    state: present
+    name: redshift-subnet
+    description: Redshift subnet
+    subnets:
+        - 'subnet-aaaaa'
+        - 'subnet-bbbbb'
+
+# Remove subnet group
+redshift_subnet_group: >
+    state: absent
+    name: redshift-subnet
+'''
+
+import sys
+
+try:
+    import boto.redshift
+except ImportError:
+    print "failed=True msg='boto required for this module'"
+    sys.exit(1)
+
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+            state       = dict(required=True, choices=['present', 'absent']),
+            name        = dict(required=True),
+            description = dict(required=False),
+            subnets     = dict(required=False, type='list'),
+        )
+    )
+    module = AnsibleModule(argument_spec=argument_spec)
+
+    state               = module.params.get('state')
+    group_name          = module.params.get('name')
+    group_description   = module.params.get('description')
+    group_subnets       = module.params.get('subnets')
+
+    if state == 'present':
+        for required in ('name', 'description', 'subnets'):
+            if not module.params.get( required ):
+                module.fail_json(msg = str("parameter %s required for state='present'" % required))
+    else:
+        for not_allowed in ('description', 'subnets'):
+            if module.params.get( not_allowed ):
+                module.fail_json(msg = str("parameter %s not allowed for state='absent'" % not_allowed))
+
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
+    if not region:
+        module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
+
+    # connect to the redshift endpoint
+    try:
+        conn = connect_to_aws(boto.redshift, region, **aws_connect_params)
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = e.error_message)
+
+    try:
+        changed = False
+        exists = False
+
+        try:
+            matching_groups = conn.describe_cluster_subnet_groups(group_name, max_records = 100)
+            exists = len(matching_groups) > 0
+        except boto.exception.JSONResponseError, e:
+            # This is a workaround, until this error
+            # https://github.com/boto/boto/issues/2776 is fixed.
+            if e.body.find('ClusterSubnetGroupNotFoundFault') == -1:
+            #if e.code != 'ClusterSubnetGroupNotFoundFault':
+                module.fail_json(msg = e.error_message)
+
+        if state == 'absent':
+            if exists:
+                conn.delete_cluster_subnet_group(group_name)
+                changed = True
+
+        else:
+            if not exists:
+                new_group = conn.create_cluster_subnet_group(group_name, group_description, group_subnets)
+            else:
+                changed_group = conn.modify_cluster_subnet_group(group_name, group_subnets, description=group_description)
+
+    except boto.exception.JSONResponseError, e:
+        # This won't produce a message, until this error
+        # https://github.com/boto/boto/issues/2776 is fixed.
+        module.fail_json(msg = e.error_message)
+
+    module.exit_json(changed=changed)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+main()

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -151,6 +151,7 @@ def main():
                 new_group = conn.create_cluster_subnet_group(group_name, group_description, group_subnets)
             else:
                 changed_group = conn.modify_cluster_subnet_group(group_name, group_subnets, description=group_description)
+            changed = True
 
     except boto.exception.JSONResponseError, e:
         # This won't produce a message, until this error

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -119,13 +119,13 @@ def main():
     if not region:
         module.fail_json(msg = str("region not specified and unable to determine region from EC2_REGION."))
 
-    # connect to the redshift endpoint
+    # Connect to the Redshift endpoint.
     try:
         conn = connect_to_aws(boto.redshift, region, **aws_connect_params)
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg = str(e))
 
     try:
         changed = False
@@ -139,7 +139,7 @@ def main():
             # https://github.com/boto/boto/issues/2776 is fixed.
             if e.body.find('ClusterSubnetGroupNotFoundFault') == -1:
             #if e.code != 'ClusterSubnetGroupNotFoundFault':
-                module.fail_json(msg = e.error_message)
+                module.fail_json(msg = str(e))
 
         if state == 'absent':
             if exists:
@@ -154,9 +154,9 @@ def main():
             changed = True
 
     except boto.exception.JSONResponseError, e:
-        # This won't produce a message, until this error
+        # FIXME: Change this to just set the error message when
         # https://github.com/boto/boto/issues/2776 is fixed.
-        module.fail_json(msg = e.error_message)
+        module.fail_json(msg = str(e))
 
     module.exit_json(changed=changed)
 

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -101,10 +101,10 @@ def main():
     )
     module = AnsibleModule(argument_spec=argument_spec)
 
-    state               = module.params.get('state')
-    group_name          = module.params.get('name')
-    group_description   = module.params.get('description')
-    group_subnets       = module.params.get('subnets')
+    state             = module.params.get('state')
+    group_name        = module.params.get('name')
+    group_description = module.params.get('description')
+    group_subnets     = module.params.get('subnets')
 
     if state == 'present':
         for required in ('name', 'description', 'subnets'):

--- a/cloud/amazon/redshift_subnet_group.py
+++ b/cloud/amazon/redshift_subnet_group.py
@@ -137,7 +137,7 @@ def main():
         except boto.exception.JSONResponseError, e:
             # This is a workaround, until this error
             # https://github.com/boto/boto/issues/2776 is fixed.
-            if e.body['Error']['Code'] != 'ClusterSubnetGroupNotFoundFault'):
+            if e.body['Error']['Code'] != 'ClusterSubnetGroupNotFoundFault':
             #if e.code != 'ClusterSubnetGroupNotFoundFault':
                 module.fail_json(msg = str(e))
 


### PR DESCRIPTION
This builds off of work by @j-carl in #185 

Changes are as follows:

**redshift** module
- add the ability to snapshot and restore clusters
- fix cluster deletion
- add additional clusters facts, including the cluster SSH public key, node count, VPC ID, tags, etc.
- add the option to take a final snapshot on cluster deletion
- add support for current Redshift node types

new module, **redshift_snapshot**
- list, delete and copy Redshift snapshots
- ability to list and filter for snapshots by cluster/snapshot name or regular expression, creation time, size, tags and snapshot type

@j-carl it looks like you were still making edits to #185, so not sure how best to proceed here.
