### PR TITLE
ec2_vpc_subnet: fix edge case where boto returns empty list after subnet creation

### DIFF
--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -122,7 +122,7 @@ def get_subnet_info(subnet):
 def subnet_exists(vpc_conn, subnet_id):
     filters = {'subnet-id': subnet_id}
     subnet = vpc_conn.get_all_subnets(filters=filters)
-    if subnet[0].state == "available":
+    if subnet and subnet[0].state == "available":
         return subnet[0]
     else:
         return False


### PR DESCRIPTION
As mentioned in the calling function `create_subnet`, aws sometimes takes a moment to create subnets.  I assume that it can sometimes take a moment for the subnets to propagate because in rare cases the list that boto returns is empty.  This PR adds a simple check to treat an empty list as if the subnet is not yet available.
