### PR TITLE
fix the spelling of vim's flavor in the example

### DIFF
--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -77,7 +77,7 @@ EXAMPLES = '''
 - openbsd_pkg: name=nmap state=present build=yes
 
 # Specify a pkg flavour with '--'
-- openbsd_pkg: name=vim--nox11 state=present
+- openbsd_pkg: name=vim--no_x11 state=present
 
 # Specify the default flavour to avoid ambiguity errors
 - openbsd_pkg: name=vim-- state=present


### PR DESCRIPTION
Hi,

With the current example
TASK [init : install vim] ******************************************************
fatal: [myhost]: FAILED! => {"changed": false, "failed": true, "msg": "Can't find vim--nox11\n"}

VS

TASK [init : install vim] ******************************************************
changed: [myhost] => {"changed": true, "name": "vim--no_x11", "state": "present"}

You can also see the right spelling there: http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/editors/vim/Makefile?rev=1.144&content-type=text/x-cvsweb-markup
