### PR TITLE
Add limit-burst support to iptables module

### DIFF
--- a/system/iptables.py
+++ b/system/iptables.py
@@ -211,6 +211,10 @@ options:
     description:
       - "Specifies the maximum average number of matches to allow per second. The number can specify units explicitly, using `/second', `/minute', `/hour' or `/day', or parts of them (so `5/second' is the same as `5/s')."
     required: false
+  limit_burst:
+    description:
+      - "Specifies the maximum burst before the above limit kicks in."
+    required: false
 '''
 
 EXAMPLES = '''
@@ -266,8 +270,9 @@ def construct_rule(params):
     append_param(rule, params['comment'], '--comment', False)
     append_match(rule, params['ctstate'], 'state')
     append_csv(rule, params['ctstate'], '--state')
-    append_match(rule, params['limit'], 'limit')
+    append_match(rule, params['limit'] or params['limit_burst'], 'limit')
     append_param(rule, params['limit'], '--limit', False)
+    append_param(rule, params['limit_burst'], '--limit-burst', False)
     return rule
 
 
@@ -319,6 +324,7 @@ def main():
             comment=dict(required=False, default=None, type='str'),
             ctstate=dict(required=False, default=[], type='list'),
             limit=dict(required=False, default=None, type='str'),
+            limit_burst=dict(required=False, default=None, type='str'),
         ),
     )
     args = dict(


### PR DESCRIPTION
This PR adds support to be able to specify a `--limit-burst` number when using the `--limit` option in the iptables module.

cc @LinusU 
