### PR TITLE
Prevent reinstallation in case of group package

### DIFF
--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -234,7 +234,7 @@ def install_packages(module, pacman_path, state, packages, package_files):
         else:
             params = '-S %s' % package
 
-        cmd = "%s %s --noconfirm" % (pacman_path, params)
+        cmd = "%s %s --noconfirm --needed" % (pacman_path, params)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
         if rc != 0:


### PR DESCRIPTION
In case of group package, a change is required, but il reinstalls all the packages of the group instead of installing only those needed.
