### PR TITLE
system/ufw.py: Add security warning re. removing ufw application prof…

### DIFF
--- a/system/ufw.py
+++ b/system/ufw.py
@@ -142,7 +142,9 @@ ufw: rule=reject port=auth log=yes
 # for details. Typical usage is:
 ufw: rule=limit port=ssh proto=tcp
 
-# Allow OpenSSH
+# Allow OpenSSH. (Note that as ufw manages its own state, simply removing
+# a rule=allow task can leave those ports exposed. Either use delete=yes
+# or a separate state=reset task)
 ufw: rule=allow name=OpenSSH
 
 # Delete OpenSSH rule


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- Docs Pull Request
##### Plugin Name:

ufw
##### Ansible Version:

```
2.0.0-0.5.beta3
```
##### Summary:

It's not particularly obvious that removing an application will remove it
from ufw's own state, potentially leaving ports open on your box if you
upload your configuration.

Whilst this applies to a lot of things in Ansible, firewall rules might
cross some sort of line that justifies such a warning in his instance.

Signed-off-by: Chris Lamb chris@chris-lamb.co.uk
