### PR TITLE
Retrieve attributes from server certificate.

### DIFF
--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -94,8 +94,8 @@ except ImportError:
     HAS_BOTO3 = False
 
 
-def get_server_cert(iam, name=None):
-    """Retrieve the attributes of a server certificate if it exists
+def get_server_certs(iam, name=None):
+    """Retrieve the attributes of a server certificate if it exists or all certs.
     Args:
         iam (botocore.client.IAM): The boto3 iam instance.
 
@@ -107,41 +107,46 @@ def get_server_cert(iam, name=None):
         >>> iam = boto3.client('iam')
         >>> name = "server-cert-name"
         >>> results = get_server_cert(iam, name)
-        [
-            {
-                "upload_date": "2015-04-25T00:36:40+00:00",
-                "server_certificate_id": "ADWAJXWTZAXIPIMQHMJPO",
-                "certificate_body": "-----BEGIN CERTIFICATE-----\nbunch of random data\n-----END CERTIFICATE-----",
-                "server_certificate_name": "server-cert-name",
-                "expiration": "2017-06-15T12:00:00+00:00",
-                "path": "/",
-                "arn": "arn:aws:iam::911277865346:server-certificate/server-cert-name"
-            }
-        ]
-    """
-    results = []
-    try:
-        server_cert = iam.get_server_certificate(ServerCertificateName=name)['ServerCertificate']
-        cert_md = server_cert['ServerCertificateMetadata']
-        cert_data = {
-            'certificate_body': server_cert['CertificateBody'],
-            'server_certificate_id': cert_md['ServerCertificateId'],
-            'server_certificate_name': cert_md['ServerCertificateName'],
-            'arn': cert_md['Arn'],
-            'path': cert_md['Path'],
-            'expiration': cert_md['Expiration'].isoformat(),
-            'upload_date': cert_md['UploadDate'].isoformat(),
+        {
+            "upload_date": "2015-04-25T00:36:40+00:00",
+            "server_certificate_id": "ADWAJXWTZAXIPIMQHMJPO",
+            "certificate_body": "-----BEGIN CERTIFICATE-----\nbunch of random data\n-----END CERTIFICATE-----",
+            "server_certificate_name": "server-cert-name",
+            "expiration": "2017-06-15T12:00:00+00:00",
+            "path": "/",
+            "arn": "arn:aws:iam::911277865346:server-certificate/server-cert-name"
         }
-        results.append(cert_data)
+    """
+    results = dict()
+    try:
+        if name:
+            server_certs = [iam.get_server_certificate(ServerCertificateName=name)['ServerCertificate']]
+        else:
+            server_certs = iam.list_server_certificates()['ServerCertificateMetadataList']
+
+        for server_cert in server_certs:
+            if not name:
+                server_cert = iam.get_server_certificate(ServerCertificateName=server_cert['ServerCertificateName'])['ServerCertificate']
+            cert_md = server_cert['ServerCertificateMetadata']
+            results[cert_md['ServerCertificateName']] = {
+                'certificate_body': server_cert['CertificateBody'],
+                'server_certificate_id': cert_md['ServerCertificateId'],
+                'server_certificate_name': cert_md['ServerCertificateName'],
+                'arn': cert_md['Arn'],
+                'path': cert_md['Path'],
+                'expiration': cert_md['Expiration'].isoformat(),
+                'upload_date': cert_md['UploadDate'].isoformat(),
+            }
 
     except botocore.exceptions.ClientError:
         pass
+
     return results
 
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        name=dict(required=True, type='str'),
+        name=dict(type='str'),
     ))
 
     module = AnsibleModule(argument_spec=argument_spec,)

--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -1,0 +1,163 @@
+#!/usr/bin/python
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: iam_server_certificate_facts
+short_description: Retrieve the facts of a server certificate
+description:
+  - Retrieve the attributes of a server certificate
+version_added: "2.1"
+author: "Allen Sanabria (@linuxdynasty)"
+options:
+  name:
+    description:
+      - The name of the server certificate you are retrieveing attributes for.
+    required: true
+extends_documentation_fragment:
+    - aws
+    - ec2
+'''
+
+EXAMPLES = '''
+# Retrieve server certificate
+- iam_server_certificate_facts:
+    name: production-cert
+  register: server_cert
+
+# Fail if the server certificate name was not found
+- iam_server_certificate_facts:
+    name: production-cert
+  register: server_cert
+  failed_when: "{{ server_cert.results | length == 0 }}"
+'''
+
+RETURN = '''
+server_certificate_id:
+    description: The 21 character certificate id
+    returned: success
+    type: str
+    sample: "ADWAJXWTZAXIPIMQHMJPO"
+certificate_body:
+    description: The asn1der encoded PEM string
+    returned: success
+    type: str
+    sample: "-----BEGIN CERTIFICATE-----\nbunch of random data\n-----END CERTIFICATE-----"
+server_certificate_name:
+    description: The name of the server certificate
+    returned: success
+    type: str
+    sample: "server-cert-name"
+arn:
+    description: The Amazon resource name of the server certificate
+    returned: success
+    type: str
+    sample: "arn:aws:iam::911277865346:server-certificate/server-cert-name"
+path:
+    description: The path of the server certificate
+    returned: success
+    type: str
+    sample: "/"
+expiration:
+    description: The date and time this server certificate will expire, in ISO 8601 format.
+    returned: success
+    type: str
+    sample: "2017-06-15T12:00:00+00:00"
+upload_date:
+    description: The date and time this server certificate was uploaded, in ISO 8601 format.
+    returned: success
+    type: str
+    sample: "2015-04-25T00:36:40+00:00"
+'''
+try:
+    import boto3
+    import botocore.exceptions
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def get_server_cert(iam, name=None):
+    """Retrieve the attributes of a server certificate if it exists
+    Args:
+        iam (botocore.client.IAM): The boto3 iam instance.
+
+    Kwargs:
+        name (str): The name of the server certificate.
+
+    Basic Usage:
+        >>> import boto3
+        >>> iam = boto3.client('iam')
+        >>> name = "server-cert-name"
+        >>> results = get_server_cert(iam, name)
+        [
+            {
+                "upload_date": "2015-04-25T00:36:40+00:00",
+                "server_certificate_id": "ADWAJXWTZAXIPIMQHMJPO",
+                "certificate_body": "-----BEGIN CERTIFICATE-----\nbunch of random data\n-----END CERTIFICATE-----",
+                "server_certificate_name": "server-cert-name",
+                "expiration": "2017-06-15T12:00:00+00:00",
+                "path": "/",
+                "arn": "arn:aws:iam::911277865346:server-certificate/server-cert-name"
+            }
+        ]
+    """
+    results = []
+    try:
+        server_cert = iam.get_server_certificate(ServerCertificateName=name)['ServerCertificate']
+        cert_md = server_cert['ServerCertificateMetadata']
+        cert_data = {
+            'certificate_body': server_cert['CertificateBody'],
+            'server_certificate_id': cert_md['ServerCertificateId'],
+            'server_certificate_name': cert_md['ServerCertificateName'],
+            'arn': cert_md['Arn'],
+            'path': cert_md['Path'],
+            'expiration': cert_md['Expiration'].isoformat(),
+            'upload_date': cert_md['UploadDate'].isoformat(),
+        }
+        results.append(cert_data)
+
+    except botocore.exceptions.ClientError:
+        pass
+    return results
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        name=dict(required=True, type='str'),
+    ))
+
+    module = AnsibleModule(argument_spec=argument_spec,)
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    try:
+       region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+       iam = boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except botocore.exceptions.ClientError, e:
+       module.fail_json(msg="Boto3 Client Error - " + str(e.msg))
+    cert_name = module.params.get('name')
+    results = get_server_cert(iam, cert_name)
+    module.exit_json(results=results)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -22,6 +22,7 @@ description:
   - Retrieve the attributes of a server certificate
 version_added: "2.1"
 author: "Allen Sanabria (@linuxdynasty)"
+requirements: ["boto3"]
 options:
   name:
     description:

--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -26,11 +26,12 @@ requirements: [boto3, botocore]
 options:
   name:
     description:
-      - The name of the server certificate you are retrieveing attributes for.
+      - The name of the server certificate you are retrieving attributes for.
     required: true
 extends_documentation_fragment:
     - aws
     - ec2
+requirements: ['boto3']
 '''
 
 EXAMPLES = '''
@@ -83,6 +84,8 @@ upload_date:
     type: str
     sample: "2015-04-25T00:36:40+00:00"
 '''
+
+
 try:
     import boto3
     import botocore.exceptions
@@ -147,10 +150,11 @@ def main():
         module.fail_json(msg='boto3 required for this module')
 
     try:
-       region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-       iam = boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        iam = boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_kwargs)
     except botocore.exceptions.ClientError, e:
-       module.fail_json(msg="Boto3 Client Error - " + str(e.msg))
+        module.fail_json(msg="Boto3 Client Error - " + str(e.msg))
+
     cert_name = module.params.get('name')
     results = get_server_cert(iam, cert_name)
     module.exit_json(results=results)

--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -152,7 +152,7 @@ def main():
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
         iam = boto3_conn(module, conn_type='client', resource='iam', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except botocore.exceptions.ClientError, e:
+    except botocore.exceptions.ClientError as e:
         module.fail_json(msg="Boto3 Client Error - " + str(e.msg))
 
     cert_name = module.params.get('name')

--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -22,7 +22,7 @@ description:
   - Retrieve the attributes of a server certificate
 version_added: "2.1"
 author: "Allen Sanabria (@linuxdynasty)"
-requirements: ["boto3"]
+requirements: [boto3, botocore]
 options:
   name:
     description:

--- a/cloud/amazon/iam_server_certificate_facts.py
+++ b/cloud/amazon/iam_server_certificate_facts.py
@@ -20,7 +20,7 @@ module: iam_server_certificate_facts
 short_description: Retrieve the facts of a server certificate
 description:
   - Retrieve the attributes of a server certificate
-version_added: "2.1"
+version_added: "2.2"
 author: "Allen Sanabria (@linuxdynasty)"
 requirements: [boto3, botocore]
 options:


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- New Module Pull Request
##### Plugin Name:

iam_server_certificate_facts
##### Ansible Version:

```
ansible 2.0.0.2
```
##### Summary:

Retrieve the attributes of a server certificate
##### Example output:

```
{
    "server-cert-name": {
        "upload_date": "2015-04-25T00:36:40+00:00",
        "server_certificate_id": "ADWAJXWTZAXIPIMQHMJPO",
        "certificate_body": "-----BEGIN CERTIFICATE-----\nbunch of random data\n-----END CERTIFICATE-----",
        "server_certificate_name": "server-cert-name",
        "expiration": "2017-06-15T12:00:00+00:00",
        "path": "/",
        "arn": "arn:aws:iam::911277865346:server-certificate/server-cert-name"
    }
}
```

This module will allow you to retrieve all the attributes related to a server certificate.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-extras/1775)

<!-- Reviewable:end -->
