### PR TITLE
Replace deprecated zabbix api method 'exists' to support zabbix 3.0

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -162,13 +162,13 @@ class Host(object):
 
     # exist host
     def is_host_exist(self, host_name):
-        result = self._zapi.host.exists({'host': host_name})
+        result = self._zapi.host.get({'filter': {'host': host_name}})
         return result
 
     # check if host group exists
     def check_host_group_exist(self, group_names):
         for group_name in group_names:
-            result = self._zapi.hostgroup.exists({'name': group_name})
+            result = self._zapi.hostgroup.get({'filter': {'name': group_name}})
             if not result:
                 self._module.fail_json(msg="Hostgroup not found: %s" % group_name)
         return True


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

zabbix_host
##### Ansible Version:

```
ansible 2.0.0.2
```
##### Summary:

zabbix_host module uses deprecated api method 'exists' removed in zabbix 3.0
##### Example output:

```
FAILED! => {"changed": false, "failed": true, "parsed": false}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: zabbix_api.ZabbixAPIException: (u'Error -32602: Invalid params., Incorrect method "hostgroup.exists". while sending {"params": {"name": "Linux servers"}, "jsonrpc": "2.0", "method": "hostgroup.exists", "auth": "aeb03b177fd358ffeae09a5ee1087125", "id": 2}', -32602)
```
