### PR TITLE
Add option to send puppet apply logs to syslog

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -67,6 +67,12 @@ options:
       - Puppet environment to be used.
     required: false
     default: None
+  logdest:
+    description:
+      - Where the puppet logs should go, if puppet apply is being used
+    required: false
+    default: stdout
+    choices: [ 'stdout', 'syslog' ]
 requirements: [ puppet ]
 author: "Monty Taylor (@emonty)"
 '''
@@ -111,8 +117,12 @@ def main():
             timeout=dict(default="30m"),
             puppetmaster=dict(required=False, default=None),
             manifest=dict(required=False, default=None),
+            logdest=dict(
+                required=False, default=['stdout'],
+                choices=['stdout', 'syslog']),
             show_diff=dict(
-                default=False, aliases=['show-diff'], type='bool'), # internal code to work with --diff, do not use
+                # internal code to work with --diff, do not use
+                default=False, aliases=['show-diff'], type='bool'),
             facts=dict(default=None),
             facter_basename=dict(default='ansible'),
             environment=dict(required=False, default=None),
@@ -184,6 +194,8 @@ def main():
             cmd += " --no-noop"
     else:
         cmd = "%s apply --detailed-exitcodes " % base_cmd
+        if p['logdest'] == 'syslog':
+            cmd += "--logdest syslog "
         if p['environment']:
             cmd += "--environment '%s' " % p['environment']
         if module.check_mode:


### PR DESCRIPTION
While returning puppet logs as ansible stdout is useful in some cases,
there are also cases where it's more destructive than helpful. For
those, local logging to syslog so that the ansible logging makes sense
is very useful.

This defaults to stdout so that behavior does not change for people.
