### PR TITLE
amazon/ec2_vpc_route_table: Fix bug in counting subnets by 'Name' tag

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -183,11 +183,11 @@ def find_subnets(vpc_conn, vpc_id, identified_subnets):
             filters={'vpc_id': vpc_id, 'tag:Name': subnet_names})
 
         for name in subnet_names:
-            matching = [s.tags.get('Name') == name for s in subnets_by_name]
-            if len(matching) == 0:
+            matching_count = len([1 for s in subnets_by_name if s.tags.get('Name') == name])
+            if matching_count == 0:
                 raise AnsibleSubnetSearchException(
                     'Subnet named "{0}" does not exist'.format(name))
-            elif len(matching) > 1:
+            elif matching_count > 1:
                 raise AnsibleSubnetSearchException(
                     'Multiple subnets named "{0}"'.format(name))
 


### PR DESCRIPTION
Fixes #1551 

---

Current logic:

``` python
len([True, True, False, False, False])  # 5
```

New logic:

``` python
len([1, 1])  # 2
```
