### PR TITLE
Fix #1512 add missing property in win_firewall_rule

### DIFF
--- a/windows/win_firewall_rule.ps1
+++ b/windows/win_firewall_rule.ps1
@@ -98,6 +98,7 @@ function getFirewallRule ($fwsettings) {
             $msg += @("No rule could be found");
         };
         $result = @{
+            failed = $false
             exists = $exists
             identical = $correct
             multiple = $multi
@@ -137,6 +138,7 @@ function createFireWallRule ($fwsettings) {
         $msg+=@("Created firewall rule $name");
 
         $result=@{
+            failed = $false
             output=$output
             changed=$true
             msg=$msg


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request (ref #1512)
##### Ansible Version:

2.0.0.2
##### Environment

Running ansible from OSX, managing a Windows 10 host
##### Affected Module:

win_firewall_rule
##### Summary:

Adding missing `failed` property to result hash map in `GetFirewallRule` and `CreateFirewallRule` functions to avoid error mentioned in #1512.

In our configuration, running ansible 2.0.0.2 against Windows 10, this is a critical patch. Without it the module win_firewall_rule did not work at all. See initial issue for details.

Let me know what you think,
Thanks
