### PR TITLE
Add auth basic support on Zabbix modules (Fixes #1647)

### DIFF
--- a/monitoring/zabbix_group.py
+++ b/monitoring/zabbix_group.py
@@ -49,6 +49,18 @@ options:
         description:
             - Zabbix user password.
         required: true
+    http_login_user:
+        description:
+            - Basic Auth login
+        required: false
+        default: None
+        version_added: "2.1"
+    http_login_password:
+        description:
+            - Basic Auth password
+        required: false
+        default: None
+        version_added: "2.1"
     state:
         description:
             - Create or delete host group.
@@ -153,6 +165,8 @@ def main():
             server_url=dict(type='str', required=True, aliases=['url']),
             login_user=dict(type='str', required=True),
             login_password=dict(type='str', required=True, no_log=True),
+            http_login_user=dict(type='str',required=False, default=None),
+            http_login_password=dict(type='str',required=False, default=None, no_log=True),
             host_groups=dict(type='list', required=True, aliases=['host_group']),
             state=dict(default="present", choices=['present','absent']),
             timeout=dict(type='int', default=10)
@@ -166,6 +180,8 @@ def main():
     server_url = module.params['server_url']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
+    http_login_user = module.params['http_login_user']
+    http_login_password = module.params['http_login_password']
     host_groups = module.params['host_groups']
     state = module.params['state']
     timeout = module.params['timeout']
@@ -174,7 +190,7 @@ def main():
 
     # login to zabbix
     try:
-        zbx = ZabbixAPI(server_url, timeout=timeout)
+        zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -47,6 +47,18 @@ options:
         description:
             - Zabbix user password.
         required: true
+    http_login_user:
+        description:
+            - Basic Auth login
+        required: false
+        default: None
+        version_added: "2.1"
+    http_login_password:
+        description:
+            - Basic Auth password
+        required: false
+        default: None
+        version_added: "2.1"
     host_name:
         description:
             - Name of the host in Zabbix.
@@ -158,8 +170,8 @@ except ImportError:
 class ZabbixAPIExtends(ZabbixAPI):
     hostinterface = None
 
-    def __init__(self, server, timeout, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=timeout)
+    def __init__(self, server, timeout, user, passwd, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
         self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
 
 
@@ -405,6 +417,8 @@ def main():
             login_user=dict(rtype='str', equired=True),
             login_password=dict(type='str', required=True, no_log=True),
             host_name=dict(type='str', required=True),
+            http_login_user=dict(type='str', required=False, default=None),
+            http_login_password=dict(type='str', required=False, default=None, no_log=True),
             host_groups=dict(type='list', required=False),
             link_templates=dict(type='list', required=False),
             status=dict(default="enabled", choices=['enabled', 'disabled']),
@@ -424,6 +438,8 @@ def main():
     server_url = module.params['server_url']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
+    http_login_user = module.params['http_login_user']
+    http_login_password = module.params['http_login_password']
     host_name = module.params['host_name']
     host_groups = module.params['host_groups']
     link_templates = module.params['link_templates']
@@ -441,7 +457,7 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/monitoring/zabbix_hostmacro.py
+++ b/monitoring/zabbix_hostmacro.py
@@ -46,6 +46,18 @@ options:
         description:
             - Zabbix user password.
         required: true
+    http_login_user:
+        description:
+            - Basic Auth login
+        required: false
+        default: None
+        version_added: "2.1"
+    http_login_password:
+        description:
+            - Basic Auth password
+        required: false
+        default: None
+        version_added: "2.1"
     host_name:
         description:
             - Name of the host.
@@ -171,6 +183,8 @@ def main():
             server_url=dict(type='str', required=True, aliases=['url']),
             login_user=dict(type='str', required=True),
             login_password=dict(type='str', required=True, no_log=True),
+            http_login_user=dict(type='str', required=False, default=None),
+            http_login_password=dict(type='str', required=False, default=None, no_log=True),
             host_name=dict(type='str', required=True),
             macro_name=dict(type='str', required=True),
             macro_value=dict(type='str', required=True),
@@ -186,6 +200,8 @@ def main():
     server_url = module.params['server_url']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
+    http_login_user = module.params['http_login_user']
+    http_login_password = module.params['http_login_password']
     host_name = module.params['host_name']
     macro_name  = (module.params['macro_name']).upper()
     macro_value = module.params['macro_value']
@@ -195,7 +211,7 @@ def main():
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)

--- a/monitoring/zabbix_screen.py
+++ b/monitoring/zabbix_screen.py
@@ -48,6 +48,18 @@ options:
         description:
             - Zabbix user password.
         required: true
+    http_login_user:
+        description:
+            - Basic Auth login
+        required: false
+        default: None
+        version_added: "2.1"
+    http_login_password:
+        description:
+            - Basic Auth password
+        required: false
+        default: None
+        version_added: "2.1"
     timeout:
         description:
             - The timeout of API request (seconds).
@@ -142,8 +154,8 @@ except ImportError:
 class ZabbixAPIExtends(ZabbixAPI):
     screenitem = None
 
-    def __init__(self, server, timeout, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=timeout)
+    def __init__(self, server, timeout, user, passwd, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
         self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
 
 
@@ -318,6 +330,8 @@ def main():
             server_url=dict(type='str', required=True, aliases=['url']),
             login_user=dict(type='str', required=True),
             login_password=dict(type='str', required=True, no_log=True),
+            http_login_user=dict(type='str', required=False, default=None),
+            http_login_password=dict(type='str', required=False, default=None, no_log=True),
             timeout=dict(type='int', default=10),
             screens=dict(type='list', required=True)
         ),
@@ -330,13 +344,15 @@ def main():
     server_url = module.params['server_url']
     login_user = module.params['login_user']
     login_password = module.params['login_password']
+    http_login_user = module.params['http_login_user']
+    http_login_password = module.params['http_login_password']
     timeout = module.params['timeout']
     screens = module.params['screens']
 
     zbx = None
     # login to zabbix
     try:
-        zbx = ZabbixAPIExtends(server_url, timeout=timeout)
+        zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
     except Exception, e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Plugin Name:

Updated: monitoring/zabbix_*
##### Summary:

Add parameter http_login_user and http_login_password for zabbix modules to provide support to Auth Basic

Previous PR: #1665
