### PR TITLE
fix error with misArg not being declared

### DIFF
--- a/windows/win_firewall_rule.ps1
+++ b/windows/win_firewall_rule.ps1
@@ -205,6 +205,7 @@ $direction=Get-Attr $params "direction" "";
 $force=Get-Attr $params "force" $false;
 $action=Get-Attr $params "action" "";
 
+$misArg = ''
 # Check the arguments
 if ($enable -ne $null) {
     if ($enable -eq $true) {
@@ -262,7 +263,7 @@ foreach ($arg in $args){
 $winprofile=Get-Attr $params "profile" "current";
 $fwsettings.Add("profile", $winprofile)
 
-if ($($($misArg|measure).count) -gt 0){
+if ($misArg){
     $result=New-Object psobject @{
         changed=$false
         failed=$true


### PR DESCRIPTION
also fixed test to work on empty string or not for error reporting
