### PR TITLE
Fixes #1616, check whether interface-list exits before querying its length

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -289,9 +289,11 @@ class Host(object):
     # check the exist_interfaces whether it equals the interfaces or not
     def check_interface_properties(self, exist_interface_list, interfaces):
         interfaces_port_list = []
-        if len(interfaces) >= 1:
-            for interface in interfaces:
-                interfaces_port_list.append(int(interface['port']))
+
+        if interfaces is not None:
+            if len(interfaces) >= 1:
+                for interface in interfaces:
+                    interfaces_port_list.append(int(interface['port']))
 
         exist_interface_ports = []
         if len(exist_interface_list) >= 1:


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- Bugfix Pull Request
##### Plugin Name:

zabbix_host
##### Summary:

Fixes #1616 

An empty interface list would cause a stacktrace. This commit fixes that.

However, the semantics of passing an empty interface list are unclear since Zabbix does not allow a host to have no interfaces. Right now the ansible module will simply ignore an empty interface list and leave it on the Zabbix server as is.
