### PR TITLE
New json_fail syntax for dnsimple module

### DIFF
--- a/network/dnsimple.py
+++ b/network/dnsimple.py
@@ -159,7 +159,7 @@ def main():
     )
 
     if not HAS_DNSIMPLE:
-        module.fail_json("dnsimple required for this module")
+        module.fail_json(msg="dnsimple required for this module")
 
     account_email     = module.params.get('account_email')
     account_api_token = module.params.get('account_api_token')


### PR DESCRIPTION
##### Issue Type: Bugfix Pull Request
##### Plugin Name: DNSimple
##### Ansible Version:

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### Summary:

Without the DNSimple python library installed, this is meant to fail with a message saying as much. However, with the change from `fail_json` only allowing kwargs, one was missed and gives `TypeError: fail_json() takes exactly 1 argument (2 given)` instead.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-extras/1801)

<!-- Reviewable:end -->
