### PR TITLE
Fix puppet module formatting issue

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -49,9 +49,7 @@ options:
     default: None
   show_diff:
     description:
-      - >
-       Should puppet return diffs of changes applied. Defaults to off to
-       avoid leaking secret changes by default.
+      - Should puppet return diffs of changes applied. Defaults to off to avoid leaking secret changes by default.
     required: false
     default: no
     choices: [ "yes", "no" ]


### PR DESCRIPTION
The `->` in the `show_diff` option doc seemed to be causing the docs page to break. Not sure why, since it was still valid YAML. Please let me know if there is anything else I can do to help.

Image of issue from docs site:

![image](https://cloud.githubusercontent.com/assets/586829/12131768/19cf7152-b3db-11e5-9f03-199714cfc2b1.png)

cc: @emonty 
