### PR TITLE
Allow Datadog metric alerts to define multiple thresholds

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -95,7 +95,7 @@ options:
         required: false
         default: False
     thresholds:
-        description: ["A dictionary of thresholds by status. Because service checks can have multiple thresholds, we don't define them directly in the query."]
+        description: ["A dictionary of thresholds by status. This option is only available for service checks and metric alerts. Because each of them can have multiple thresholds, we don't define them directly in the query."]
         required: false
         default: {'ok': 1, 'critical': 1, 'warning': 1}
 '''
@@ -152,7 +152,7 @@ def main():
             renotify_interval=dict(required=False, default=None),
             escalation_message=dict(required=False, default=None),
             notify_audit=dict(required=False, default=False, type='bool'),
-            thresholds=dict(required=False, type='dict', default={'ok': 1, 'critical': 1, 'warning': 1}),
+            thresholds=dict(required=False, type='dict', default=None),
         )
     )
 
@@ -228,6 +228,8 @@ def install_monitor(module):
     }
 
     if module.params['type'] == "service check":
+        options["thresholds"] = module.params['thresholds'] or {'ok': 1, 'critical': 1, 'warning': 1}
+    if module.params['type'] == "metric alert" and module.params['thresholds'] is not None:
         options["thresholds"] = module.params['thresholds']
 
     monitor = _get_monitor(module)


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

datadog_monitor
##### Summary:

Datadog allows monitors to define multiple levels. When monitoring a metric e.g., one can define an alert that triggers a warning when the metric is `>= 1` and an alert when it is `>= 2`. These levels are called `thresholds` in the [Datadog API](http://docs.datadoghq.com/api/#monitors) and can be defined on monitors of the types `metric alert` and `service check`.
Before this PR, the `datadog_monitor` module only allowed `thresholds` to be defined for `metric alerts`.

In order to make sense of the `threshold` options default value, I had to split it. For service checks, the default value is still `{'ok': 1, 'critical': 1, 'warning': 1}`. For metric alerts no thresholds are defined by default. This is compliant with the [Datadog API docs](http://docs.datadoghq.com/api/#monitors):

> METRIC ALERT OPTIONS
> 
> These options only apply to metric alerts.
> thresholds a dictionary of thresholds by threshold type. Currently we have two threshold types for metric alerts: critical and warning. Critical is defined in the query, but can also be specified in this option. Warning threshold can only be specified using the thresholds option.
> Example: {'critical': 90, 'warning': 80}
> 
> SERVICE CHECK OPTIONS
> 
> These options only apply to service checks and will be ignored for other monitor types.
> thresholds a dictionary of thresholds by status. Because service checks can have multiple thresholds, we don't define them directly in the query.
> Default: {'ok': 1, 'critical': 1, 'warning': 1}
##### Example:

**Usage:**

```
- name: Monitor the remaining capacity in Autoscaling-Group                                                                                     
  datadog_monitor:
    name: Remaining slots in Autoscaling Group low - Cluster Autoscaling might reach the limit soon
    query: "max(last_5m):(min:aws.autoscaling.group_max_size{[...]} - max:aws.autoscaling.group_desired_capacity{[...]}) <= 1"
    message: "You might want to increase the max size of the autoscaling-group"
    notify_no_data: False
    type: metric alert
    state: present
    thresholds:
      critical: 1
      warning: 2
    api_key: "{{ api_key }}"
    app_key: "{{ app_key }}"
```

**Execution:**

```
TASK [monitor_provisioner : Monitor remaining capacity in Autoscaling-Group] ***
task path: [...]/roles/monitor_provisioner/tasks/main.yaml:28

ESTABLISH LOCAL CONNECTION FOR USER: seiffert
localhost EXEC ( umask 22 && mkdir -p "$( echo $HOME/.ansible/tmp/ansible-tmp-1458242747.44-239115222330744 )" && echo "$( echo $HOME/.ansible/tmp/ansible-tmp
-1458242747.44-239115222330744 )" )
localhost PUT /var/folders/np/83xy439d6_5988v01qhl3yyh0000gn/T/tmpU7qXgE TO /Users/seiffert/.ansible/tmp/ansible-tmp-1458242747.44-239115222330744/datadog_mon
itor
localhost EXEC LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 python /Users/seiffert/.ansible/tmp/ansible-tmp-1458242747.44-239115222330744/datad
og_monitor; rm -rf "/Users/seiffert/.ansible/tmp/ansible-tmp-1458242747.44-239115222330744/" > /dev/null 2>&1
changed: [localhost] => {"changed": true, "invocation": {"module_args": {"api_key": "[...]", "app_key": "[...]", "escalation_message": null, "message": "You might want to increase the max size of the autoscaling-group", 
"name": "Remaining slots in Autoscaling Group low - Cluster Autoscaling might reach the limit soon", "no_data_timeframe": null, "notify_audit": false, "
notify_no_data": false, "query": "max(last_5m):(min:aws.autoscaling.group_max_size{[...]} - max:aws.autoscaling.group_desired_capacity{[...]}) <= 1", "renotify_interval": null, "silenced": null, "state": "present", "thresholds": {"critical": 1, "warning": 2}, "timeout_h": null, "type": "
metric alert"}, "module_name": "datadog_monitor"}, "msg": {"created": "2016-03-17T17:25:15.921081+00:00", "created_at": 1458235515000, "id": 519317, "message"
: "You might want to increase the max size of the autoscaling-group", "modified": "2016-03-17T19:25:48.417526+00:00", "multi
": false, "name": "Remaining slots in Autoscaling Group low - Cluster Autoscaling might reach the limit soon", "options": {"escalation_message": null, "
no_data_timeframe": null, "notify_audit": false, "notify_no_data": false, "renotify_interval": null, "silenced": {}, "thresholds": {"critical": 1.0, "warning"
: 2.0}, "timeout_h": null}, "org_id": 31585, "overall_state": "No Data", "query": "max(last_5m):(min:aws.autoscaling.group_max_size{[...]} - max
:aws.autoscaling.group_desired_capacity{[...]}) <= 1", "tags": [], "type": "query alert"}}
```
