### PR TITLE
Replace deprecated exists API for Zabbix 3.0 compatibility

### DIFF
--- a/monitoring/zabbix_group.py
+++ b/monitoring/zabbix_group.py
@@ -114,7 +114,7 @@ class HostGroup(object):
         try:
             group_add_list = []
             for group_name in group_names:
-                result = self._zapi.hostgroup.exists({'name': group_name})
+                result = self._zapi.hostgroup.get({'filter': {'name': group_name}})
                 if not result:
                     try:
                         if self._module.check_mode:

--- a/monitoring/zabbix_hostmacro.py
+++ b/monitoring/zabbix_hostmacro.py
@@ -108,11 +108,6 @@ class HostMacro(object):
         self._module = module
         self._zapi = zbx
 
-    # exist host
-    def is_host_exist(self, host_name):
-        result = self._zapi.host.exists({'host': host_name})
-        return result
-
     # get host id by host name
     def get_host_id(self, host_name):
         try:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

zabbix_group
zabbix_hostmacro
##### Summary:

Final partial fix for #1759 

This replaces a call to the deprecated exists-api in zabbix_group, making it compatible with Zabbix 3.0 (and keeping compatibility with previous versions). Also removed an unused method in zabbix_hostmacro referencing the same API.
