### PR TITLE
Add optional mysql connect timeout.

### DIFF
--- a/database/mysql/mysql_replication.py
+++ b/database/mysql/mysql_replication.py
@@ -205,6 +205,7 @@ def main():
             master_ssl_cert=dict(default=None),
             master_ssl_key=dict(default=None),
             master_ssl_cipher=dict(default=None),
+            connect_timeout=dict(default=30, type='int'),
             config_file=dict(default="~/.my.cnf"),
             ssl_cert=dict(default=None),
             ssl_key=dict(default=None),
@@ -235,6 +236,7 @@ def main():
     ssl_cert = module.params["ssl_cert"]
     ssl_key = module.params["ssl_key"]
     ssl_ca = module.params["ssl_ca"]
+    connect_timeout = module.params['connect_timeout']
     config_file = module.params['config_file']
     config_file = os.path.expanduser(os.path.expandvars(config_file))
 
@@ -247,7 +249,8 @@ def main():
     login_user = module.params["login_user"]
 
     try:
-        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'MySQLdb.cursors.DictCursor')
+        cursor = mysql_connect(module, login_user, login_password, config_file, ssl_cert, ssl_key, ssl_ca, None, 'MySQLdb.cursors.DictCursor',
+                               connect_timeout=connect_timeout)
     except Exception, e:
         if os.path.exists(config_file):
             module.fail_json(msg="unable to connect to database, check login_user and login_password are correct or %s has the credentials. Exception message: %s" % (config_file, e))


### PR DESCRIPTION
##### Issue Type:

Feature Pull Request
##### Plugin Name:

mysql_replication
##### Ansible Version:

```
ansible 2.1.0 (mysql-connect-timeout 07d71f040f) last updated 2016/03/10 13:33:12 (GMT -700)
  lib/ansible/modules/core: (detached HEAD c86a0ef84a) last updated 2016/03/10 13:04:45 (GMT -700)
  lib/ansible/modules/extras: (detached HEAD 33a557cc59) last updated 2016/03/10 09:27:07 (GMT -700)
  config file = 
  configured module search path = Default w/o overrides
```
##### Summary:

Add optional connect_timeout option.

Support for the connection timeout was previously added in commit https://github.com/ansible/ansible/commit/16f107a49196f2afc38d204c61bce0f3ff37a4ae
##### Example output:

Tested on Ubuntu 15.10:

```
#time ansible -m mysql_replication -a 'mode=getmaster login_host=12.0.0.9 connect_timeout=1' all -i 'localhost,' -e 'ansible_connection=local'
localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "unable to find /root/.my.cnf. Exception message: (2003, \"Can't connect to MySQL server on '12.0.0.9' (110)\")"
}

real    0m2.090s
user    0m0.988s
sys 0m0.316s
```
