### PR TITLE
ec2_remote_facts.py - added block_device_mapping to the returned output

### DIFF
--- a/cloud/amazon/ec2_remote_facts.py
+++ b/cloud/amazon/ec2_remote_facts.py
@@ -83,6 +83,21 @@ def get_instance_info(instance):
     except AttributeError:
         source_dest_check = None
 
+    # Get block device mapping
+    try:
+        bdm_dict = []
+        bdm = getattr(instance, 'block_device_mapping')
+        for device_name in bdm.keys():
+            bdm_dict.append({
+                'device_name': device_name,
+                'status': bdm[device_name].status,
+                'volume_id': bdm[device_name].volume_id,
+                'delete_on_termination': bdm[device_name].delete_on_termination,
+                'attach_time': bdm[device_name].attach_time
+            })
+    except AttributeError:
+        pass
+
     instance_info = { 'id': instance.id,
                     'kernel': instance.kernel,
                     'instance_profile': instance.instance_profile,
@@ -115,6 +130,7 @@ def get_instance_info(instance):
                     'private_ip_address': instance.private_ip_address,
                     'state': instance._state.name,
                     'vpc_id': instance.vpc_id,
+                    'block_device_mapping': bdm_dict,
                   }
 
     return instance_info


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Ansible Version:

2.0.0.2
##### Summary:

This PR adds to the returned output of the module the block_device_mapping structure.
It's useful to know what EBS volumes are currently attached to EC2 instance.

ansible-modules-extras/cloud/amazon/ec2_remote_facts.py

```
...
"block_device_mapping": {
                    "/dev/sda1": {
                        "attach_time": "2015-11-13T16:53:52.000Z",
                        "delete_on_termination": true,
                        "status": "attached",
                        "volume_id": "vol-02ceebcd"
                    }
},
...
```
