### PR TITLE
seport module fails when the `ports` argument is a integer

### DIFF
--- a/system/seport.py
+++ b/system/seport.py
@@ -234,7 +234,7 @@ def main():
     if not selinux.is_selinux_enabled():
         module.fail_json(msg="SELinux is disabled on this host.")
 
-    ports = [x.strip() for x in module.params['ports'].split(',')]
+    ports = [x.strip() for x in str(module.params['ports']).split(',')]
     proto = module.params['proto']
     setype = module.params['setype']
     state = module.params['state']


### PR DESCRIPTION
**Issue Type:** Bugfix Pull Request
**Summary:**
If you specify `ports` argument to `seport` module as a variable that is a integer, you will get the following error:

```
FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {"module_name": "seport"},
    "module_stderr": "",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-1452760636.61-276955643742433/seport\", line 2195, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1452760636.61-276955643742433/seport\", line 238, in main\r\n    ports = [x.strip() for x in module.params['ports'].split(',')]\r\nAttributeError: 'int' object has no attribute 'split'\r\n",
    "msg": "MODULE FAILURE",
    "parsed": false
}
```

**Steps to reproduce:**
Write a task that sets the `ports` argument from a variable that is a integer. For example:

```
seport: ports={{ http_port }} proto=tcp setype=http_port_t state=present
```

and specify the `http_port` variable like this:

```
http_port: 80
```

This will fail because the interpolated value is a integer and `seport` module tries to use the `split` method on it.

**Ansible Version:** Tested on Ansible version 2.0.0.1 and devel
**Ansible Config:** default
**Environment:** N/A
