### PR TITLE
Fix boolean type conversion in osx_defaults module when value is not …

### DIFF
--- a/system/osx_defaults.py
+++ b/system/osx_defaults.py
@@ -124,9 +124,11 @@ class OSXDefaults(object):
         if type == "string":
             return str(value)
         elif type in ["bool", "boolean"]:
-            if value.lower() in [True, 1, "true", "1", "yes"]:
+            if isinstance(value, basestring):
+                value = value.lower()
+            if value in [True, 1, "true", "1", "yes"]:
                 return True
-            elif value.lower() in [False, 0, "false", "0", "no"]:
+            elif value in [False, 0, "false", "0", "no"]:
                 return False
             raise OSXDefaultsException("Invalid boolean value: {0}".format(repr(value)))
         elif type == "date":


### PR DESCRIPTION
…a string.

`value.lower()` was raising an AttributeError when `value` was an `int` or `bool`.
