### PR TITLE
Wrapping room parameter in a string in case of using room IDs

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -184,7 +184,7 @@ def main():
     )
 
     token = module.params["token"]
-    room = module.params["room"]
+    room = str(module.params["room"])
     msg = module.params["msg"]
     msg_from = module.params["msg_from"]
     color = module.params["color"]


### PR DESCRIPTION
I was running into an issue when trying to use a room ID (int) versus a room name (string):

``` YAML

---
  - hipchat:
    api: "https://our.hipchat.server/v2"
    validate_certs: yes
    token: "token"
    room: 99
    msg: "message to lobby"
```

``` python
ASK: [notify hipchat] ********************************************************
failed: [host1] => {"failed": true}
msg: unable to send msg: expected a character buffer object
```

If I didn't quote the room ID (which one would expect to be an int), I found that when main loads the parameters via the AnsibleModule, it doesn't do any type checking.  So if a user passes an unquoted room ID:

``` python
room = module.params["room"]
```

 an int can make it through to the send_msg methods (in my case send_msg_v2):

``` python
try:
    if api.find('/v2') != -1:
        send_msg_v2(module, token, room, msg_from, msg, msg_format, color, notify, api)
    else:
        send_msg_v1(module, token, room, msg_from, msg, msg_format, color, notify, api)
except Exception, e:
    module.fail_json(msg="unable to send msg: %s" % e)
```
