### PR TITLE
Fix up vsphere_copy after open_url change

### DIFF
--- a/cloud/vmware/vsphere_copy.py
+++ b/cloud/vmware/vsphere_copy.py
@@ -137,8 +137,9 @@ def main():
     }
 
     try:
-        r = open_url(module, url, data=data, headers=headers, method='PUT',
-                url_username=login, url_password=password, validate_certs=validate_certs)
+        r = open_url(url, data=data, headers=headers, method='PUT',
+                url_username=login, url_password=password, validate_certs=validate_certs,
+                force_basic_auth=True)
     except socket.error, e:
         if isinstance(e.args, tuple) and e[0] == errno.ECONNRESET:
             # VSphere resets connection if the file is in use and cannot be replaced


### PR DESCRIPTION
- Remove leading module parameter on open_url call as it's no longer used
  by module_utils.urls.open_url
- Force basic auth otherwise vsphere will just return a 401

---

I think the exception handler below open_url is probably not valid anymore... on bad auth I get a `urlopen error [Errno 32] Broken pipe`  but it seems like it could also raise an HTTPError of some sort under certain circumstances.   At the very least this PR allows vsphere_copy to work where it didn't after the move to open_url.
