### PR TITLE
Adding missing attributes regarding the hosted zone. / Fixes #1549

### DIFF
--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -136,6 +136,8 @@ def get_elb_info(connection,elb):
         'name': elb.name,
         'zones': elb.availability_zones,
         'dns_name': elb.dns_name,
+        'canonical_hosted_zone_name': elb.canonical_hosted_zone_name,
+        'canonical_hosted_zone_name_id': elb.canonical_hosted_zone_name_id,
         'instances': [instance.id for instance in elb.instances],
         'listeners': get_elb_listeners(elb.listeners),
         'scheme': elb.scheme,


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

cloud/amazon/ec2_elb_facts
##### Ansible Version:

```
ansible 2.0.1.0
```
##### Summary:

The provided attributes of the Elastic Load Balancer are required, for example when one wants to create an alias DNS record for the ELB in Route53.

Fixes #1549
