### PR TITLE
amazon/ec2_vpc_subnet.py: Add `auto_assign_public_ip` support

### DIFF
--- a/cloud/amazon/ec2_vpc_subnet.py
+++ b/cloud/amazon/ec2_vpc_subnet.py
@@ -37,6 +37,7 @@ options:
       - "Assign a public IP address to instances launched into the specified subnet."
     required: false
     default: no
+    version_added: "2.1"
   tags:
     description:
       - "A dict of tags to apply to the subnet. Any tags currently applied to the subnet and not present here will be removed."


### PR DESCRIPTION
Adds support for assigning public IPs to instances launched within a given subnet. Implementation is largely based on the solution suggested @ https://github.com/boto/boto/issues/2646

I've named the key itself `auto_assign_public_ip` (rather than `map_public_ip_on_launch`) for consistency with how it's displayed in the AWS Console ([link](https://i.imgur.com/lStbDJA.png)), but happy to rename it as you wish.

It should be noted that Boto3 has [first-class support for (un)setting this attribute](https://boto3.readthedocs.org/en/latest/reference/services/ec2.html#EC2.Subnet.map_public_ip_on_launch), but, in order to maintain backwards compatibility with Boto2, I've avoided using it.
