### PR TITLE
Add XenServer 6.5.0 codename to list of codenames

### DIFF
--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -54,7 +54,8 @@ class XenServerFacts:
             '5.6.100': 'oxford',
             '6.0.0': 'boston',
             '6.1.0': 'tampa',
-            '6.2.0': 'clearwater'
+            '6.2.0': 'clearwater',
+            '6.5.0': 'creedence'
         }
 
     @property


### PR DESCRIPTION
XenServer 6.5.0 has been out for over a year.
