### PR TITLE
Download non-snapshots also when md5 has changed

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -332,9 +332,7 @@ def main():
     if os.path.isdir(dest):
         dest = dest + "/" + artifact_id + "-" + version + "." + extension
     if os.path.lexists(dest):
-        if not artifact.is_snapshot():
-            prev_state = "present"
-        elif downloader.verify_md5(dest, downloader.find_uri_for_artifact(artifact) + '.md5'):
+        if downloader.verify_md5(dest, downloader.find_uri_for_artifact(artifact) + '.md5'):
             prev_state = "present"
     else:
         path = os.path.dirname(dest)


### PR DESCRIPTION
##### Issue Type:

Bugfix Pull Request
##### Plugin Name:

maven_artifact
##### Ansible Version:

ansible 2.0.0.2
##### Summary:

I use the maven_artifact plugin to download the specific versions of my application to the production servers. If I want to upgrade the version of the application, the maven_artifact plugin doesn't check if the md5 has changed if I'm not deploying a snapshot, so it does not update the application.
