### PR TITLE
monit startup fix

### DIFF
--- a/monitoring/monit.py
+++ b/monitoring/monit.py
@@ -127,9 +127,8 @@ def main():
                 module.exit_json(changed=True)
             status = run_command('reload')
             if status == '':
-                module.fail_json(msg='%s process not configured with monit' % name, name=name, state=state)
-            else:
-                module.exit_json(changed=True, name=name, state=state)
+                wait_for_monit_to_stop_pending()
+            module.exit_json(changed=True, name=name, state=state)
         module.exit_json(changed=False, name=name, state=state)
 
     wait_for_monit_to_stop_pending()


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

monit
##### Summary:

When using `state=present` to load new configurations, the module doesn't honor monit's "pending" state. This change simply waits for up too the timeout period for a new service configuration to appear before erroring out.
