### PR TITLE
The size option is required for lvol module

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -48,7 +48,8 @@ options:
     choices: [ "present", "absent" ]
     default: present
     description:
-    - Control if the logical volume exists.
+    - Control if the logical volume exists. If C(present) the C(size) option 
+      is required.
     required: false
   force:
     version_added: "1.5"


### PR DESCRIPTION
##### Issue Type: Docs Pull Request
##### Plugin Name: lvol
##### Ansible Version: 2.0.0.2

```
ansible 2.0.0.2
  config file = /etc/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

The size option is required for lvol module actually.
