### PR TITLE
zypper_repository: don't silently ignore repo changes

### DIFF
--- a/packaging/os/zypper_repository.py
+++ b/packaging/os/zypper_repository.py
@@ -121,7 +121,7 @@ def repo_exists(module, **kwargs):
 
         for k, v in realrepo.items():
             if k in repocmp:
-                if v.rstrip("/") != repocmp[k].rstrip("/"):
+                if (v or "").rstrip("/") != (repocmp[k] or "").rstrip("/"):
                     return True
         return False
 


### PR DESCRIPTION
So far when a repo URL changes this got silently ignored (leading to
incorrect package installations) due to this code:

```
elif 'already exists. Please use another alias' in stderr:
    changed = False
```

Removing this reveals that we correctly detect that a repo definition
has changes (via repo_subset) but don't indicate this as change but as a
nonexistent repo. This makes us currenlty bail out silently in the above
statement.

To fix this distinguish between non existent and modified repos and
remove the repo first in case of modifications (since there is no force
option in zypper to overwrite it and 'zypper mr' uses different
arguments). Recreate it as usual. Only do this if we have an alias name
since with a different name a new repo is o.k.
