### PR TITLE
Allow CPU and Memory to be templatable

### DIFF
--- a/cloud/amazon/ecs_taskdefinition.py
+++ b/cloud/amazon/ecs_taskdefinition.py
@@ -187,6 +187,9 @@ def main():
         else:
             if not module.check_mode:
                 # doesn't exist. create it.
+                for container in module.params['containers']:
+                    container['cpu'] = int(container['cpu'])
+                    container['memory'] = int(container['memory'])
                 volumes = []
                 if 'volumes' in module.params:
                     volumes = module.params['volumes']


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ecs_taskdefinition
##### Ansible Version:

```
ansible 2.0.0.2
```
##### Summary:

Currently, the module does not allow the CPU and Memory parameters to be templatable. They must be integer/long. This makes the module unusable with variables. In other words, we would need to call the module for every task definition.
This change will allow the CPU and Memory to be templatable like so,

```
    containers:
      - name: "nikhil-test"
        image: "nikhil-test-nginx:{{deploy_tag}}"
        memory: "{{mycontainers.nginx.memory}}"
        cpu: "{{mycontainers.nginx.cpu}}"
```
##### Example output:

Error before change: 

```
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter containerDefinitions[0].memory, value: 1920, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
Invalid type for parameter containerDefinitions[0].cpu, value: 2560, type: <type 'str'>, valid types: <type 'int'>, <type 'long'>
```

This error is not seen with suggested change
