### PR TITLE
fix arg_spec type for rabbitmq_user module

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -228,7 +228,7 @@ def main():
         user=dict(required=True, aliases=['username', 'name']),
         password=dict(default=None),
         tags=dict(default=None),
-        permissions=dict(default=list()),
+        permissions=dict(default=list(), type='list'),
         vhost=dict(default='/'),
         configure_priv=dict(default='^$'),
         write_priv=dict(default='^$'),


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Ansible Version:

ansible 2.1.0 (devel cf251258a8) last updated 2016/02/11 14:40:12 (GMT +200)
##### Ansible Configuration:

Default configuration
##### Environment:

Fedora 23
##### Summary:

Exception creating a rabbitmq user by using the rabbitmq_user module. This needs pull req #1656, or it will fail before exposing this problem.
##### Steps To Reproduce:

Using the following playbook

```
- hosts: test
  tasks:
    - name: remove user
      rabbitmq_user: user=aaa password=9TWB18eJqmuRRbszSqHh node=rabbit@orchestra6 vhost=/ydin configure_priv=.* read_priv=.* write_priv=.* state=absent

    - name: add user
      rabbitmq_user: user=aaa password=9TWB18eJqmuRRbszSqHh node=rabbit@orchestra6 vhost=/ydin configure_priv=.* read_priv=.* write_priv=.* state=present
```
##### Expected Results:

No Exceptions
##### Actual Results:

The following  exception

```
cmd.append(permission['vhost'])
TypeError: string indices must be integers, not str
```
