### PR TITLE
Fix problem with 'restarted' state not restarting the apppool when it is in running state

### DIFF
--- a/windows/win_iis_webapppool.ps1
+++ b/windows/win_iis_webapppool.ps1
@@ -90,9 +90,13 @@ try {
       Stop-WebAppPool -Name $name -ErrorAction Stop
       $result.changed = $TRUE
     }
-    if ((($state -eq 'started') -and ($pool.State -eq 'Stopped')) -or ($state -eq 'restarted')) {
+    if ((($state -eq 'started') -and ($pool.State -eq 'Stopped'))) {
       Start-WebAppPool -Name $name -ErrorAction Stop
       $result.changed = $TRUE
+    }
+    if ($state -eq 'restarted') {
+      Restart-WebAppPool -Name $name
+      $result.changed = $TRUE   
     }
   }
 } catch {

--- a/windows/win_iis_webapppool.ps1
+++ b/windows/win_iis_webapppool.ps1
@@ -95,7 +95,11 @@ try {
       $result.changed = $TRUE
     }
     if ($state -eq 'restarted') {
-      Restart-WebAppPool -Name $name
+      switch ($pool.State)
+        { 
+          'Stopped' { Start-WebAppPool -Name $name -ErrorAction Stop }
+          default { Restart-WebAppPool -Name $name -ErrorAction Stop }
+        }
       $result.changed = $TRUE   
     }
   }


### PR DESCRIPTION
Scenario: I have a webappool running but I need to recycle it after making a config change.
Problem: In the current implementation, a restart does not happen when  my app pool is running since the Start-WebAppPool cmdlet is used to  perform the recycling action.
Proposed fix: Invoke the Restart-WebAppPool cmdlet to restart an App Pool regardless of App Pool running state

This is the same PR #1371 but reopened to take care of branching issue
