### PR TITLE
iptables: fix param check in append_csv function

### DIFF
--- a/system/iptables.py
+++ b/system/iptables.py
@@ -238,7 +238,7 @@ def append_param(rule, param, flag, is_list):
 
 
 def append_csv(rule, param, flag):
-    if param is not None:
+    if param:
         rule.extend([flag, ','.join(param)])
 
 


### PR DESCRIPTION
A bug in `append_csv` method was added in this PR: https://github.com/ansible/ansible-modules-extras/pull/1403

This PR corrects this. It was caused by the comparison of `params['ctstate']`and `None`. The default value of `params['ctstate']` is `[]`, so the comparison was never true. It triggered the following error:

```
PARSED OUTPUT
{
    "cmd": "/sbin/iptables -t filter -A INPUT -s 1.2.3.4 -j ACCEPT --state '' -m limit --limit 5 --limit-burst 6",
    "failed": true,
    "invocation": {
        "module_args": {
            "chain": "INPUT",
            "comment": null,
            "ctstate": [],
            "destination": null,
            "destination_port": null,
            "fragment": null,
            "goto": null,
            "in_interface": null,
            "ip_version": "ipv4",
            "jump": "ACCEPT",
            "limit": "5",
            "limit_burst": "6",
            "match": [],
            "out_interface": null,
            "protocol": null,
            "set_counters": null,
            "source": "1.2.3.4",
            "source_port": null,
            "state": "present",
            "table": "filter",
            "to_ports": null
        }
    },
    "msg": "iptables v1.4.21: unknown option \"--state\"\nTry `iptables -h' or 'iptables --help' for more information.",
    "rc": 2,
    "stderr": "iptables v1.4.21: unknown option \"--state\"\nTry `iptables -h' or 'iptables --help' for more information.\n",
    "stdout": ""
}
```
