### PR TITLE
Fix for existing ENIs w/ multiple security groups

### DIFF
--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -324,7 +324,7 @@ def compare_eni(connection, module):
 
         for eni in all_eni:
             remote_security_groups = get_sec_group_list(eni.groups)
-            if (eni.subnet_id == subnet_id) and (eni.private_ip_address == private_ip_address) and (eni.description == description) and (remote_security_groups == security_groups):
+            if (eni.subnet_id == subnet_id) and (eni.private_ip_address == private_ip_address) and (eni.description == description) and (sorted(remote_security_groups) == sorted(security_groups)):
                 return eni
 
     except BotoServerError as e:


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

ec2_eni.py
##### Summary:

This adds a sorted compare to security groups supplied via `module.params.get('security_groups')` and the list of security groups fetched via `get_sec_group_list(eni.groups)` and fixes an incorrect "The specified address is already in use" error if the order of security groups in those lists differ.
