### PR TITLE
Modified win_acl to accept Security Identifiers for Windows' users and groups

### DIFF
--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -108,6 +108,15 @@ If ($params.user) {
           Fail-Json $result "$($Params.User) is not a valid user or group on the host machine or domain"
     }    
 }
+ElseIf($params.sid)
+{
+    $objSID = New-Object System.Security.Principal.SecurityIdentifier($params.sid)
+    $user = $objSID.Translate([System.Security.Principal.NTAccount])
+    if (!$user)
+    {
+          Fail-Json $result "$($Params.Sid) is not a valid user or group on the host machine or domain"
+    }
+}
 Else {
     Fail-Json $result "missing required argument: user.  specify the user or group to apply permission changes."
 }

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -36,7 +36,12 @@ options:
   user:
     description:
       - User or Group to add specified rights to act on src file/folder
-    required: yes
+    required: Only if sid is not supplied
+    default: none
+  sid:
+    description:
+      - Security Identifier for the User or Group to add specified rights to act on src file/folder
+    required: Only if user is not supplied
     default: none
   state:
     description:
@@ -136,4 +141,15 @@ $ ansible -i hosts -m win_acl -a "user=Fed-Phil path=C:\Important\Executable.exe
     rights: 'Read,Write,Modify,FullControl,Delete'
     type: 'deny'
     state: 'present'
+
+#Allow Network Service user FullControl to MySite using the Security Identifier
+- name: Add NETWORK SERVICE allow rights
+  win_acl:
+    path: 'C:\inetpub\wwwroot\MySite'
+    sid: 'S-1-5-20'
+    rights: 'FullControl'
+    type: 'allow'
+    state: 'present'
+    inherit: 'ContainerInherit, ObjectInherit'
+    propagation: 'None'
 '''

--- a/windows/win_acl.py
+++ b/windows/win_acl.py
@@ -35,13 +35,11 @@ options:
     required: yes
   user:
     description:
-      - User or Group to add specified rights to act on src file/folder
-    required: Only if sid is not supplied
+      - User or Group to add specified rights to act on src file/folder. Only required if no sid is provided.
     default: none
   sid:
     description:
-      - Security Identifier for the User or Group to add specified rights to act on src file/folder
-    required: Only if user is not supplied
+      - Security Identifier for the User or Group to add specified rights to act on src file/folder. Only required if no user is provided.
     default: none
   state:
     description:


### PR DESCRIPTION
We use SIDs in our server configuration for most things (setting application pools and application config). Allowing win_acl to accept SIDs allows me to only have 1 variable for a specified user opposed to 2 (SID and user name).

Plus it allows for users outside of the domain or local machine, E.G. the NETWORK SERVICE user.
