### PR TITLE
Fix instantiation of openstack_cloud object in os_project

### DIFF
--- a/cloud/openstack/os_project.py
+++ b/cloud/openstack/os_project.py
@@ -156,7 +156,7 @@ def main():
 
     name = module.params['name']
     description = module.params['description']
-    domain = module.params['domain_id']
+    domain = module.params.pop('domain_id')
     enabled = module.params['enabled']
     state = module.params['state']
 


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

os_project
##### Ansible Version:

ansible 2.1.0 (devel 71402abf21) last updated 2016/03/01 20:37:11 (GMT +000)
  lib/ansible/modules/core: (detached HEAD 0bbb7ba38d) last updated 2016/03/01 20:37:15 (GMT +000)
  lib/ansible/modules/extras: (detached HEAD 39e4040685) last updated 2016/03/01 20:37:18 (GMT +000)
  config file = 
  configured module search path = Default w/o overrides
##### Summary:

The os_project module instantiates the openstack cloud object
by passing the module params kwargs.
As the params contain a key named 'domain_id', this is used
for domain in the OpenStack connection, instead of the domain value
the user specifies on the OSCC clouds.yaml or openrc envvars.
