### PR TITLE
fixed python 2.4 compatibility

### DIFF
--- a/system/pam_limits.py
+++ b/system/pam_limits.py
@@ -243,11 +243,16 @@ def main():
         nf.write(new_limit)
 
     f.close()
-    nf.close()
+    nf.flush()
 
     # Copy tempfile to newfile
     module.atomic_move(nf.name, f.name)
 
+    try:
+        nf.close()
+    except:
+        pass
+   
     res_args = dict(
         changed = changed, msg = message
     )


### PR DESCRIPTION
When running pam_limits again RHEL5, it fails because the "delete" argument to tempfile.NamedTemporaryFile was added in Python 2.6: https://docs.python.org/2/library/tempfile.html

nf=tempfile.NamedTemporaryFile(delete=False)
TypeError: NamedTemporaryFile() got an unexpected keyword argument 'delete'
