### PR TITLE
Fix facter path

### DIFF
--- a/system/facter.py
+++ b/system/facter.py
@@ -47,7 +47,10 @@ def main():
         argument_spec = dict()
     )
 
-    cmd = ["/usr/bin/env", "facter", "--puppet", "--json"]
+    facter_path = module.get_bin_path('facter', opt_dirs=['/opt/puppetlabs/bin'])
+
+    cmd = [facter_path, "--puppet", "--json"]
+
     rc, out, err = module.run_command(cmd, check_rc=True)
     module.exit_json(**json.loads(out))
 


### PR DESCRIPTION
- Bugfix Pull Request
##### Plugin Name:

```
facter.py
```
##### Ansible Version:

```
ansible 1.9.4
```
##### Summary:

In Puppet version 4 and in Puppet PE the Puppet tree is installed in `/opt/puppetlabs` and the
commands are installed in `/opt/puppetlabs/bin`. This directory is out of scope for the `setup` or `facter` module. This fix makes sure this/these module(s) can find the facter program.
