### PR TITLE
Windows: win_regedit; Add extra Powershell Drives so you can access other parts of the registry

### DIFF
--- a/windows/win_regedit.ps1
+++ b/windows/win_regedit.ps1
@@ -21,6 +21,10 @@ $ErrorActionPreference = "Stop"
 # WANT_JSON
 # POWERSHELL_COMMON
 
+New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR -ErrorAction SilentlyContinue
+New-PSDrive -PSProvider registry -Root HKEY_USERS -Name HKU -ErrorAction SilentlyContinue
+New-PSDrive -PSProvider registry -Root HKEY_CURRENT_CONFIG -Name HCCC -ErrorAction SilentlyContinue
+
 $params = Parse-Args $args;
 $result = New-Object PSObject;
 Set-Attr $result "changed" $false;


### PR DESCRIPTION
Hi,
I realized that you can't access HKEY_CLASSES_ROOT part of the registry as, for some reason, powershell only creates HKLM and HKCU 'drives' by default.

This PR adds drives for the other parts of the registry

New-PSDrive -PSProvider registry -Root HKEY_CLASSES_ROOT -Name HKCR
New-PSDrive -PSProvider registry -Root HKEY_USERS -Name HKU
New-PSDrive -PSProvider registry -Root HKEY_CURRENT_CONFIG - Name HCCC

I added -ErrorAction SilentlyContinue in case the drives already exist

Info from here: https://blogs.technet.microsoft.com/heyscriptingguy/2012/05/07/use-the-powershell-registry-provider-to-simplify-registry-access/
