### PR TITLE
Fix inconsistent use of return value of up_connection()

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -886,8 +886,7 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_team()
                 self.execute_command(cmd)
-                cmd=self.up_connection()
-                return self.execute_command(cmd)
+                return self.up_connection()
             elif (self.dns4 is None) or (self.dns6 is None):
                 cmd=self.create_connection_team()
                 return self.execute_command(cmd)
@@ -896,9 +895,8 @@ class Nmcli(object):
                 cmd=self.create_connection_team_slave()
                 self.execute_command(cmd)
                 cmd=self.modify_connection_team_slave()
-                self.execute_command(cmd)
-                # cmd=self.up_connection()
                 return self.execute_command(cmd)
+                #return self.up_connection()
             else:
                 cmd=self.create_connection_team_slave()
                 return self.execute_command(cmd)
@@ -908,8 +906,7 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_bond()
                 self.execute_command(cmd)
-                cmd=self.up_connection()
-                return self.execute_command(cmd)
+                return self.up_connection()
             else:
                 cmd=self.create_connection_bond()
                 return self.execute_command(cmd)
@@ -921,8 +918,7 @@ class Nmcli(object):
                 self.execute_command(cmd)
                 cmd=self.modify_connection_ethernet()
                 self.execute_command(cmd)
-                cmd=self.up_connection()
-                return self.execute_command(cmd)
+                return self.up_connection()
             else:
                 cmd=self.create_connection_ethernet()
                 return self.execute_command(cmd)


### PR DESCRIPTION
The function up_connection() calls execute_command() from within itself and returns that command's exit status.  Callers to up_connection should not be calling execute_command() on that return status.
