### PR TITLE
Add https support for consul clustering modules

### DIFF
--- a/clustering/consul.py
+++ b/clustering/consul.py
@@ -77,7 +77,7 @@ options:
         required: false
         default: http
         version_added: "2.1"
-    verify:
+    validate_certs:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
@@ -321,7 +321,7 @@ def get_consul_api(module, token=None):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),
-                         verify=module.params.get('verify'),
+                         validate_certs=module.params.get('validate_certs'),
                          token=module.params.get('token'))
 
 
@@ -518,7 +518,7 @@ def main():
             host=dict(default='localhost'),
             port=dict(default=8500, type='int'),
             scheme=dict(required=False, default='http'),
-            verify=dict(required=False, default=True, type='bool'),
+            validate_certs=dict(required=False, default=True, type='bool'),
             check_id=dict(required=False),
             check_name=dict(required=False),
             check_node=dict(required=False),

--- a/clustering/consul.py
+++ b/clustering/consul.py
@@ -71,6 +71,16 @@ options:
           - the port on which the consul agent is running
         required: false
         default: 8500
+    scheme:
+        description:
+          - the protocol scheme on which the consul agent is running
+        required: false
+        default: http
+    verify:
+        description:
+          - whether to verify the tls certificate of the consul agent
+        required: false
+        default: True
     notes:
         description:
           - Notes to attach to check when registering it.
@@ -308,6 +318,8 @@ def remove_service(module, service_id):
 def get_consul_api(module, token=None):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
+                         scheme=module.params.get('scheme'),
+                         verify=module.params.get('verify'),
                          token=module.params.get('token'))
 
 
@@ -503,6 +515,8 @@ def main():
         argument_spec=dict(
             host=dict(default='localhost'),
             port=dict(default=8500, type='int'),
+            scheme=dict(required=False, default='http'),
+            verify=dict(required=False, default=True, type='bool'),
             check_id=dict(required=False),
             check_name=dict(required=False),
             check_node=dict(required=False),

--- a/clustering/consul.py
+++ b/clustering/consul.py
@@ -76,11 +76,13 @@ options:
           - the protocol scheme on which the consul agent is running
         required: false
         default: http
+        version_added: "2.1"
     verify:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
         default: True
+        version_added: "2.1"
     notes:
         description:
           - Notes to attach to check when registering it.

--- a/clustering/consul_acl.py
+++ b/clustering/consul_acl.py
@@ -75,7 +75,7 @@ options:
         required: false
         default: http
         version_added: "2.1"
-    verify:
+    validate_certs:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
@@ -313,7 +313,7 @@ def get_consul_api(module, token=None):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),
-                         verify=module.params.get('verify'),
+                         validate_certs=module.params.get('validate_certs'),
                          token=token)
 
 def test_dependencies(module):
@@ -330,7 +330,7 @@ def main():
         mgmt_token=dict(required=True, no_log=True),
         host=dict(default='localhost'),
         scheme=dict(required=False, default='http'),
-        verify=dict(required=False, default=True),
+        validate_certs=dict(required=False, default=True),
         name=dict(required=False),
         port=dict(default=8500, type='int'),
         rules=dict(default=None, required=False, type='list'),

--- a/clustering/consul_acl.py
+++ b/clustering/consul_acl.py
@@ -74,11 +74,13 @@ options:
           - the protocol scheme on which the consul agent is running
         required: false
         default: http
+        version_added: "2.1"
     verify:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
         default: True
+        version_added: "2.1"
 """
 
 EXAMPLES = '''

--- a/clustering/consul_acl.py
+++ b/clustering/consul_acl.py
@@ -69,6 +69,16 @@ options:
           - the port on which the consul agent is running
         required: false
         default: 8500
+    scheme:
+        description:
+          - the protocol scheme on which the consul agent is running
+        required: false
+        default: http
+    verify:
+        description:
+          - whether to verify the tls certificate of the consul agent
+        required: false
+        default: True
 """
 
 EXAMPLES = '''
@@ -300,6 +310,8 @@ def get_consul_api(module, token=None):
         token = module.params.get('token')
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
+                         scheme=module.params.get('scheme'),
+                         verify=module.params.get('verify'),
                          token=token)
 
 def test_dependencies(module):
@@ -315,6 +327,8 @@ def main():
     argument_spec = dict(
         mgmt_token=dict(required=True, no_log=True),
         host=dict(default='localhost'),
+        scheme=dict(required=False, default='http'),
+        verify=dict(required=False, default=True),
         name=dict(required=False),
         port=dict(default=8500, type='int'),
         rules=dict(default=None, required=False, type='list'),

--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -99,6 +99,16 @@ options:
           - the port on which the consul agent is running
         required: false
         default: 8500
+    scheme:
+        description:
+          - the protocol scheme on which the consul agent is running
+        required: false
+        default: http
+    verify:
+        description:
+          - whether to verify the tls certificate of the consul agent
+        required: false
+        default: True
 """
 
 
@@ -218,6 +228,8 @@ def remove_value(module):
 def get_consul_api(module, token=None):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
+                         scheme=module.params.get('scheme'),
+                         verify=module.params.get('verify'),
                          token=module.params.get('token'))
 
 def test_dependencies(module):
@@ -232,6 +244,8 @@ def main():
         flags=dict(required=False),
         key=dict(required=True),
         host=dict(default='localhost'),
+        scheme=dict(required=False, default='http'),
+        verify=dict(required=False, default=True),
         port=dict(default=8500, type='int'),
         recurse=dict(required=False, type='bool'),
         retrieve=dict(required=False, default=True),

--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -105,7 +105,7 @@ options:
         required: false
         default: http
         version_added: "2.1"
-    verify:
+    validate_certs:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
@@ -231,7 +231,7 @@ def get_consul_api(module, token=None):
     return consul.Consul(host=module.params.get('host'),
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),
-                         verify=module.params.get('verify'),
+                         validate_certs=module.params.get('validate_certs'),
                          token=module.params.get('token'))
 
 def test_dependencies(module):
@@ -247,7 +247,7 @@ def main():
         key=dict(required=True),
         host=dict(default='localhost'),
         scheme=dict(required=False, default='http'),
-        verify=dict(required=False, default=True),
+        validate_certs=dict(required=False, default=True),
         port=dict(default=8500, type='int'),
         recurse=dict(required=False, type='bool'),
         retrieve=dict(required=False, default=True),

--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -104,11 +104,13 @@ options:
           - the protocol scheme on which the consul agent is running
         required: false
         default: http
+        version_added: "2.1"
     verify:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
         default: True
+        version_added: "2.1"
 """
 
 

--- a/clustering/consul_session.py
+++ b/clustering/consul_session.py
@@ -93,11 +93,13 @@ options:
           - the protocol scheme on which the consul agent is running
         required: false
         default: http
+        version_added: "2.1"
     verify:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
         default: True
+        version_added: "2.1"
 """
 
 EXAMPLES = '''

--- a/clustering/consul_session.py
+++ b/clustering/consul_session.py
@@ -94,7 +94,7 @@ options:
         required: false
         default: http
         version_added: "2.1"
-    verify:
+    validate_certs:
         description:
           - whether to verify the tls certificate of the consul agent
         required: false
@@ -257,7 +257,7 @@ def main():
         host=dict(default='localhost'),
         port=dict(default=8500, type='int'),
         scheme=dict(required=False, default='http'),
-        verify=dict(required=False, default=True),
+        validate_certs=dict(required=False, default=True),
         id=dict(required=False),
         name=dict(required=False),
         node=dict(required=False),

--- a/clustering/consul_session.py
+++ b/clustering/consul_session.py
@@ -88,6 +88,16 @@ options:
           - the port on which the consul agent is running
         required: false
         default: 8500
+    scheme:
+        description:
+          - the protocol scheme on which the consul agent is running
+        required: false
+        default: http
+    verify:
+        description:
+          - whether to verify the tls certificate of the consul agent
+        required: false
+        default: True
 """
 
 EXAMPLES = '''
@@ -244,6 +254,8 @@ def main():
         delay=dict(required=False,type='str', default='15s'),
         host=dict(default='localhost'),
         port=dict(default=8500, type='int'),
+        scheme=dict(required=False, default='http'),
+        verify=dict(required=False, default=True),
         id=dict(required=False),
         name=dict(required=False),
         node=dict(required=False),


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:
- clustering/consul.py
- clustering/consul_acl.py
- clustering/consul_kv.py
- clustering/consul_session.py
##### Ansible Version:

```
[root@f0d9838d1868 ansible-modules-extras-github]# cat VERSION 
2.0.0-0.5.beta3
[root@f0d9838d1868 ansible-modules-extras-github]#
```
##### Summary:

Adds support for the consul clustering modules to communicate with the consul agent over https (and optionally not verify the certificate, in the event of self-signed certs).
