### PR TITLE
Fix opening libvirt esx connection

### DIFF
--- a/cloud/misc/virt.py
+++ b/cloud/misc/virt.py
@@ -128,6 +128,9 @@ class LibvirtConnection(object):
 
         if "xen" in stdout:
             conn = libvirt.open(None)
+        elif "esx" in uri:
+            auth = [[libvirt.VIR_CRED_AUTHNAME, libvirt.VIR_CRED_NOECHOPROMPT], [], None]
+            conn = libvirt.openAuth(uri, auth)
         else:
             conn = libvirt.open(uri)
 


### PR DESCRIPTION
Currently, there is an error when trying to use libvirt module with VMWare.

> invalid argument: Missing or invalid auth pointer

We must use openAuth instead of open for opening connection with VMWare ESX in libvirt (as per [documentation](https://libvirt.org/drvesx.html))
