### PR TITLE
a ping_path may have more than one path separator

### DIFF
--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -112,7 +112,7 @@ def get_elb_listeners(listeners):
 def get_health_check(health_check):
     protocol, port_path = health_check.target.split(':')
     try:
-        port, path = port_path.split('/')
+        port, path = port_path.split('/', 1)
         path = '/{}'.format(path)
     except ValueError:
         port = port_path


### PR DESCRIPTION
@mjschultz This is a very small change to handle `ping_path`s which have more than one occurrence of the path separator. E.g. `/path/health`
