### PR TITLE
methods hostgroup.exists and host.exists were removed in zabbix v3 re…

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -162,13 +162,13 @@ class Host(object):
 
     # exist host
     def is_host_exist(self, host_name):
-        result = self._zapi.host.exists({'host': host_name})
+        result = self._zapi.host.get({'output': 'extend', 'filter': {'host': [host_name]}})
         return result
 
     # check if host group exists
     def check_host_group_exist(self, group_names):
         for group_name in group_names:
-            result = self._zapi.hostgroup.exists({'name': group_name})
+            result = self._zapi.hostgroup.get({'name': group_name})
             if not result:
                 self._module.fail_json(msg="Hostgroup not found: %s" % group_name)
         return True


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

monitoring/zabbix_host.py
##### Ansible Version:

```
ansible 2.1.0 (devel 7404d4ce7f) last updated 2016/03/02 11:25:13 (GMT -300)
  lib/ansible/modules/core: (detached HEAD 0bbb7ba38d) last updated 2016/03/02 11:25:24 (GMT -300)
  lib/ansible/modules/extras: (detached HEAD 39e4040685) last updated 2016/03/02 11:25:24 (GMT -300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### Summary:

This PR replaces the methods `host.exists` and `hostgroup.exists` with `host.get` and `hostgroup.get` that were removed[1][2] in the new Zabbix release (>3.0).

[1] https://www.zabbix.com/documentation/2.4/manual/api/reference/host/exists
[2] https://www.zabbix.com/documentation/2.4/manual/api/reference/hostgroup/exists
