### PR TITLE
Indicate proxy_host and proxy_port were added in 2.1

### DIFF
--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -66,11 +66,13 @@ options:
             - Proxy host to use during plugin installation
         required: False
         default: None
+        version_added: "2.1"
     proxy_port:
         description:
             - Proxy port to use during plugin installation
         required: False
-        default: None        
+        default: None
+        version_added: "2.1"
     version:
         description:
             - Version of the plugin to be installed.


### PR DESCRIPTION
`proxy_host` and `proxy_port` were recently added, but documentation did not indicate `2.1` for `version_added` on those new arguments.
