### PR TITLE
Elb tags

### DIFF
--- a/cloud/amazon/elb_tags.py
+++ b/cloud/amazon/elb_tags.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+
+DOCUMENTATION = '''
+---
+module: elb_tags
+short_description: allows manipulation of elb tags
+options:
+
+  elb_name:
+    description:
+      - Name of the elb of which to modify tags
+    required: true
+    default: null
+    aliases: []
+
+  tags:
+    description:
+      - list of dictionaries of tags
+    required: true
+
+  state:
+    description:
+      - add or remove tags
+    required: true
+
+
+extends_documentation_fragment: aws
+'''
+
+EXAMPLES = '''
+    # Adds elb tag
+    elb_tag:
+        elb_name: foo
+        tags: "{{ tags_dict }}"
+        state: present
+'''
+
+try:
+    import boto3
+    import botocore
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+def check_if_tags_exist(result):
+    tags_new = [ values for tags in result['tags']
+                        for values in tags.values() ]
+    tags_existing = [ values for tags in result['existing']
+                             for values in tags.values() ]
+    return set(tags_new).issubset(set(tags_existing))
+
+def create_or_update_elb_tags(client, module, result):
+    if check_if_tags_exist(result):
+        module.exit_json(**result)
+    try:
+        result['msg'] = client.add_tags(
+            LoadBalancerNames = [ result['elb_name'] ],
+            Tags = result['tags']
+        )
+        result['changed'] = True
+    except botocore.exceptions.ClientError:
+        result['msg'] = 'Failed to create/update elb tags due to error: ' + \
+                        traceback.format_exc()
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+
+def delete_elb_tags(client, module, result):
+    try:
+        result['msg'] = client.remove_tags(
+            LoadBalancerNames = [ result['elb_name'] ],
+            Tags = result['tags']
+        )
+        result['changed'] = True
+    except botocore.exceptions.ClientError:
+        result['msg'] = 'Failed to create/update elb tags due to error: ' + \
+                        traceback.format_exc()
+        module.fail_json(**result)
+    else:
+        module.exit_json(**result)
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        state = dict(default='present', choices=['present', 'absent']),
+        elb_name = dict(type="str", required = True),
+        tags = dict(type="list")
+    ))
+
+    module = AnsibleModule(
+        argument_spec = argument_spec,
+        supports_check_mode = True
+    )
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    client = boto3.client('elb')
+    state = module.params.get('state')
+    result = dict(
+        elb_name = module.params.get('elb_name'),
+        tags = sorted(module.params.get('tags')),
+        region = module.params.get('region'),
+        changed = False
+    )
+    result['existing'] = sorted(client.describe_tags(
+        LoadBalancerNames = [result['elb_name']])['TagDescriptions'][0]['Tags'])
+
+    if state == 'present':
+        create_or_update_elb_tags(client, module, result)
+    elif state == 'absent':
+        delete_elb_tags(client, module, result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+main()

--- a/cloud/amazon/elb_tags.py
+++ b/cloud/amazon/elb_tags.py
@@ -1,37 +1,51 @@
 #!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This is a free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Ansible library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
 
 DOCUMENTATION = '''
----
 module: elb_tags
-short_description: allows manipulation of elb tags
+short_description: allows manipulation of ELB tags
+description:
+    - Module allows for adding and removing tags from ELBs
+version_added: 2.1
+author: "Fernando Jose Pando (@oldmanlinux)"
 options:
-
   elb_name:
     description:
       - Name of the elb of which to modify tags
     required: true
     default: null
     aliases: []
-
   tags:
     description:
       - list of dictionaries of tags
     required: true
-
   state:
     description:
       - add or remove tags
     required: true
-
-
 extends_documentation_fragment: aws
+requirements: [ "boto3" ]
 '''
 
 EXAMPLES = '''
     # Adds elb tag
     elb_tag:
         elb_name: foo
-        tags: "{{ tags_dict }}"
+        tags: "{{ list_of_dicts }}"
         state: present
 '''
 

--- a/cloud/amazon/elb_tags.py
+++ b/cloud/amazon/elb_tags.py
@@ -20,25 +20,28 @@ module: elb_tags
 short_description: allows manipulation of ELB tags
 description:
     - Module allows for adding and removing tags from ELBs
+    - ELBs have no Resource-ID so ec2_tag will not work
 version_added: 2.1
 author: "Fernando Jose Pando (@oldmanlinux)"
+requirements: [ "boto3" ]
 options:
   elb_name:
     description:
       - Name of the elb of which to modify tags
     required: true
-    default: null
-    aliases: []
   tags:
     description:
-      - list of dictionaries of tags
+      - List of dictionaries of tags
     required: true
   state:
     description:
-      - add or remove tags
-    required: true
-extends_documentation_fragment: aws
-requirements: [ "boto3" ]
+      - Add or remove tags
+    required: false
+    choices: ['present', 'absent']
+    default: 'present'
+extends_documentation_fragment:
+  - aws
+  - ec2
 '''
 
 EXAMPLES = '''
@@ -97,18 +100,18 @@ def delete_elb_tags(client, module, result):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        state = dict(default='present', choices=['present', 'absent']),
-        elb_name = dict(type="str", required = True),
-        tags = dict(type="list")
+        state = dict(default = 'present', choices = ['present', 'absent']),
+        elb_name = dict(type = "str", required = True),
+        tags = dict(type = "list", required = True)
     ))
 
     module = AnsibleModule(
         argument_spec = argument_spec,
-        supports_check_mode = True
+        supports_check_mode = False
     )
 
     if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
+        module.fail_json(msg = 'boto3 required for this module')
 
     client = boto3.client('elb')
     state = module.params.get('state')

--- a/cloud/amazon/elb_tags.py
+++ b/cloud/amazon/elb_tags.py
@@ -52,6 +52,39 @@ EXAMPLES = '''
         state: present
 '''
 
+RETURN = '''
+changed:
+    description: Whether tags have been added or removed
+    type: bool
+    returned: changed
+    sample: True
+elb_name:
+    description: The name of elb that was changed
+    type: string
+    returned: state == "present" or state == "absent"
+    sample: "elb_name"
+existing:
+    description: list of dicts of existing tags
+    type: list
+    returned: state == "present" or state == "absent"
+    sample: [{ "Key": "Owner", "Value": "owner@example.com" }]
+msg:
+    description: response from AWS API
+    type: dict
+    returned: state == "present" or state == "absent"
+    sample: {"ResponseMetadata": {"HTTPStatusCode": 200, "RequestId": "01234567-0123-0123-0123-0123456789ab"}}
+region:
+    description: the region elb is in
+    type: string
+    returned: state == "present" or state == "absent"
+    sample: "us-east-1"
+tags:
+    description: the tags list of dicts that have been applied or removed
+    type: list
+    returned: state == "present" or state == "absent"
+    sample: [{ "Key": "Department", "Value": "Information Retrieval" }]
+'''
+
 try:
     import boto3
     import botocore


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- New Module Pull Request
##### Plugin Name:

elb_tags
##### Ansible Version:

```
ansible 1.9.4
```
##### Summary:

Module allows for adding and removing tags from ELBs

As ELB's do not have an AWS Resource-ID, the ec2_tag module
cannot be used to tag ELBs.  This new mod allows for tagging ELBs
and returns changed=True only when tags are actually changed.
