### PR TITLE
fixes improper syntax of Get-Member

### DIFF
--- a/windows/win_updates.ps1
+++ b/windows/win_updates.ps1
@@ -337,7 +337,7 @@ Function RunAsScheduledJob {
   $sw = [System.Diagnostics.Stopwatch]::StartNew()
 
   # NB: output from scheduled jobs is delayed after completion (including the sub-objects after the primary Output object is available)
-  While (($job.Output -eq $null -or -not (Get-Member -InputObjet $job.Output -Name Keys) -or -not $job.Output.Keys.Contains('job_output')) -and $sw.ElapsedMilliseconds -lt 15000) {
+  While (($job.Output -eq $null -or -not (Get-Member -InputObject $job.Output -Name Keys) -or -not $job.Output.Keys.Contains('job_output')) -and $sw.ElapsedMilliseconds -lt 15000) {
     Write-DebugLog "Waiting for job output to populate..."
     Start-Sleep -Milliseconds 500
   }

--- a/windows/win_updates.ps1
+++ b/windows/win_updates.ps1
@@ -107,7 +107,7 @@ $job_body = {
         $searchresult = $searcher.Search($criteria)
 
         Write-DebugLog "Creating update collection..."
-    
+
         $updates_to_install = New-Object -ComObject Microsoft.Update.UpdateColl
 
         Write-DebugLog "Found $($searchresult.Updates.Count) updates"
@@ -141,29 +141,29 @@ $job_body = {
         $update_status.found_update_count = $updates_to_install.Count
         $update_status.installed_update_count = 0
 
-        # bail out here for check mode  
-        if($is_check_mode -eq $true) { 
+        # bail out here for check mode
+        if($is_check_mode -eq $true) {
           Write-DebugLog "Check mode; exiting..."
           Write-DebugLog "Return value: $($update_status | out-string)"
 
           if($updates_to_install.Count -gt 0) { $update_status.changed = $true }
-          return $update_status 
+          return $update_status
         }
 
-        if($updates_to_install.Count -gt 0) {   
-          if($update_status.reboot_required) { 
+        if($updates_to_install.Count -gt 0) {
+          if($update_status.reboot_required) {
             throw "A reboot is required before more updates can be installed."
           }
           else {
             Write-DebugLog "No reboot is pending..."
           }
-          Write-DebugLog "Downloading updates..." 
+          Write-DebugLog "Downloading updates..."
         }
 
         foreach($update in $updates_to_install) {
-            if($update.IsDownloaded) { 
+            if($update.IsDownloaded) {
                 Write-DebugLog "Update $($update.Identity.UpdateID) already downloaded, skipping..."
-                continue 
+                continue
             }
             Write-DebugLog "Creating downloader object..."
             $dl = $session.CreateUpdateDownloader()
@@ -228,7 +228,7 @@ $job_body = {
 
         }
 
-        if($update_fail_count -gt 0) {  
+        if($update_fail_count -gt 0) {
             $update_status.failed = $true
             $update_status.msg="Failed to install one or more updates"
         }
@@ -247,7 +247,7 @@ $job_body = {
         return $update_status
     }
 
-    Try { 
+    Try {
         # job system adds a bunch of cruft to top-level dict, so we have to send a sub-dict
         return @{ job_output = DoWindowsUpdate @boundparms }
     }
@@ -265,7 +265,7 @@ Function DestroyScheduledJob {
   $schedjob = Get-ScheduledJob -Name $job_name -ErrorAction SilentlyContinue
 
   # nuke it if it's there
-  If($schedjob -ne $null) {  
+  If($schedjob -ne $null) {
       Write-DebugLog "ScheduledJob $job_name exists, ensuring it's not running..."
       # can't manage jobs across sessions, so we have to resort to the Task Scheduler script object to kill running jobs
       $schedserv = New-Object -ComObject Schedule.Service
@@ -279,8 +279,8 @@ Function DestroyScheduledJob {
           $task_to_stop.Stop()
       }
 
-      <# FUTURE: add a global waithandle for this to release any other waiters. Wait-Job 
-      and/or polling will block forever, since the killed job object in the parent 
+      <# FUTURE: add a global waithandle for this to release any other waiters. Wait-Job
+      and/or polling will block forever, since the killed job object in the parent
       session doesn't know it's been killed :( #>
 
       Unregister-ScheduledJob -Name $job_name
@@ -313,7 +313,7 @@ Function RunAsScheduledJob {
   }
   else {
     Write-DebugLog "Starting scheduled job (PS3 method)"
-    Add-JobTrigger -inputobject $schedjob -trigger $(New-JobTrigger -once -at $(Get-Date).AddSeconds(2))      
+    Add-JobTrigger -inputobject $schedjob -trigger $(New-JobTrigger -once -at $(Get-Date).AddSeconds(2))
   }
 
   $sw = [System.Diagnostics.Stopwatch]::StartNew()
@@ -331,13 +331,13 @@ Function RunAsScheduledJob {
 
       # FUTURE: configurable timeout so we don't block forever?
       # FUTURE: add a global WaitHandle in case another instance kills our job, so we don't block forever
-      $job = Wait-Job -Name $schedjob.Name -ErrorAction SilentlyContinue 
+      $job = Wait-Job -Name $schedjob.Name -ErrorAction SilentlyContinue
   }
 
   $sw = [System.Diagnostics.Stopwatch]::StartNew()
 
   # NB: output from scheduled jobs is delayed after completion (including the sub-objects after the primary Output object is available)
-  While (($job.Output -eq $null -or -not ($job.Output | Get-Member -Name Keys) -or -not $job.Output.Keys.Contains('job_output')) -and $sw.ElapsedMilliseconds -lt 15000) {
+  While (($job.Output -eq $null -or -not (Get-Member -InputObjet $job.Output -Name Keys) -or -not $job.Output.Keys.Contains('job_output')) -and $sw.ElapsedMilliseconds -lt 15000) {
     Write-DebugLog "Waiting for job output to populate..."
     Start-Sleep -Milliseconds 500
   }
@@ -358,7 +358,7 @@ Function RunAsScheduledJob {
       $ret.Output = $job.Output.job_output # sub-object returned, can only be accessed as a property for some reason
   }
 
-  Try { # this shouldn't be fatal, but can fail with both Powershell errors and COM Exceptions, hence the dual error-handling... 
+  Try { # this shouldn't be fatal, but can fail with both Powershell errors and COM Exceptions, hence the dual error-handling...
       Unregister-ScheduledJob -Name $job_name -Force -ErrorAction Continue
   }
   Catch {


### PR DESCRIPTION
Bug fix for win_updates:  cannot pipe variable to Get-Member, must use -InputObject
