### PR TITLE
Include instance states (InService or OutOfService) as ELB facts

### DIFF
--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -131,7 +131,7 @@ def get_health_check(health_check):
     return health_check_dict
 
 
-def get_elb_info(elb):
+def get_elb_info(connection,elb):
     elb_info = {
         'name': elb.name,
         'zones': elb.availability_zones,
@@ -142,9 +142,23 @@ def get_elb_info(elb):
         'security_groups': elb.security_groups,
         'health_check': get_health_check(elb.health_check),
         'subnets': elb.subnets,
+        'instances_inservice': [],
+        'instances_inservice_count': 0,
+        'instances_outofservice': [],
+        'instances_outofservice_count': 0,
+        'instances_inservice_percent': 0.0,
     }
     if elb.vpc_id:
         elb_info['vpc_id'] = elb.vpc_id
+    if elb.instances:
+        instance_health = connection.describe_instance_health(elb.name)
+        elb_info['instances_inservice'] = [inst.instance_id for inst in instance_health if inst.state == 'InService']
+        elb_info['instances_inservice_count'] = len(elb_info['instances_inservice'])
+        elb_info['instances_outofservice'] = [inst.instance_id for inst in instance_health if inst.state == 'OutOfService']
+        elb_info['instances_outofservice_count'] = len(elb_info['instances_outofservice'])
+        elb_info['instances_inservice_percent'] = float(elb_info['instances_inservice_count'])/(
+                    float(elb_info['instances_inservice_count']) + 
+                    float(elb_info['instances_outofservice_count']))
 
     return elb_info
 
@@ -161,7 +175,7 @@ def list_elb(connection, module):
 
     elb_array = []
     for elb in all_elbs:
-        elb_array.append(get_elb_info(elb))
+        elb_array.append(get_elb_info(connection,elb))
 
     module.exit_json(elbs=elb_array)
 

--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -158,7 +158,7 @@ def get_elb_info(connection,elb):
         elb_info['instances_outofservice_count'] = len(elb_info['instances_outofservice'])
         elb_info['instances_inservice_percent'] = float(elb_info['instances_inservice_count'])/(
                     float(elb_info['instances_inservice_count']) + 
-                    float(elb_info['instances_outofservice_count']))
+                    float(elb_info['instances_outofservice_count']))*100
 
     return elb_info
 


### PR DESCRIPTION
@mjschultz I added the a list of instances being `InService` or `OutOfService`, as well as a count of each, and the percent `InService` so that one can make determinations on whether or not to degregister instances when doing a deploy/update.

The dictionaries in list `elbs` now have these keys:

```
        "elb_facts.elbs": [                                                                                                                                                                   [50/1898]
            {
                "dns_name": "my-elb-98765432.us-east-1.elb.amazonaws.com",
                "health_check": {
                    "healthy_threshold": 4,
                    "interval": 30,
                    "ping_path": "/users/forgot_password",
                    "ping_port": 80,
                    "ping_protocol": "http",
                    "response_timeout": 5,
                    "unhealthy_threshold": 2
                },
                "instances": [
                    "i-260f4087",
                    "i-2f95f5f3"
                ],
                "instances_inservice": [
                    "i-2f95f5f3"
                ],
                "instances_inservice_count": 1,
"instances_inservice_percent": 50.0,
                "instances_outofservice": [
                    "i-260f4087"
                ],
                "instances_outofservice_count": 1,
                "listeners": [
```
