### PR TITLE
win_unzip: overwrite any existing file

### DIFF
--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -61,7 +61,8 @@ If ($ext -eq ".zip" -And $recurse -eq $false) {
         $shell = New-Object -ComObject Shell.Application
         $zipPkg = $shell.NameSpace($src)
         $destPath = $shell.NameSpace($dest)
-        $destPath.CopyHere($zipPkg.Items())
+        # 20 means do not display any dialog (4) and overwrite any file (16)
+        $destPath.CopyHere($zipPkg.Items(), 20)
         $result.changed = $true
     }
     Catch {


### PR DESCRIPTION
If the destination files exist, the win_unzip module hangs forever because the server asked what to do with the existing files (overwrite or not).

It seems to me that the unarchive module overwrite any existing file so I'm applying the same logic here. 

See https://msdn.microsoft.com/en-us/library/ms723207%28v=vs.85%29.aspx for any documentation about `CopyHere` flags.
