### PR TITLE
add append-only mode to ec2_vpc_route_table.py

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -45,8 +45,8 @@ options:
   append_routes:
     description:
       - If set to true, routes will not be deleted from the route table; only specified routes that are missing will be created.
-      required: false
-      default: false
+    required: false
+    default: false
   state:
     description:
       - "Create or destroy the VPC route table"

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -43,6 +43,7 @@ options:
       - "List of routes in the route table. Routes are specified as dicts containing the keys 'dest' and one of 'gateway_id', 'instance_id', 'interface_id', or 'vpc_peering_connection_id'. If 'gateway_id' is specified, you can refer to the VPC's IGW by using the value 'igw'."
     required: true
   append_routes:
+    version_added: "2.1"
     description:
       - If set to true, routes will not be deleted from the route table; only specified routes that are missing will be created.
     required: false

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -42,6 +42,11 @@ options:
     description:
       - "List of routes in the route table. Routes are specified as dicts containing the keys 'dest' and one of 'gateway_id', 'instance_id', 'interface_id', or 'vpc_peering_connection_id'. If 'gateway_id' is specified, you can refer to the VPC's IGW by using the value 'igw'."
     required: true
+  append_routes:
+    description:
+      - If set to true, routes will not be deleted from the route table; only specified routes that are missing will be created.
+      required: false
+      default: false
   state:
     description:
       - "Create or destroy the VPC route table"
@@ -301,7 +306,7 @@ def index_of_matching_route(route_spec, routes_to_match):
 
 
 def ensure_routes(vpc_conn, route_table, route_specs, propagating_vgw_ids,
-                  check_mode):
+                  check_mode, append_only):
     routes_to_match = list(route_table.routes)
     route_specs_to_create = []
     for route_spec in route_specs:
@@ -319,7 +324,7 @@ def ensure_routes(vpc_conn, route_table, route_specs, propagating_vgw_ids,
     # VGWs in place.
     routes_to_delete = [r for r in routes_to_match
                         if r.gateway_id != 'local'
-                        and r.gateway_id not in propagating_vgw_ids]
+                        and r.gateway_id not in propagating_vgw_ids] if not append_only else []
 
     changed = routes_to_delete or route_specs_to_create
     if changed:
@@ -476,6 +481,7 @@ def create_route_spec(connection, routes, vpc_id):
 
 def ensure_route_table_present(connection, module):
 
+    append_routes = module.params.get('append_routes')
     lookup = module.params.get('lookup')
     propagating_vgw_ids = module.params.get('propagating_vgw_ids')
     route_table_id = module.params.get('route_table_id')
@@ -519,7 +525,7 @@ def ensure_route_table_present(connection, module):
 
     if routes is not None:
         try:
-            result = ensure_routes(connection, route_table, routes, propagating_vgw_ids, module.check_mode)
+            result = ensure_routes(connection, route_table, routes, propagating_vgw_ids, module.check_mode, append_only=append_routes)
             changed = changed or result['changed']
         except EC2ResponseError as e:
             module.fail_json(msg=e.message)
@@ -561,6 +567,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
+            append_routes = dict(default=False, type='bool', required=False),
             lookup = dict(default='tag', required=False, choices=['tag', 'id']),
             propagating_vgw_ids = dict(default=None, required=False, type='list'),
             route_table_id = dict(default=None, required=False),


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

ec2_vpc_route_table
##### Summary:

this adds append-only functionality to ec2_vpc_route_table, in order to not have to rewrite all routing table entries on every run. this PR essentially duplicates work I found here: https://github.com/preo/ansible-modules-core/pull/2
##### Example:

```
- name: add default route to a routing table
  ec2_vpc_route_table:
    vpc_id: vpc-1245678
    region: us-west-1
    tags:
      Name: Public
    subnets:
      - "{{ jumpbox_subnet.subnet.id }}"
      - "{{ frontend_subnet.subnet.id }}"
      - "{{ vpn_subnet.subnet_id }}"
    routes:
      - dest: 0.0.0.0/0
        gateway_id: igw
    append_routes: true
```
