### PR TITLE
dnf module: package not installed with state=latest

### DIFF
--- a/packaging/os/dnf.py
+++ b/packaging/os/dnf.py
@@ -274,11 +274,10 @@ def ensure(module, base, state, names):
                     # If not already installed, try to install.
                     base.group_install(group, const.GROUP_PACKAGE_TYPES)
             for pkg_spec in pkg_specs:
-                try:
-                    base.upgrade(pkg_spec)
-                except dnf.exceptions.MarkingError:
-                    # If not already installed, try to install.
-                    _mark_package_install(module, base, pkg_spec)
+                # best effort causes to install the latest package
+                # even if not previously installed
+                base.conf.best = True
+                base.install(pkg_spec)
 
         else:
             # state == absent


### PR DESCRIPTION
dnf: name=PACKAGE state=latest is reponsible for two use cases:
- to install a package if not already installed.
- to update the package to the latest if already installed.

The latter use cases is not handled properly as base.upgrade does not
throw dnf.exceptions.MarkingError if a package is not installed.

Setting base.conf.best = True ensures a package is installed or
updated to the latest when calling base.install.

Sign-off: jsilhan@redhat.com (dnf guy)
Sign-off: jchaloup@redhat.com

Thanks Jan Silhan for the 1 minute fix.
