### PR TITLE
Fix: route53_facts hosted_zone_id boto error

### DIFF
--- a/cloud/amazon/route53_facts.py
+++ b/cloud/amazon/route53_facts.py
@@ -178,7 +178,7 @@ def get_hosted_zone(client, module):
     params = dict()
 
     if module.params.get('hosted_zone_id'):
-        params['HostedZoneId'] = module.params.get('hosted_zone_id')
+        params['Id'] = module.params.get('hosted_zone_id')
     else:
         module.fail_json(msg="Hosted Zone Id is required")
 


### PR DESCRIPTION
Boto is expecting parameter called "Id", not "HostedZoneId" for get_hosted_zone function. See
http://boto3.readthedocs.org/en/latest/reference/services/route53.html#Route53.Client.get_hosted_zone

Following task will now work (replace "XYZ" with actual zone id):

```
 - name: Get zone details
      route53_facts:
        query: hosted_zone
        hosted_zone_id: "XYZ"
        hosted_zone_method: details
      register: res_dns_ns
```

Fixes ansible/ansible-modules-extras/#1465
