### PR TITLE
re-write ec2_vpc_route_table.py to be Boto3 compatible [WIP]

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -19,7 +19,7 @@ module: ec2_vpc_route_table
 short_description: Manage route tables for AWS virtual private clouds
 description:
     - Manage route tables for AWS virtual private clouds
-version_added: "2.1"
+version_added: "2.2"
 author: Robert Estelle (@erydo), Rob White (@wimnat), Allen Sanabria (@linuxdynasty)
 options:
   lookup:

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -371,12 +371,7 @@ def make_tags_in_aws_format(tags):
         >>> make_tags_in_proper_format(tags)
         [
             {
-                "Value": "web",
-                "Key": "service"
-             },
-            {
-               "Value": "development",
-               "key": "env"
+               "env": "development"
             }
         ]
 

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -344,12 +344,7 @@ def make_tags_in_proper_format(tags):
         >>> make_tags_in_proper_format(tags)
         [
             {
-                "Value": "web",
-                "Key": "service"
-             },
-            {
-               "Value": "development",
-               "key": "env"
+               "env": "development"
             }
         ]
 


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Feature Pull Request
##### Plugin Name:

ec2_vpc_route_table.py
##### Summary:

In the process of writing the ec2_vpc_nat_gateway.py, the ec2_vpc_route_table.py module would fail on subsequent runs. After further digging, Boto2 does not officially support Nat Gateways. This re-write of the module rips out Boto2 completely in place of Boto3. This module  officially supports all Amazon supported gateways. Also each function is heavily documented as well.
##### Example:

```
       [
            {
                "success": true,
                "changed": true,
                "msg": "Route table rtb-1234567 updated.",
                "associations": [
                    {
                        "subnet_id": "subnet-12345667",
                        "route_table_id": "rtb-1234567",
                        "main": false,
                        "route_table_association_id": "rtbassoc-1234567"
                    },
                    {
                        "subnet_id": "subnet-78654321",
                        "route_table_id": "rtb-78654321",
                        "main": false,
                        "route_table_association_id": "rtbassoc-78654321"
                    }
                ],
                "tags": [
                    {
                        "key": "Name",
                        "value": "dev_route_table"
                    },
                    {
                        "key": "env",
                        "value": "development"
                    }
                ],
                "routes": [
                    {
                        "gateway_id": "local",
                        "origin": "CreateRouteTable",
                        "state": "active",
                        "destination_cidr_block": "10.100.0.0/16"
                    },
                    {
                        "origin": "CreateRoute",
                        "state": "active",
                        "nat_gateway_id": "nat-12345678",
                        "destination_cidr_block": "0.0.0.0/0"
                    }
                ],
                "route_table_id": "rtb-1234567",
                "vpc_id": "vpc-1234567",
                "propagating_vgws": []
            }
        ]
```
- Rewrote the module to be Boto3 compatible.
- Documented every function.
- Supports all gateways (gateway_id, instance_id, network_interface_id, vpc_peering_connection_id, nat_gateway_id).

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-extras/1846)

<!-- Reviewable:end -->
