### PR TITLE
adding public ip address to ec2_remote_facts

### DIFF
--- a/cloud/amazon/ec2_remote_facts.py
+++ b/cloud/amazon/ec2_remote_facts.py
@@ -113,7 +113,7 @@ def get_instance_info(instance):
                     'region': instance.region.name,
                     'persistent': instance.persistent,
                     'private_ip_address': instance.private_ip_address,
-                    'public_ip_adress': instance.ip_address,
+                    'public_ip_address': instance.ip_address,
                     'state': instance._state.name,
                     'vpc_id': instance.vpc_id,
                   }

--- a/cloud/amazon/ec2_remote_facts.py
+++ b/cloud/amazon/ec2_remote_facts.py
@@ -113,6 +113,7 @@ def get_instance_info(instance):
                     'region': instance.region.name,
                     'persistent': instance.persistent,
                     'private_ip_address': instance.private_ip_address,
+                    'public_ip_adress': instance.ip_address,
                     'state': instance._state.name,
                     'vpc_id': instance.vpc_id,
                   }


### PR DESCRIPTION
Seems like the ec2_remote_facts module does not currently provide the public ip address of the instance. 

This PR adds the public ip address.
