### PR TITLE
Doc wrongly indicates firewalld permanent flag is required

### DIFF
--- a/system/firewalld.py
+++ b/system/firewalld.py
@@ -56,7 +56,8 @@ options:
   permanent:
     description:
       - "Should this configuration be in the running firewalld configuration or persist across reboots."
-    required: true
+    required: false
+    default: null
   immediate:
     description:
       - "Should this configuration be applied immediately, if set as permanent"


### PR DESCRIPTION
But it isn't.

https://github.com/ansible/ansible-modules-extras/blob/174bef08ae79e84881da8f29956036f64b643199/system/firewalld.py#L255
