### PR TITLE
correct win_firewall state parameter

### DIFF
--- a/windows/win_firewall_rule.py
+++ b/windows/win_firewall_rule.py
@@ -34,7 +34,7 @@ options:
         choices: ['yes', 'no']
     state:
         description:
-            - create/remove/update or powermanage your VM
+            - should this rule be added or removed
         default: "present"
         required: true
         choices: ['present', 'absent']


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

win_firewall module
##### Ansible Version:

Git devel
##### Summary:

Please describe the change and the reason for it.
- original parameter comment was probably copy&paste error
- new comment highlights that firewall rules can be
  added or removed altering this parameter
