### PR TITLE
Fix exception output for os_keystone_domain.

### DIFF
--- a/cloud/openstack/os_keystone_domain.py
+++ b/cloud/openstack/os_keystone_domain.py
@@ -181,7 +181,7 @@ def main():
             module.exit_json(changed=changed)
 
     except shade.OpenStackCloudException as e:
-        module.fail_json(msg=e.message)
+        module.fail_json(msg=str(e))
 
 
 from ansible.module_utils.basic import *


### PR DESCRIPTION
The message attribute of a shade exception is not very helpful.
Converting to a full string will contain many more details.
