### PR TITLE
#1747 mongodb_user support check mode

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -172,6 +172,8 @@ def user_add(module, client, db_name, user, password, roles):
 def user_remove(module, client, db_name, user):
     exists = user_find(client, user)
     if exists:
+        if module.check_mode:
+            module.exit_json(changed=True, user=user)
         db = client[db_name]
         db.remove_user(user)
     else:
@@ -212,7 +214,8 @@ def main():
             roles=dict(default=None, type='list'),
             state=dict(default='present', choices=['absent', 'present']),
             update_password=dict(default="always", choices=["always", "on_create"]),
-        )
+        ),
+        supports_check_mode=True
     )
 
     if not pymongo_found:
@@ -263,6 +266,9 @@ def main():
 
         if update_password != 'always' and user_find(client, user):
             password = None
+
+        if module.check_mode:
+            module.exit_json(changed=True, user=user)
 
         try:
             user_add(module, client, db_name, user, password, roles)


### PR DESCRIPTION
##### Issue Type:
- Feature Idea
  ##### Plugin Name:
- database/misc/mongodb_user
##### Ansible Version:

```
Ansible Version: 2.0.0.2
Plugin Version: 8d86666 on 1 Dec 2015
```
##### Ansible Configuration:

“N/A”
##### Environment:

“N/A”
##### Summary:

Support check mode
##### Steps To Reproduce:

Execute this task on an empty database with check mode

```
- mongodb_user: login_user={{ mongodb3_admin_user }} login_password={{ mongodb3_admin_password }} login_port={{ mongodb3_mongos_port }} login_database=admin database={{ item.db }} name={{ item.name }} password={{ item.passwd }} roles={{ item.roles | join(",") }} state=present update_password=on_create
  with_items: mongodb3_users
  run_once: true
```
##### Expected Results:

Says "changed" but no user inserted
##### Actual Results:

skip task
