### PR TITLE
[2.0.1] cloudstack: fixes and improvements

### DIFF
--- a/cloud/cloudstack/cs_portforward.py
+++ b/cloud/cloudstack/cs_portforward.py
@@ -230,7 +230,7 @@ class AnsibleCloudStackPortforwarding(AnsibleCloudStack):
             'publicport':       'public_port',
             'publicendport':    'public_end_port',
             'privateport':      'private_port',
-            'private_end_port': 'private_end_port',
+            'privateendport':   'private_end_port',
         }
         self.portforwarding_rule = None
         self.vm_default_nic = None
@@ -322,7 +322,6 @@ class AnsibleCloudStackPortforwarding(AnsibleCloudStack):
         args['publicendport']       = self.get_or_fallback('public_end_port', 'public_port')
         args['privateport']         = self.module.params.get('private_port')
         args['privateendport']      = self.get_or_fallback('private_end_port', 'private_port')
-        args['openfirewall']        = self.module.params.get('open_firewall')
         args['vmguestip']           = self.get_vm_guest_ip()
         args['ipaddressid']         = self.get_ip_address(key='id')
         args['virtualmachineid']    = self.get_vm(key='id')


### PR DESCRIPTION
cloudstack: cs_portforward: fix missing return and remove unused arg

please backport to 2.0.1 
/cc @abadger 

fixes: open_firewall param is used, always returns changed.
