### PR TITLE
Add SQS queue policy attachment functionality

### DIFF
--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -174,12 +174,15 @@ def set_queue_attribute(queue, attribute, value, check_mode=False):
     except:
         existing_value = ''
 
+    # convert dict attributes to JSON strings (sort keys for comparing)
+    if attribute is 'Policy':
+        value = json.dumps(value, sort_keys=True)
+        if existing_value:
+            existing_value = json.dumps(json.loads(existing_value), sort_keys=True)
+
     if str(value) != existing_value:
         if not check_mode:
-            if attribute is 'Policy':
-                queue.set_attribute(attribute, json.dumps(value))
-            else:
-                queue.set_attribute(attribute, value)
+            queue.set_attribute(attribute, value)
         return True
 
     return False

--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -22,7 +22,9 @@ description:
   - Create or delete AWS SQS queues.
   - Update attributes on existing queues.
 version_added: "2.0"
-author: Alan Loi (@loia)
+author:
+  - Alan Loi (@loia)
+  - Fernando Jose Pando (@nand0p)
 requirements:
   - "boto >= 2.33.0"
 options:

--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -66,6 +66,7 @@ options:
       - The policy document to attach to queue
     required: false
     default: null
+    version_added: "2.1"
 extends_documentation_fragment:
     - aws
     - ec2

--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -167,16 +167,18 @@ def set_queue_attribute(queue, attribute, value, check_mode=False):
     if not value:
         return False
 
-    # SQS queue has no attribute 'Policy' until one is attached, so this special
-    # case must be handled uniquely
-    if attribute is not 'Policy':
+    try:
         existing_value = queue.get_attributes(attributes=attribute)[attribute]
-        if str(value) != existing_value:
-            if not check_mode:
+    except:
+        existing_value = ''
+
+    if str(value) != existing_value:
+        if not check_mode:
+            if attribute is 'Policy':
+                queue.set_attribute(attribute, json.dumps(value))
+            else:
                 queue.set_attribute(attribute, value)
-            return True
-    else:
-        queue.set_attribute('Policy',json.dumps(value))
+        return True
 
     return False
 

--- a/cloud/amazon/sqs_queue.py
+++ b/cloud/amazon/sqs_queue.py
@@ -63,7 +63,7 @@ options:
     default: null
   policy:
     description:
-      - The policy document to attach to queue
+      - The json dict policy to attach to queue
     required: false
     default: null
     version_added: "2.1"
@@ -82,7 +82,7 @@ EXAMPLES = '''
     maximum_message_size: 1024
     delivery_delay: 30
     receive_message_wait_time: 20
-    policy: policy_document.json
+    policy: "{{ json_dict }}"
 
 # Delete SQS queue
 - sqs_queue:


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

cloud/amazon/sqs_queue
##### Ansible Version:

```
ansible 1.9.4
```
##### Summary:

Allows for attaching policy to sqs queue upon create / update

SQS queue has no attribute 'Policy' until one is attached, so this special
case must be handled uniquely

SQS queue Policy can now be passed in as json
