### PR TITLE
Resolves issue with vmware_cluster module for v2.0

### DIFF
--- a/cloud/vmware/vmware_cluster.py
+++ b/cloud/vmware/vmware_cluster.py
@@ -77,152 +77,153 @@ except ImportError:
     HAS_PYVMOMI = False
 
 
-def configure_ha(enable_ha):
-    das_config = vim.cluster.DasConfigInfo()
-    das_config.enabled = enable_ha
-    das_config.admissionControlPolicy = vim.cluster.FailoverLevelAdmissionControlPolicy()
-    das_config.admissionControlPolicy.failoverLevel = 2
-    return das_config
+class VMwareCluster(object):
+    def __init__(self, module):
+        self.module = module
+        self.enable_ha = module.params['enable_ha']
+        self.enable_drs = module.params['enable_drs']
+        self.enable_vsan = module.params['enable_vsan']
+        self.cluster_name = module.params['cluster_name']
+        self.desired_state = module.params['state']
+        self.datacenter = None
+        self.cluster = None
+        self.content = connect_to_api(module)
+        self.datacenter_name = module.params['datacenter_name']
 
+    def process_state(self):
+        cluster_states = {
+            'absent': {
+                'present': self.state_destroy_cluster,
+                'absent': self.state_exit_unchanged,
+            },
+            'present': {
+                'update': self.state_update_cluster,
+                'present': self.state_exit_unchanged,
+                'absent': self.state_create_cluster,
+            }
+        }
+        current_state = self.check_cluster_configuration()
+        # Based on the desired_state and the current_state call
+        # the appropriate method from the dictionary
+        cluster_states[self.desired_state][current_state]()
 
-def configure_drs(enable_drs):
-    drs_config = vim.cluster.DrsConfigInfo()
-    drs_config.enabled = enable_drs
-    # Set to partially automated
-    drs_config.vmotionRate = 3
-    return drs_config
+    def configure_ha(self):
+        das_config = vim.cluster.DasConfigInfo()
+        das_config.enabled = self.enable_ha
+        das_config.admissionControlPolicy = vim.cluster.FailoverLevelAdmissionControlPolicy()
+        das_config.admissionControlPolicy.failoverLevel = 2
+        return das_config
 
+    def configure_drs(self):
+        drs_config = vim.cluster.DrsConfigInfo()
+        drs_config.enabled = self.enable_drs
+        # Set to partially automated
+        drs_config.vmotionRate = 3
+        return drs_config
 
-def configure_vsan(enable_vsan):
-    vsan_config = vim.vsan.cluster.ConfigInfo()
-    vsan_config.enabled = enable_vsan
-    vsan_config.defaultConfig = vim.vsan.cluster.ConfigInfo.HostDefaultInfo()
-    vsan_config.defaultConfig.autoClaimStorage = False
-    return vsan_config
+    def configure_vsan(self):
+        vsan_config = vim.vsan.cluster.ConfigInfo()
+        vsan_config.enabled = self.enable_vsan
+        vsan_config.defaultConfig = vim.vsan.cluster.ConfigInfo.HostDefaultInfo()
+        vsan_config.defaultConfig.autoClaimStorage = False
+        return vsan_config
 
+    def state_create_cluster(self):
+        try:
+            cluster_config_spec = vim.cluster.ConfigSpecEx()
+            cluster_config_spec.dasConfig = self.configure_ha()
+            cluster_config_spec.drsConfig = self.configure_drs()
+            if self.enable_vsan:
+                cluster_config_spec.vsanConfig = self.configure_vsan()
+            if not self.module.check_mode:
+                self.datacenter.hostFolder.CreateClusterEx(self.cluster_name, cluster_config_spec)
+            self.module.exit_json(changed=True)
+        except vim.fault.DuplicateName:
+            self.module.fail_json(msg="A cluster with the name %s already exists" % self.cluster_name)
+        except vmodl.fault.InvalidArgument:
+            self.module.fail_json(msg="Cluster configuration specification parameter is invalid")
+        except vim.fault.InvalidName:
+            self.module.fail_json(msg="%s is an invalid name for a cluster" % self.cluster_name)
+        except vmodl.fault.NotSupported:
+            # This should never happen
+            self.module.fail_json(msg="Trying to create a cluster on an incorrect folder object")
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            # This should never happen either
+            self.module.fail_json(msg=method_fault.msg)
 
-def state_create_cluster(module):
+    def state_destroy_cluster(self):
+        changed = True
+        result = None
 
-    enable_ha = module.params['enable_ha']
-    enable_drs = module.params['enable_drs']
-    enable_vsan = module.params['enable_vsan']
-    cluster_name = module.params['cluster_name']
-    datacenter = module.params['datacenter']
+        try:
+            if not self.module.check_mode:
+                task = self.cluster.Destroy_Task()
+                changed, result = wait_for_task(task)
+            self.module.exit_json(changed=changed, result=result)
+        except vim.fault.VimFault as vim_fault:
+            self.module.fail_json(msg=vim_fault.msg)
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            self.module.fail_json(msg=method_fault.msg)
 
-    try:
+    def state_exit_unchanged(self):
+        self.module.exit_json(changed=False)
+
+    def state_update_cluster(self):
         cluster_config_spec = vim.cluster.ConfigSpecEx()
-        cluster_config_spec.dasConfig = configure_ha(enable_ha)
-        cluster_config_spec.drsConfig = configure_drs(enable_drs)
-        if enable_vsan:
-            cluster_config_spec.vsanConfig = configure_vsan(enable_vsan)
-        if not module.check_mode:
-            datacenter.hostFolder.CreateClusterEx(cluster_name, cluster_config_spec)
-        module.exit_json(changed=True)
-    except vim.fault.DuplicateName:
-        module.fail_json(msg="A cluster with the name %s already exists" % cluster_name)
-    except vmodl.fault.InvalidArgument:
-        module.fail_json(msg="Cluster configuration specification parameter is invalid")
-    except vim.fault.InvalidName:
-        module.fail_json(msg="%s is an invalid name for a cluster" % cluster_name)
-    except vmodl.fault.NotSupported:
-        # This should never happen
-        module.fail_json(msg="Trying to create a cluster on an incorrect folder object")
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        # This should never happen either
-        module.fail_json(msg=method_fault.msg)
+        changed = True
+        result = None
 
+        if self.cluster.configurationEx.dasConfig.enabled != self.enable_ha:
+            cluster_config_spec.dasConfig = self.configure_ha()
+        if self.cluster.configurationEx.drsConfig.enabled != self.enable_drs:
+            cluster_config_spec.drsConfig = self.configure_drs()
+        if self.cluster.configurationEx.vsanConfigInfo.enabled != self.enable_vsan:
+            cluster_config_spec.vsanConfig = self.configure_vsan()
 
-def state_destroy_cluster(module):
-    cluster = module.params['cluster']
-    changed = True
-    result = None
+        try:
+            if not self.module.check_mode:
+                task = self.cluster.ReconfigureComputeResource_Task(cluster_config_spec, True)
+                changed, result = wait_for_task(task)
+            self.module.exit_json(changed=changed, result=result)
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            self.module.fail_json(msg=method_fault.msg)
+        except TaskError as task_e:
+            self.module.fail_json(msg=str(task_e))
 
-    try:
-        if not module.check_mode:
-            task = cluster.Destroy_Task()
-            changed, result = wait_for_task(task)
-        module.exit_json(changed=changed, result=result)
-    except vim.fault.VimFault as vim_fault:
-        module.fail_json(msg=vim_fault.msg)
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        module.fail_json(msg=method_fault.msg)
+    def check_cluster_configuration(self):
+        try:
+            self.datacenter = find_datacenter_by_name(self.content, self.datacenter_name)
+            if self.datacenter is None:
+                self.module.fail_json(msg="Datacenter %s does not exist, "
+                                     "please create first with Ansible Module vmware_datacenter or manually."
+                                     % self.datacenter_name)
+            self.cluster = find_cluster_by_name_datacenter(self.datacenter, self.cluster_name)
 
-
-def state_exit_unchanged(module):
-    module.exit_json(changed=False)
-
-
-def state_update_cluster(module):
-
-    cluster_config_spec = vim.cluster.ConfigSpecEx()
-    cluster = module.params['cluster']
-    enable_ha = module.params['enable_ha']
-    enable_drs = module.params['enable_drs']
-    enable_vsan = module.params['enable_vsan']
-    changed = True
-    result = None
-
-    if cluster.configurationEx.dasConfig.enabled != enable_ha:
-        cluster_config_spec.dasConfig = configure_ha(enable_ha)
-    if cluster.configurationEx.drsConfig.enabled != enable_drs:
-        cluster_config_spec.drsConfig = configure_drs(enable_drs)
-    if cluster.configurationEx.vsanConfigInfo.enabled != enable_vsan:
-        cluster_config_spec.vsanConfig = configure_vsan(enable_vsan)
-
-    try:
-        if not module.check_mode:
-            task = cluster.ReconfigureComputeResource_Task(cluster_config_spec, True)
-            changed, result = wait_for_task(task)
-        module.exit_json(changed=changed, result=result)
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        module.fail_json(msg=method_fault.msg)
-    except TaskError as task_e:
-        module.fail_json(msg=str(task_e))
-
-
-def check_cluster_configuration(module):
-    datacenter_name = module.params['datacenter_name']
-    cluster_name = module.params['cluster_name']
-
-    try:
-        content = connect_to_api(module)
-        datacenter = find_datacenter_by_name(content, datacenter_name)
-        if datacenter is None:
-            module.fail_json(msg="Datacenter %s does not exist, "
-                                 "please create first with Ansible Module vmware_datacenter or manually."
-                                 % datacenter_name)
-        cluster = find_cluster_by_name_datacenter(datacenter, cluster_name)
-
-        module.params['content'] = content
-        module.params['datacenter'] = datacenter
-
-        if cluster is None:
-            return 'absent'
-        else:
-            module.params['cluster'] = cluster
-
-            desired_state = (module.params['enable_ha'],
-                             module.params['enable_drs'],
-                             module.params['enable_vsan'])
-
-            current_state = (cluster.configurationEx.dasConfig.enabled,
-                             cluster.configurationEx.drsConfig.enabled,
-                             cluster.configurationEx.vsanConfigInfo.enabled)
-
-            if cmp(desired_state, current_state) != 0:
-                return 'update'
+            if self.cluster is None:
+                return 'absent'
             else:
-                return 'present'
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        module.fail_json(msg=method_fault.msg)
+                desired_state = (self.enable_ha,
+                                 self.enable_drs,
+                                 self.enable_vsan)
+
+                current_state = (self.cluster.configurationEx.dasConfig.enabled,
+                                 self.cluster.configurationEx.drsConfig.enabled,
+                                 self.cluster.configurationEx.vsanConfigInfo.enabled)
+
+                if cmp(desired_state, current_state) != 0:
+                    return 'update'
+                else:
+                    return 'present'
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            self.module.fail_json(msg=method_fault.msg)
 
 
 def main():
@@ -240,23 +241,8 @@ def main():
     if not HAS_PYVMOMI:
         module.fail_json(msg='pyvmomi is required for this module')
 
-    cluster_states = {
-        'absent': {
-            'present': state_destroy_cluster,
-            'absent': state_exit_unchanged,
-        },
-        'present': {
-            'update': state_update_cluster,
-            'present': state_exit_unchanged,
-            'absent': state_create_cluster,
-        }
-    }
-    desired_state = module.params['state']
-    current_state = check_cluster_configuration(module)
-
-    # Based on the desired_state and the current_state call
-    # the appropriate method from the dictionary
-    cluster_states[desired_state][current_state](module)
+    vmware_cluster = VMwareCluster(module)
+    vmware_cluster.process_state()
 
 from ansible.module_utils.vmware import *
 from ansible.module_utils.basic import *


### PR DESCRIPTION
When this module was written back in May 2015 we were using 1.9.x. Being lazy I added to param the objects that the other functions would need. What I have noticed is in 2.0 exit_json is trying to jsonify those complex objects and failing. This PR resolves that issue with the `vmware_cluster` module.

@kamsz reported this issue in https://github.com/ansible/ansible-modules-extras/pull/1568

Playbook

```
    - name: Create Cluster
      local_action:
        module: vmware_cluster
        hostname: "{{ mgmt_ip_address }}"
        username: "{{ vcsa_user }}"
        password: "{{ vcsa_pass }}"
        datacenter_name: "{{ mgmt_vdc }}"
        cluster_name: "{{ mgmt_cluster }}"
        enable_ha: True
        enable_drs: True
        enable_vsan: True
```

Module testing

```
TASK [Create Cluster] **********************************************************
task path: /opt/autodeploy/projects/emmet/site_deploy.yml:188
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC ( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1454693788.92-14097560271233 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1454693788.92-14097560271233 )" )
localhost PUT /tmp/tmpAJfdPb TO /root/.ansible/tmp/ansible-tmp-1454693788.92-14097560271233/vmware_cluster
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1454693788.92-14097560271233/vmware_cluster; rm -rf "/root/.ansible/tmp/ansible-tmp-1454693788.92-14097560271233/" > /dev/null 2>&1
changed: [foundation-vcsa -> localhost] => {"changed": true, "invocation": {"module_args": {"cluster_name": "Foundation", "datacenter_name": "Test-Lab", "enable_drs": true, "enable_ha": true, "enable_vsan": true, "hostname": "172.27.0.100", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "state": "present", "username": "root"}, "module_name": "vmware_cluster"}}
```
