### PR TITLE
Adding the ability to update all zypper packages

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -32,7 +32,6 @@ DOCUMENTATION = '''
 ---
 module: zypper
 author:
-    - "Patrick Callahan (@dirtyharrycallahan)"
     - "Alexander Gubin (@alxgu)"
     - "Thomas O'Donnell (@andytom)"
 version_added: "1.2"


### PR DESCRIPTION
Adding the option to have zypper update all packaged when name=\* state=latest (similar to the yum module). This resolves #546.
