### PR TITLE
Optimize haproxy enable and disable actions

### DIFF
--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -253,17 +253,20 @@ class HAProxy(object):
             output = output.split('\n')
             result = output
 
+            pxnames = []
             for line in result:
                 if 'BACKEND' in line:
-                    result =  line.split(',')[0]
-                    pxname = result
-                    cmd = "get weight %s/%s ; enable server %s/%s" % (pxname, svname, pxname, svname)
-                    if weight:
-                        cmd += "; set weight %s/%s %s" % (pxname, svname, weight)
-                    self.execute(cmd)
-                    if self.wait:
-                        self.wait_until_status(pxname, svname, 'UP')
+                    pxnames.append(line.split(',')[0])
 
+            for pxname in pxnames:
+                cmd = "get weight %s/%s ; enable server %s/%s" % (pxname, svname, pxname, svname)
+                if weight:
+                    cmd += "; set weight %s/%s %s" % (pxname, svname, weight)
+                self.execute(cmd)
+
+            if self.wait:
+                for pxname in pxnames:
+                    self.wait_until_status(pxname, svname, 'UP')
         else:
             pxname = backend
             cmd = "get weight %s/%s ; enable server %s/%s" % (pxname, svname, pxname, svname)
@@ -287,16 +290,20 @@ class HAProxy(object):
             output = output.split('\n')
             result = output
 
+            pxnames = []
             for line in result:
                 if 'BACKEND' in line:
-                    result =  line.split(',')[0]
-                    pxname = result
-                    cmd = "get weight %s/%s ; disable server %s/%s" % (pxname, svname, pxname, svname)
-                    if shutdown_sessions:
-                        cmd += "; shutdown sessions server %s/%s" % (pxname, svname)
-                    self.execute(cmd)
-                    if self.wait:
-                        self.wait_until_status(pxname, svname, 'MAINT')
+                    pxnames.append(line.split(',')[0])
+
+            for pxname in pxnames:
+                cmd = "get weight %s/%s ; disable server %s/%s" % (pxname, svname, pxname, svname)
+                if shutdown_sessions:
+                    cmd += "; shutdown sessions server %s/%s" % (pxname, svname)
+                self.execute(cmd)
+
+            if self.wait:
+                for pxname in pxnames:
+                    self.wait_until_status(pxname, svname, 'MAINT')
 
         else:
             pxname = backend


### PR DESCRIPTION
##### Issue Type:

Please pick one and delete the rest:
- Bugfix Pull Request
##### Plugin Name:

haproxy
##### Ansible Version:

```
2.0.1.0
```
##### Summary:

Enabling a haproxy host with the wait option can be very slow, because it 
first enables a service, then check if it is up, then enables a service again, checks it, and so on.

So optimize this loop with first enabling/disabling all services, then check them. This makes a transition from O(n) to O(1), where n is the number of proxies on a host.
##### Example output:

The same as before, just faster.
