### PR TITLE
Resolves issue with vmware_vm_vss_dvs_migrate module for v2.0

### DIFF
--- a/cloud/vmware/vmware_vm_vss_dvs_migrate.py
+++ b/cloud/vmware/vmware_vm_vss_dvs_migrate.py
@@ -40,7 +40,6 @@ options:
         description:
             - Name of the portgroup to migrate to the virtual machine to
         required: True
-extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''
@@ -61,82 +60,81 @@ except ImportError:
     HAS_PYVMOMI = False
 
 
-def _find_dvspg_by_name(content, pg_name):
+class VMwareVmVssDvsMigrate(object):
+    def __init__(self, module):
+        self.module = module
+        self.content = connect_to_api(module)
+        self.vm = None
+        self.vm_name = module.params['vm_name']
+        self.dvportgroup_name = module.params['dvportgroup_name']
 
-    vmware_distributed_port_group = get_all_objs(content, [vim.dvs.DistributedVirtualPortgroup])
-    for dvspg in vmware_distributed_port_group:
-        if dvspg.name == pg_name:
-            return dvspg
-    return None
+    def process_state(self):
+        vm_nic_states = {
+            'absent': self.migrate_network_adapter_vds,
+            'present': self.state_exit_unchanged,
+        }
 
+        vm_nic_states[self.check_vm_network_state()]()
 
-def find_vm_by_name(content, vm_name):
+    def find_dvspg_by_name(self):
+        vmware_distributed_port_group = get_all_objs(self.content, [vim.dvs.DistributedVirtualPortgroup])
+        for dvspg in vmware_distributed_port_group:
+            if dvspg.name == self.dvportgroup_name:
+                return dvspg
+        return None
 
-    virtual_machines = get_all_objs(content, [vim.VirtualMachine])
-    for vm in virtual_machines:
-        if vm.name == vm_name:
-            return vm
-    return None
+    def find_vm_by_name(self):
+        virtual_machines = get_all_objs(self.content, [vim.VirtualMachine])
+        for vm in virtual_machines:
+            if vm.name == self.vm_name:
+                return vm
+        return None
 
+    def migrate_network_adapter_vds(self):
+        vm_configspec = vim.vm.ConfigSpec()
+        nic = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+        port = vim.dvs.PortConnection()
+        devicespec = vim.vm.device.VirtualDeviceSpec()
 
-def migrate_network_adapter_vds(module):
-    vm_name = module.params['vm_name']
-    dvportgroup_name = module.params['dvportgroup_name']
-    content = module.params['content']
+        pg = self.find_dvspg_by_name()
 
-    vm_configspec = vim.vm.ConfigSpec()
-    nic = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
-    port = vim.dvs.PortConnection()
-    devicespec = vim.vm.device.VirtualDeviceSpec()
+        if pg is None:
+            self.module.fail_json(msg="The standard portgroup was not found")
 
-    pg = _find_dvspg_by_name(content, dvportgroup_name)
+        dvswitch = pg.config.distributedVirtualSwitch
+        port.switchUuid = dvswitch.uuid
+        port.portgroupKey = pg.key
+        nic.port = port
 
-    if pg is None:
-        module.fail_json(msg="The standard portgroup was not found")
-
-    vm = find_vm_by_name(content, vm_name)
-    if vm is None:
-        module.fail_json(msg="The virtual machine was not found")
-
-    dvswitch = pg.config.distributedVirtualSwitch
-    port.switchUuid = dvswitch.uuid
-    port.portgroupKey = pg.key
-    nic.port = port
-
-    for device in vm.config.hardware.device:
-        if isinstance(device, vim.vm.device.VirtualEthernetCard):
-            devicespec.device = device
-            devicespec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
-            devicespec.device.backing = nic
-            vm_configspec.deviceChange.append(devicespec)
-
-    task = vm.ReconfigVM_Task(vm_configspec)
-    changed, result = wait_for_task(task)
-    module.exit_json(changed=changed, result=result)
-
-
-def state_exit_unchanged(module):
-    module.exit_json(changed=False)
-
-
-def check_vm_network_state(module):
-    vm_name = module.params['vm_name']
-    try:
-        content = connect_to_api(module)
-        module.params['content'] = content
-        vm = find_vm_by_name(content, vm_name)
-        module.params['vm'] = vm
-        if vm is None:
-            module.fail_json(msg="A virtual machine with name %s does not exist" % vm_name)
-        for device in vm.config.hardware.device:
+        for device in self.vm.config.hardware.device:
             if isinstance(device, vim.vm.device.VirtualEthernetCard):
-                if isinstance(device.backing, vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo):
-                    return 'present'
-        return 'absent'
-    except vmodl.RuntimeFault as runtime_fault:
-        module.fail_json(msg=runtime_fault.msg)
-    except vmodl.MethodFault as method_fault:
-        module.fail_json(msg=method_fault.msg)
+                devicespec.device = device
+                devicespec.operation = vim.vm.device.VirtualDeviceSpec.Operation.edit
+                devicespec.device.backing = nic
+                vm_configspec.deviceChange.append(devicespec)
+
+        task = self.vm.ReconfigVM_Task(vm_configspec)
+        changed, result = wait_for_task(task)
+        self.module.exit_json(changed=changed, result=result)
+
+    def state_exit_unchanged(self):
+        self.module.exit_json(changed=False)
+
+    def check_vm_network_state(self):
+        try:
+            self.vm = self.find_vm_by_name()
+
+            if self.vm is None:
+                self.module.fail_json(msg="A virtual machine with name %s does not exist" % self.vm_name)
+            for device in self.vm.config.hardware.device:
+                if isinstance(device, vim.vm.device.VirtualEthernetCard):
+                    if isinstance(device.backing, vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo):
+                        return 'present'
+            return 'absent'
+        except vmodl.RuntimeFault as runtime_fault:
+            self.module.fail_json(msg=runtime_fault.msg)
+        except vmodl.MethodFault as method_fault:
+            self.module.fail_json(msg=method_fault.msg)
 
 
 def main():
@@ -149,12 +147,8 @@ def main():
     if not HAS_PYVMOMI:
         module.fail_json(msg='pyvmomi is required for this module')
 
-    vm_nic_states = {
-        'absent': migrate_network_adapter_vds,
-        'present': state_exit_unchanged,
-    }
-
-    vm_nic_states[check_vm_network_state(module)](module)
+    vmware_vmnic_migrate = VMwareVmVssDvsMigrate(module)
+    vmware_vmnic_migrate.process_state()
 
 from ansible.module_utils.vmware import *
 from ansible.module_utils.basic import *

--- a/cloud/vmware/vmware_vm_vss_dvs_migrate.py
+++ b/cloud/vmware/vmware_vm_vss_dvs_migrate.py
@@ -40,6 +40,7 @@ options:
         description:
             - Name of the portgroup to migrate to the virtual machine to
         required: True
+extends_documentation_fragment: vmware.documentation
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
When this module was written back in May 2015 we were using 1.9.x. Being lazy I added to param the objects that the other functions would need. What I have noticed is in 2.0 exit_json is trying to jsonify those complex objects and failing. This PR resolves that issue with the vmware_vm_vss_dvs_migrate module.

@kamsz reported this issue in https://github.com/ansible/ansible-modules-extras/pull/1568

Playbook

```
- name: Migrate VCSA to vDS
      local_action:
        module: vmware_vm_vss_dvs_migrate
        hostname: "{{ mgmt_ip_address }}"
        username: "{{ vcsa_user }}"
        password: "{{ vcsa_pass }}"
        vm_name: "{{ hostname }}"
        dvportgroup_name: Management
```

Module Testing

```
ASK [Migrate VCSA to vDS] *****************************************************
task path: /opt/autodeploy/projects/emmet/site_deploy.yml:260
ESTABLISH LOCAL CONNECTION FOR USER: root
localhost EXEC ( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1454695546.3-207189190861859 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp-1454695546.3-207189190861859 )" )
localhost PUT /tmp/tmpkzD4pF TO /root/.ansible/tmp/ansible-tmp-1454695546.3-207189190861859/vmware_vm_vss_dvs_migrate
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1454695546.3-207189190861859/vmware_vm_vss_dvs_migrate; rm -rf "/root/.ansible/tmp/ansible-tmp-1454695546.3-207189190861859/" > /dev/null 2>&1
changed: [foundation-vcsa -> localhost] => {"changed": true, "invocation": {"module_args": {"dvportgroup_name": "Management", "hostname": "172.27.0.100", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "username": "root", "vm_name": "cscvcatmp001"}, "module_name": "vmware_vm_vss_dvs_migrate"}, "result": null}

```
