### PR TITLE
Fix: Rename gem_install_path to gem_path - as specified in the docs

### DIFF
--- a/packaging/language/bundler.py
+++ b/packaging/language/bundler.py
@@ -163,7 +163,7 @@ def main():
     local = module.params.get('local')
     deployment_mode = module.params.get('deployment_mode')
     user_install = module.params.get('user_install')
-    gem_path = module.params.get('gem_install_path')
+    gem_path = module.params.get('gem_path')
     binstub_directory = module.params.get('binstub_directory')
     extra_args = module.params.get('extra_args')
 


### PR DESCRIPTION
I've noticed the `gem_path` option specified [here](http://docs.ansible.com/ansible/bundler_module.html) was not really working for me: it would never append `--path` to the `bundle install` call.

so I had a look at the source code and realised that it's actually looking for `gem_install_path`. but that one doesn't work either because it's not in the list of supported arguments :)

so this PR fixes the parameter name to the one in the specification: `gem_path`.

in the mean time, everyone else interested in this issue can use the `extra_args` as a (hopefully) temporary fix:

```
- bundler: extra_args="--path /path/to/gems"
```

looking forward to your feedback :dancers: 
