### PR TITLE
Hiera new module added, to parse and use hiera variables as node facts

### DIFF
--- a/system/hiera.py
+++ b/system/hiera.py
@@ -109,8 +109,36 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-This module will return the datatype that you got in Hieradata backend.
-
+path:
+    description: bin for hiera execution
+    returned: success
+    type: string
+    sample: "/path/to/file"
+environment:
+    description: scope to be interpreted by hiera
+    returned: success even the scope does not exists
+    type: string
+    sample: "production"
+fqdn:
+    description: other scope for hiera parse
+    returned: success even the scope does not exists
+    type: string
+    sample: ""
+key:
+    description: hiera's value name
+    returned: success
+    type: string
+    sample: "proxy::array_multi"
+fact:
+    description: variable where store the Hiera's value
+    returned: success
+    type: string
+    sample: "var_array_multi"
+source:
+    description: hiera config file
+    returned: success
+    type: string
+    sample: "/path/to/hiera.yaml"
 '''
 
 
@@ -132,7 +160,7 @@ def main():
     """
     module = AnsibleModule(
         argument_spec=dict(
-            name=dict(aliases=['key']),
+            name=dict(required=True, aliases=['key']),
             fact=dict(required=False),
             path=dict(required=False, default="hiera"),
             context=dict(required=False, default={}, type='dict'),

--- a/system/hiera.py
+++ b/system/hiera.py
@@ -36,23 +36,19 @@ options:
         description:
             - This is a fact name where you want to save your variable from Hiera.
         required: false
-        default: null
     key:
         description:
             - This is the Hiera variable name that you want to get.
         required: true
-        default: null
         aliases: ['name']
     context:
         description:
             - This key value will set the scope of hiera key/value. Also will follow the hiera's hierarchi, then if you dont have any variable in the first scope will go down to the next one.
         required: false
-        default: null
     source:
         description:
             - The hiera config file path, if you want to custom every query with multiple hierarchies
         required: false
-        default: null
 '''
 
 EXAMPLES = '''

--- a/system/hiera.py
+++ b/system/hiera.py
@@ -21,7 +21,7 @@ Hiera-Ansible Parser.
 DOCUMENTATION = '''
 ---
 module: hiera
-version_added: "2.1"
+version_added: "2.2"
 short_description: Use Hiera key/values into Ansible as fact.
 author: "Juan Manuel Parrilla @kerbeross jparrill@redhat.com"
 description:

--- a/system/hiera.py
+++ b/system/hiera.py
@@ -21,7 +21,7 @@ Hiera-Ansible Parser.
 DOCUMENTATION = '''
 ---
 module: hiera
-version_added: "1.0.0"
+version_added: "2.1"
 short_description: Use Hiera key/values into Ansible as fact.
 author: "Juan Manuel Parrilla @kerbeross jparrill@redhat.com"
 description:
@@ -106,6 +106,11 @@ EXAMPLES = '''
     - debug: msg="{{ item }}"
       with_items: var_array_line
     - debug: msg="{{ line }}"
+'''
+
+RETURN = '''
+# Without Puppetmaster example, stand-alone node
+
 '''
 
 

--- a/system/hiera.py
+++ b/system/hiera.py
@@ -1,4 +1,4 @@
-#!/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 """
 Hiera-Ansible Parser.
@@ -23,22 +23,18 @@ DOCUMENTATION = '''
 module: hiera
 version_added: "1.0.0"
 short_description: Use Hiera key/values into Ansible as fact.
-author: "Jua"
+author: "Juan Manuel Parrilla @kerbeross jparrill@redhat.com"
 description:
-    - Once copied all Hiera Data from PuppetMaster and Hiera.yaml into
-    destination node, this module will parse all key-value that you need
-    and create node facts in execution time
+    - Once copied all Hiera Data from PuppetMaster and Hiera.yaml into destination node, this module will parse all key-value that you need and create node facts in execution time
 options:
     path:
         description:
-            - Hiera executable path in destination node. This bin will be
-            executed to follow all hierarchi and get data from hiera
+            - Hiera executable path in destination node. This bin will be executed to follow all hierarchi and get data from hiera
         required: false
         default: hiera
     fact:
         description:
-            - This is a fact name where you want to save your variable
-            from Hiera.
+            - This is a fact name where you want to save your variable from Hiera.
         required: false
         default: null
     key:
@@ -49,15 +45,12 @@ options:
         aliases: ['name']
     context:
         description:
-            - This key value will set the scope of hiera key/value. Also will
-            follow the hiera's hierarchi, then if you dont have any variable
-            in the first scope will go down to the next one.
+            - This key value will set the scope of hiera key/value. Also will follow the hiera's hierarchi, then if you dont have any variable in the first scope will go down to the next one.
         required: false
         default: null
     source:
         description:
-            - The hiera config file path, if you want to custom every query
-            with multiple hierarchies
+            - The hiera config file path, if you want to custom every query with multiple hierarchies
         required: false
         default: null
 '''
@@ -123,8 +116,7 @@ def main():
     values
     - key: Is the key name of the hiera variable
     - fact: Is the key name that must store the hiera output
-    - args: context: must contain all the values that identify the node against
-        hiera
+    - args: context: must contain all the values that identify the node against hiera
     - path: hiera executable
     - source: hiera config file
         WARNING: This module try to solve a disparity between arch of

--- a/system/hiera.py
+++ b/system/hiera.py
@@ -109,7 +109,7 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-# Without Puppetmaster example, stand-alone node
+This module will return the datatype that you got in Hieradata backend.
 
 '''
 

--- a/system/hiera.py
+++ b/system/hiera.py
@@ -1,0 +1,179 @@
+#!/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Hiera-Ansible Parser.
+
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+
+DOCUMENTATION = '''
+---
+module: hiera
+version_added: "1.0.0"
+short_description: Use Hiera key/values into Ansible as fact.
+author: "Jua"
+description:
+    - Once copied all Hiera Data from PuppetMaster and Hiera.yaml into
+    destination node, this module will parse all key-value that you need
+    and create node facts in execution time
+options:
+    path:
+        description:
+            - Hiera executable path in destination node. This bin will be
+            executed to follow all hierarchi and get data from hiera
+        required: false
+        default: hiera
+    fact:
+        description:
+            - This is a fact name where you want to save your variable
+            from Hiera.
+        required: false
+        default: null
+    key:
+        description:
+            - This is the Hiera variable name that you want to get.
+        required: true
+        default: null
+        aliases: ['name']
+    context:
+        description:
+            - This key value will set the scope of hiera key/value. Also will
+            follow the hiera's hierarchi, then if you dont have any variable
+            in the first scope will go down to the next one.
+        required: false
+        default: null
+    source:
+        description:
+            - The hiera config file path, if you want to custom every query
+            with multiple hierarchies
+        required: false
+        default: null
+'''
+
+EXAMPLES = '''
+# Without Puppetmaster example, stand-alone node
+---
+- name: Test
+  hosts: 127.0.0.1
+  tasks:
+    - name: Retrieving Hiera Data
+      hiera: path=/bin/hiera key="{{ item.value }}" fact="{{ item.key }}" source=/etc/hiera.yaml
+      args:
+        context:
+          environment: 'production'
+          fqdn: 'puppet01.localdomain'
+      with_dict:
+        var_array_multi: "proxy::array_multi"
+        var_array_line: "proxy::array_line"
+        line: "line"
+
+    - debug: msg="{{ item }}"
+      with_items: var_array_multi
+    - debug: msg="{{ item }}"
+      with_items: var_array_line
+    - debug: msg="{{ line }}"
+
+# Puppetmaster example
+---
+- name: Create Facts with Hiera Data
+  hosts: nodes
+  sudo: yes
+  tasks:
+    - name: Copy Hiera Data into Destination node
+      copy: src=/var/lib/hiera/ dest=/var/lib/
+
+    - name: Copy Hiera Config into Destination node
+      copy: src=/etc/hiera.yaml dest=/etc/hiera.yaml
+
+    - name: Retrieving Hiera Data
+      hiera: path=/bin/hiera key="{{ item.value }}" fact="{{ item.key }}" source=/etc/hiera.yaml
+      args:
+        context:
+          environment: 'production'
+          fqdn: 'puppet01.localdomain'
+      with_dict:
+        var_array_multi: "proxy::array_multi"
+        var_array_line: "proxy::array_line"
+        line: "line"
+
+    - debug: msg="{{ item }}"
+      with_items: var_array_multi
+    - debug: msg="{{ item }}"
+      with_items: var_array_line
+    - debug: msg="{{ line }}"
+'''
+
+
+def main():
+    """
+    Main function.
+    This module will parse your hiera hierarchi and will return the required
+    values
+    - key: Is the key name of the hiera variable
+    - fact: Is the key name that must store the hiera output
+    - args: context: must contain all the values that identify the node against
+        hiera
+    - path: hiera executable
+    - source: hiera config file
+        WARNING: This module try to solve a disparity between arch of
+        Puppet/Hiera and Ansible, because of how they works (Puppet compile
+        the values into puppet master node) (Ansible are executed into
+        destination node and have not access to Hiera backend directly)
+
+    """
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(aliases=['key']),
+            fact=dict(required=False),
+            path=dict(required=False, default="hiera"),
+            context=dict(required=False, default={}, type='dict'),
+            source=dict(required=False, default=None)
+        )
+    )
+
+    params = module.params
+    out = {}
+
+    if not params['fact']:
+        params['fact'] = params['name']
+
+    try:
+        pargs = [params['path']]
+
+        if params['source']:
+            pargs.extend(['-c', params['source']])
+
+        pargs.append(params['name'])
+        pargs.extend(
+            [r'%s=%s' % (k, v) for k, v in params['context'].iteritems()]
+        )
+
+        rc, output, tmp = module.run_command(pargs)
+
+        # Debug
+        # module.exit_json(changed=True, something_else=pargs)
+        # module.exit_json(changed=True, something_else=output.strip('\n'))
+        #
+        out['ansible_facts'] = {}
+        out['ansible_facts'][params['fact']] = output.strip('\n')
+
+        module.exit_json(**out)
+
+    except Exception, e:
+        module.fail_json(msg=str(e))
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()


### PR DESCRIPTION
##### Issue Type:
- New Module Pull Request
##### Plugin Name:

Hiera-Ansible
##### Ansible Version:

```
ansible 1.9.4
  configured module search path = None
```
##### Summary:

Ansible-Hiera Parser could retrieve all Hiera data that you want to map as node facts, just copy all hieradata and hiera.yaml from Puppetmaster into destination node (the good way to do it is executing from Puppetmaster the ansible-playbook) and select the variable to store your hiera variable.

**Why?**

We are thinking about create one repository with only Hiera data and hierarchy file, also 2 repositories One with Puppet code and other one with Ansible code that will have the Hiera repository as submodule, this way will centralize all relevant data in one place avoiding replication errors.

I think this is a elegant way to organize your repositories and separate the logic from key/value data
##### Example output:

```
TASK: [Retrieving Hiera Data] *************************************************
ok: [vagrantServer] => (item={'key': 'var_array_line', 'value': 'proxy::array_line'})
ok: [vagrantServer] => (item={'key': 'line', 'value': 'line'})
ok: [vagrantServer] => (item={'key': 'var_array_multi', 'value': 'proxy::array_multi'})
```
