### PR TITLE
Do not return failure when the package is installed and nothing is done

### DIFF
--- a/packaging/os/svr4pkg.py
+++ b/packaging/os/svr4pkg.py
@@ -225,9 +225,10 @@ def main():
     else:
         result['changed'] = False
 
+    # rc will be none when the package already was installed and no action took place
     # Only return failed=False when the returncode is known to be good as there may be more
     # undocumented failure return codes
-    if rc not in (0, 2, 10, 20):
+    if rc not in (None, 0, 2, 10, 20):
         result['failed'] = True
     else:
         result['failed'] = False


### PR DESCRIPTION
When the package is installed and state=present is requested there is a failure reported at the moment because rc == None from the initialization.
