### PR TITLE
Add actual version to version_added for svc module

### DIFF
--- a/system/svc.py
+++ b/system/svc.py
@@ -22,7 +22,7 @@ DOCUMENTATION = '''
 ---
 module: svc
 author: "Brian Coca (@bcoca)"
-version_added:
+version_added: "1.9"
 short_description:  Manage daemontools services.
 description:
     - Controls daemontools services on remote hosts using the svc utility.


### PR DESCRIPTION
`version_added` was specified, but with no value, making it `None` instead of the actual version it was added.  Correct `version_added` to be `1.9`.
