### PR TITLE
Resolves issue with vmware_vswitch module for v2.0

### DIFF
--- a/cloud/vmware/vmware_vswitch.py
+++ b/cloud/vmware/vmware_vswitch.py
@@ -32,20 +32,6 @@ requirements:
     - "python >= 2.6"
     - PyVmomi
 options:
-    hostname:
-        description:
-            - The hostname or IP address of the ESXi server
-        required: True
-    username:
-        description:
-            - The username of the ESXi server
-        required: True
-        aliases: ['user', 'admin']
-    password:
-        description:
-            - The password of the ESXi server
-        required: True
-        aliases: ['pass', 'pwd']
     switch_name:
         description:
             - vSwitch name to add

--- a/cloud/vmware/vmware_vswitch.py
+++ b/cloud/vmware/vmware_vswitch.py
@@ -32,6 +32,20 @@ requirements:
     - "python >= 2.6"
     - PyVmomi
 options:
+    hostname:
+        description:
+            - The hostname or IP address of the ESXi server
+        required: True
+    username:
+        description:
+            - The username of the ESXi server
+        required: True
+        aliases: ['user', 'admin']
+    password:
+        description:
+            - The password of the ESXi server
+        required: True
+        aliases: ['pass', 'pwd']
     switch_name:
         description:
             - vSwitch name to add
@@ -82,82 +96,101 @@ except ImportError:
 
 
 def find_vswitch_by_name(host, vswitch_name):
-    for vss in host.config.network.vswitch:
-        if vss.name == vswitch_name:
-            return vss
-    return None
+        for vss in host.config.network.vswitch:
+            if vss.name == vswitch_name:
+                return vss
+        return None
 
 
-# Source from
-# https://github.com/rreubenur/pyvmomi-community-samples/blob/patch-1/samples/create_vswitch.py
+class VMwareHostVirtualSwitch(object):
+    
+    def __init__(self, module):
+        self.host_system = None
+        self.content = None
+        self.vss = None
+        self.module = module
+        self.switch_name = module.params['switch_name']
+        self.number_of_ports = module.params['number_of_ports']
+        self.nic_name = module.params['nic_name']
+        self.mtu = module.params['mtu']
+        self.state = module.params['state']
+        self.content = connect_to_api(self.module)
 
-def state_create_vswitch(module):
+    def process_state(self):
+        try:
+            vswitch_states = {
+                'absent': {
+                    'present': self.state_destroy_vswitch,
+                    'absent': self.state_exit_unchanged,
+                },
+                'present': {
+                    'update': self.state_update_vswitch,
+                    'present': self.state_exit_unchanged,
+                    'absent': self.state_create_vswitch,
+                }
+            }
 
-    switch_name = module.params['switch_name']
-    number_of_ports = module.params['number_of_ports']
-    nic_name = module.params['nic_name']
-    mtu = module.params['mtu']
-    host = module.params['host']
+            vswitch_states[self.state][self.check_vswitch_configuration()]()
 
-    vss_spec = vim.host.VirtualSwitch.Specification()
-    vss_spec.numPorts = number_of_ports
-    vss_spec.mtu = mtu
-    vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=[nic_name])
-    host.configManager.networkSystem.AddVirtualSwitch(vswitchName=switch_name, spec=vss_spec)
-    module.exit_json(changed=True)
-
-
-def state_exit_unchanged(module):
-    module.exit_json(changed=False)
-
-
-def state_destroy_vswitch(module):
-    vss = module.params['vss']
-    host = module.params['host']
-    config = vim.host.NetworkConfig()
-
-    for portgroup in host.configManager.networkSystem.networkInfo.portgroup:
-        if portgroup.spec.vswitchName == vss.name:
-            portgroup_config = vim.host.PortGroup.Config()
-            portgroup_config.changeOperation = "remove"
-            portgroup_config.spec = vim.host.PortGroup.Specification()
-            portgroup_config.spec.name = portgroup.spec.name
-            portgroup_config.spec.vlanId = portgroup.spec.vlanId
-            portgroup_config.spec.vswitchName = portgroup.spec.vswitchName
-            portgroup_config.spec.policy = vim.host.NetworkPolicy()
-            config.portgroup.append(portgroup_config)
-
-    host.configManager.networkSystem.UpdateNetworkConfig(config, "modify")
-    host.configManager.networkSystem.RemoveVirtualSwitch(vss.name)
-    module.exit_json(changed=True)
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            self.module.fail_json(msg=method_fault.msg)
+        except Exception as e:
+            self.module.fail_json(msg=str(e))
 
 
-def state_update_vswitch(module):
-    module.exit_json(changed=False, msg="Currently not implemented.")
+    # Source from
+    # https://github.com/rreubenur/pyvmomi-community-samples/blob/patch-1/samples/create_vswitch.py
+    
+    def state_create_vswitch(self):
+        vss_spec = vim.host.VirtualSwitch.Specification()
+        vss_spec.numPorts = self.number_of_ports
+        vss_spec.mtu = self.mtu
+        vss_spec.bridge = vim.host.VirtualSwitch.BondBridge(nicDevice=[self.nic_name])
+        self.host_system.configManager.networkSystem.AddVirtualSwitch(vswitchName=self.switch_name, spec=vss_spec)
+        self.module.exit_json(changed=True)
 
+    def state_exit_unchanged(self):
+        self.module.exit_json(changed=False)
 
-def check_vswitch_configuration(module):
-    switch_name = module.params['switch_name']
-    content = connect_to_api(module)
-    module.params['content'] = content
+    def state_destroy_vswitch(self):
+        config = vim.host.NetworkConfig()
+    
+        for portgroup in self.host_system.configManager.networkSystem.networkInfo.portgroup:
+            if portgroup.spec.vswitchName == self.vss.name:
+                portgroup_config = vim.host.PortGroup.Config()
+                portgroup_config.changeOperation = "remove"
+                portgroup_config.spec = vim.host.PortGroup.Specification()
+                portgroup_config.spec.name = portgroup.spec.name
+                portgroup_config.spec.name = portgroup.spec.name
+                portgroup_config.spec.vlanId = portgroup.spec.vlanId
+                portgroup_config.spec.vswitchName = portgroup.spec.vswitchName
+                portgroup_config.spec.policy = vim.host.NetworkPolicy()
+                config.portgroup.append(portgroup_config)
+    
+        self.host_system.configManager.networkSystem.UpdateNetworkConfig(config, "modify")
+        self.host_system.configManager.networkSystem.RemoveVirtualSwitch(self.vss.name)
+        self.module.exit_json(changed=True)
 
-    host = get_all_objs(content, [vim.HostSystem])
-    if not host:
-        module.fail_json(msg="Unble to find host")
+    def state_update_vswitch(self):
+        self.module.exit_json(changed=False, msg="Currently not implemented.")
 
-    host_system = host.keys()[0]
-    module.params['host'] = host_system
-    vss = find_vswitch_by_name(host_system, switch_name)
-
-    if vss is None:
-        return 'absent'
-    else:
-        module.params['vss'] = vss
-        return 'present'
-
+    def check_vswitch_configuration(self):
+        host = get_all_objs(self.content, [vim.HostSystem])
+        if not host:
+            self.module.fail_json(msg="Unable to find host")
+    
+        self.host_system = host.keys()[0]
+        self.vss = find_vswitch_by_name(self.host_system, self.switch_name)
+    
+        if self.vss is None:
+            return 'absent'
+        else:
+            return 'present'
+    
 
 def main():
-
     argument_spec = vmware_argument_spec()
     argument_spec.update(dict(switch_name=dict(required=True, type='str'),
                          nic_name=dict(required=True, type='str'),
@@ -170,27 +203,8 @@ def main():
     if not HAS_PYVMOMI:
         module.fail_json(msg='pyvmomi is required for this module')
 
-    try:
-        vswitch_states = {
-            'absent': {
-                'present': state_destroy_vswitch,
-                'absent': state_exit_unchanged,
-            },
-            'present': {
-                'update': state_update_vswitch,
-                'present': state_exit_unchanged,
-                'absent': state_create_vswitch,
-            }
-        }
-
-        vswitch_states[module.params['state']][check_vswitch_configuration(module)](module)
-
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        module.fail_json(msg=method_fault.msg)
-    except Exception as e:
-        module.fail_json(msg=str(e))
+    host_virtual_switch = VMwareHostVirtualSwitch(module)
+    host_virtual_switch.process_state()
 
 from ansible.module_utils.vmware import *
 from ansible.module_utils.basic import *


### PR DESCRIPTION
When this module was written back in May 2015 we were using 1.9.x. Being lazy I added to param the objects that the other functions would need. What I have noticed is in 2.0 exit_json is trying to jsonify those complex objects and failing.  This PR resolves that issue with the `vmware_vswitch` module.  In the process of testing all the VMware modules for our open source release of our playbooks.

``` bash
ansible-playbook --version
ansible-playbook 2.0.0.2
  config file = /opt/autodeploy/projects/emmet/ansible.cfg
  configured module search path = Default w/o overrides
```

Playbook

``` yaml
   - name: Add a temporary vSwitch
      local_action:
        module: vmware_vswitch
        hostname: "{{ inventory_hostname }}"
        username: "{{ esxi_username }}"
        password: "{{ site_passwd }}"
        switch_name: temp_vswitch
        nic_name: "{{ vss_vmnic }}"
        mtu: 1500
```

Module Testing

``` bash
TASK [Add a temporary vSwitch] *************************************************
task path: /opt/autodeploy/projects/emmet/tasks/deploy/esxi_network.yml:13
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC ( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1454342817.37-180776062017566 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1454342817.37-180776062017566 )" )
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC ( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1454342817.41-201974997737598 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1454342817.41-201974997737598 )" )
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC ( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1454342817.44-148446986849801 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1454342817.44-148446986849801 )" )
localhost PUT /tmp/tmpLLExSG TO /root/.ansible/tmp/ansible-tmp-1454342817.37-180776062017566/vmware_vswitch
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1454342817.37-180776062017566/vmware_vswitch; rm -rf "/root/.ansible/tmp/ansible-tmp-1454342817.37-180776062017566/" > /dev/null 2>&1
localhost PUT /tmp/tmpyoAaHt TO /root/.ansible/tmp/ansible-tmp-1454342817.41-201974997737598/vmware_vswitch
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1454342817.41-201974997737598/vmware_vswitch; rm -rf "/root/.ansible/tmp/ansible-tmp-1454342817.41-201974997737598/" > /dev/null 2>&1
localhost PUT /tmp/tmpPcmaMZ TO /root/.ansible/tmp/ansible-tmp-1454342817.44-148446986849801/vmware_vswitch
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1454342817.44-148446986849801/vmware_vswitch; rm -rf "/root/.ansible/tmp/ansible-tmp-1454342817.44-148446986849801/" > /dev/null 2>&1
changed: [foundation-esxi-01 -> localhost] => {"changed": true, "invocation": {"module_args": {"hostname": "foundation-esxi-01", "mtu": 1500, "nic_name": "vmnic1", "number_of_ports": 128, "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "state": "present", "switch_name": "temp_vswitch", "username": "root"}, "module_name": "vmware_vswitch"}}
changed: [foundation-esxi-02 -> localhost] => {"changed": true, "invocation": {"module_args": {"hostname": "foundation-esxi-02", "mtu": 1500, "nic_name": "vmnic1", "number_of_ports": 128, "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "state": "present", "switch_name": "temp_vswitch", "username": "root"}, "module_name": "vmware_vswitch"}}
changed: [foundation-esxi-03 -> localhost] => {"changed": true, "invocation": {"module_args": {"hostname": "foundation-esxi-03", "mtu": 1500, "nic_name": "vmnic1", "number_of_ports": 128, "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "state": "present", "switch_name": "temp_vswitch", "username": "root"}, "module_name": "vmware_vswitch"}}
```
