### PR TITLE
win_unzip: Use absolute path for src and dest

### DIFF
--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -59,8 +59,8 @@ $rm = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "rm" -default "false")
 If ($ext -eq ".zip" -And $recurse -eq $false) {
     Try {
         $shell = New-Object -ComObject Shell.Application
-        $zipPkg = $shell.NameSpace($src)
-        $destPath = $shell.NameSpace($dest)
+        $zipPkg = $shell.NameSpace([IO.Path]::GetFullPath($src))
+        $destPath = $shell.NameSpace([IO.Path]::GetFullPath($dest))
         # 20 means do not display any dialog (4) and overwrite any file (16)
         $destPath.CopyHere($zipPkg.Items(), 20)
         $result.changed = $true


### PR DESCRIPTION
win_unzip fails to extract files when either src or dest contains complex paths such as "..\..\" or "C:\\Program Files" (double slashes).
Fix this by fetching absolute path of both before invoking CopyHere method.
