### PR TITLE
fixes bug where puppet fails if logdest is not specified

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -119,7 +119,7 @@ def main():
             puppetmaster=dict(required=False, default=None),
             manifest=dict(required=False, default=None),
             logdest=dict(
-                required=False, default=['stdout'],
+                required=False, default='stdout',
                 choices=['stdout', 'syslog']),
             show_diff=dict(
                 # internal code to work with --diff, do not use


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- Bugfix Pull Request
  ##### Plugin Name:

system/puppet.py
##### Ansible Version:

```
latest devel
```
##### Summary:

If logdest is not specified, the module fails, because the default is misinterpreted.
##### Example output:

```
[root@phy01 test]# ansible -i hosts all -m puppet
centos7.soh.re | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "value of logdest must be one of: stdout,syslog, got: ['stdout']"
}
```
