### PR TITLE
fix trying to iterate None when creating a user

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -139,7 +139,7 @@ class RabbitMqUser(object):
         self.bulk_permissions = bulk_permissions
 
         self._tags = None
-        self._permissions = None
+        self._permissions = []
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
     def _exec(self, args, run_in_check_mode=False):


### PR DESCRIPTION
##### Issue Type:

 Bugfix Pull Request
##### Ansible Version:

ansible 2.1.0 (devel cf251258a8) last updated 2016/02/11 14:40:12 (GMT +200)
##### Ansible Configuration:

Default configuration
##### Environment:

Fedora 23
##### Summary:

Exception creating a rabbitmq user by using the rabbitmq_user module. After this fix, another exception will be raised, addressed in #1657
##### Steps To Reproduce:

Using the following playbook

```
- hosts: test
  tasks:
    - name: remove user
      rabbitmq_user: user=aaa password=9TWB18eJqmuRRbszSqHh node=rabbit@orchestra6 vhost=/ydin configure_priv=.* read_priv=.* write_priv=.* state=absent

    - name: add user
      rabbitmq_user: user=aaa password=9TWB18eJqmuRRbszSqHh node=rabbit@orchestra6 vhost=/ydin configure_priv=.* read_priv=.* write_priv=.* state=present
```
##### Expected Results:

No exceptions
##### Actual Results:

the following exception is raised:

```
     for permission in self._permissions:
TypeError: 'NoneType' object is not iterable
```
