### PR TITLE
Fixing typo in bigip_monitors

### DIFF
--- a/network/f5/bigip_monitor_http.py
+++ b/network/f5/bigip_monitor_http.py
@@ -250,7 +250,7 @@ def check_integer_property(api, monitor, int_property):
 
 def set_integer_property(api, monitor, int_property):
 
-    api.LocalLB.Monitor.set_template_int_property(template_names=[monitor], values=[int_property])
+    api.LocalLB.Monitor.set_template_integer_property(template_names=[monitor], values=[int_property])
 
 
 def update_monitor_properties(api, module, monitor, template_string_properties, template_integer_properties):

--- a/network/f5/bigip_monitor_tcp.py
+++ b/network/f5/bigip_monitor_tcp.py
@@ -269,7 +269,7 @@ def check_integer_property(api, monitor, int_property):
 
 def set_integer_property(api, monitor, int_property):
 
-    api.LocalLB.Monitor.set_template_int_property(template_names=[monitor], values=[int_property])
+    api.LocalLB.Monitor.set_template_integer_property(template_names=[monitor], values=[int_property])
 
 
 def update_monitor_properties(api, module, monitor, template_string_properties, template_integer_properties):


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

bigip_monitor_http.py
bigip_monitor_tcp.py
##### Summary:

Fixing typos in both monitor files for set_template_int_property to set_template_integer_property. Ansible runs that try to modify an existing monitor's integer setting on an F5 fail without this.
