### PR TITLE
Change example to include ethernet as the type.

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -360,7 +360,7 @@ tenant_ip: "192.168.200.21/23"
 - nmcli: ctype=ethernet name=my-eth1 ifname="*" state=present
 
 # To change the property of a setting e.g. MTU, issue a command as follows:
-- nmcli: conn_name=my-eth1 mtu=9000 state=present
+- nmcli: conn_name=my-eth1 mtu=9000 type=ethernet state=present
 
     Exit Status's:
         - nmcli exits with status 0 if it succeeds, a value greater than 0 is


### PR DESCRIPTION
I'm sure this is not the true fix, the actual problem is without a type:

TASK [ntoggle.networking : Set MTU=9000 on external NICs] **********************
failed: [node14.us-east.mgmt.ntoggle.com] => (item=ens1) => {"cmd": "", "failed": true, "item": "ens1", "msg": "Traceback (most recent call last):\n  File \"<stdin>\", line 2906, in run_command\n  File \"/usr/lib64/python2.7/subprocess.py\", line 710, in **init**\n    errread, errwrite)\n  File \"/usr/lib64/python2.7/subprocess.py\", line 1214, in _execute_child\n    executable = args[0]\nIndexError: list index out of range\n", "rc": 257}
failed: [node14.us-east.mgmt.ntoggle.com] => (item=ens1d1) => {"cmd": "", "failed": true, "item": "ens1d1", "msg": "Traceback (most recent call last):\n  File \"<stdin>\", line 2906, in run_command\n  File \"/usr/lib64/python2.7/subprocess.py\", line 710, in __init__\n    errread, errwrite)\n  File \"/usr/lib64/python2.7/subprocess.py\", line 1214, in _execute_child\n    executable = args[0]\nIndexError: list index out of range\n", "rc": 257}

But setting a type works for now.
