### PR TITLE
ec2_vpc_route_table_facts.py - added route associations to the output structure

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table_facts.py
+++ b/cloud/amazon/ec2_vpc_route_table_facts.py
@@ -73,13 +73,20 @@ def get_route_table_info(route_table):
     for route in route_table.routes:
         routes.append(route.__dict__)
 
+    # Add route associations too
+    route_associations = []
+    for route_association in route_table.associations:
+        route_associations.append(route_association.__dict__)
+
     route_table_info = { 'id': route_table.id,
                          'routes': routes,
                          'tags': route_table.tags,
-                         'vpc_id': route_table.vpc_id
+                         'vpc_id': route_table.vpc_id,
+                         'associations': route_associations
                        }
 
     return route_table_info
+
 
 def list_ec2_vpc_route_tables(connection, module):
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

ansible-modules-extras/cloud/amazon/ec2_vpc_route_table_facts.py
##### Ansible Version:

```
ansible 2.1.0
```
##### Summary:

This PR adds route table 'association' to the output structure.
Reason - now it's possible to identify which route table has Main attribute.
##### Example output:

```
ok: [localhost] => {
    "rtables_res": {
        "changed": false,
        "route_tables": [
            {
                "associations": [
                    {
                        "id": "rtbassoc-e980058d",
                        "main": true,
                        "route_table_id": "rtb-281be64c",
                        "subnet_id": null
                    }
                ],
                "id": "rtb-281be64c",
                "routes": [
                    {
                        "destination_cidr_block": "10.10.32.0/20",
                        "gateway_id": "local",
                        "instance_id": null,
                        "interface_id": null,
                        "origin": "CreateRouteTable",
                        "state": "active",
                        "vpc_peering_connection_id": null
                    }
                ],
                "tags": {},
                "vpc_id": "vpc-9cf1fff9"
            }
        ]
    }
}
```
