### PR TITLE
Fix test failure for lxc_container

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -416,7 +416,7 @@ lxc_container:
             description: resulting state of the container
             returned: success, when archive is true
             type: string
-            sample: "/tmp/test-container-config.tar",
+            sample: "/tmp/test-container-config.tar"
         clone:
             description: if the container was cloned
             returned: success, when clone_name is specified


### PR DESCRIPTION
##### Issue Type:
-  Docs Pull Request
##### Plugin Name:

cloud/lxc/lxc_container.py
##### Summary:

doc fix for travis build error
##### Example:

from travis

TRACE:
    while parsing a block mapping
      in "<string>", line 33, column 13:
                    description: resulting state of  ...
                    ^
    expected <block end>, but found ','
      in "lxc_container.RETURN", line 419, column 53:
         ... "/tmp/test-container-config.tar",

ERROR: RETURN is not valid YAML. Line 419 column 53
