### PR TITLE
Update return variable in xenserver_facts.py

### DIFF
--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -188,7 +188,7 @@ def main():
     if xs_srs:
         data['xs_srs'] = xs_srs
 
-    module.exit_json(ansible=data)
+    module.exit_json(ansible_facts=data)
 
 from ansible.module_utils.basic import *
 


### PR DESCRIPTION
Returning data under a key of 'ansible' does nothing useful, if you return data under the key 'ansible_facts', it gets merged with the existing ansible_facts.
