### PR TITLE
Fix version_added for recently added modules

### DIFF
--- a/windows/win_regmerge.py
+++ b/windows/win_regmerge.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_regmerge
-version_added: "2.0"
+version_added: "2.1"
 short_description: Merges the contents of a registry file into the windows registry
 description:
     - Wraps the reg.exe command to import the contents of a registry file.
@@ -68,3 +68,4 @@ EXAMPLES = '''
     compare_to: HKLM:\SOFTWARE\myCompany
 '''
 
+RETURN = '''# '''

--- a/windows/win_timezone.py
+++ b/windows/win_timezone.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_timezone
-version_added: "2.0"
+version_added: "2.1"
 short_description: Sets Windows machine timezone
 description:
     - Sets machine time to the specified timezone, the module will check if the provided timezone is supported on the machine.
@@ -45,3 +45,5 @@ EXAMPLES = '''
   win_timezone:
     timezone: "Central Standard Time"
 '''
+
+RETURN = '''# '''


### PR DESCRIPTION
##### Issue Type:

Docs Pull Request
##### Plugin Name:
- `win_regmerge`
- `win_timezone`
##### Ansible Version:

```
v2.1
```
##### Summary:

Recently merged modules had a wrong version_added, and additionally were missing `RETURN` docs.
##### Example output:

```
N/A
```
