### PR TITLE
Allow numeric npm package versions

### DIFF
--- a/packaging/language/npm.py
+++ b/packaging/language/npm.py
@@ -131,7 +131,7 @@ class Npm(object):
             self.executable = [module.get_bin_path('npm', True)]
 
         if kwargs['version']:
-            self.name_version = self.name + '@' + self.version
+            self.name_version = self.name + '@' + str(self.version)
         else:
             self.name_version = self.name
 


### PR DESCRIPTION
When passing a package version that parses as a number (e.g. `1.9`), the version should be converted to a string before being concatenated to the package name.
