### PR TITLE
ec2_elb_facts - Print explicit error cause when no ELBs are found in AWS

### DIFF
--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -157,7 +157,7 @@ def list_elb(connection, module):
     try:
         all_elbs = connection.get_all_load_balancers(elb_names)
     except BotoServerError as e:
-        module.fail_json(msg=get_error_message(e.args[2]))
+        module.fail_json(msg = "%s: %s" % (e.error_code, e.error_message))
 
     elb_array = []
     for elb in all_elbs:


### PR DESCRIPTION
This PR fixes a bug reported in #1468

Make the error message more meaningful.
