### PR TITLE
osx_defaults: Fix boolean value parsing

### DIFF
--- a/system/osx_defaults.py
+++ b/system/osx_defaults.py
@@ -124,9 +124,11 @@ class OSXDefaults(object):
         if type == "string":
             return str(value)
         elif type in ["bool", "boolean"]:
-            if value.lower() in [True, 1, "true", "1", "yes"]:
+            if isinstance(value, basestring):
+                value = value.lower()
+            if value in [True, 1, "true", "1", "yes"]:
                 return True
-            elif value.lower() in [False, 0, "false", "0", "no"]:
+            elif value in [False, 0, "false", "0", "no"]:
                 return False
             raise OSXDefaultsException("Invalid boolean value: {0}".format(repr(value)))
         elif type == "date":


### PR DESCRIPTION
Values for boolean types were being unconditionally treated as strings
(by calling `.lower()`), thus breaking value parsing for actual boolean
and integer objects.

It looks like the bug was introduced in:
- 130bd670d82cc55fa321021e819838e07ff10c08

Fixes #709.
