### PR TITLE
Fix documentation os_project module.

### DIFF
--- a/cloud/openstack/os_project.py
+++ b/cloud/openstack/os_project.py
@@ -44,7 +44,7 @@ options:
         - Description for the project
      required: false
      default: None
-   domain_id:
+   domain:
      description:
         - Domain id to create the project in if the cloud supports domains
      required: false
@@ -71,7 +71,7 @@ EXAMPLES = '''
     state: present
     name: demoproject
     description: demodescription
-    domain_id: demoid
+    domain: demoid
     enabled: True
 
 # Delete a project


### PR DESCRIPTION
os_project returns this fatal error:

```
fatal: [openstack-vcenter]: FAILED! => {"changed": false, "failed": true, "msg": "unsupported parameter for module: domain_id"}
```

The documentation is wrong because the correct parameter must be "domain" instead "domain_id".
See line 173
