### PR TITLE
Fix vmware_portgroup throwing an error if port group already exists

### DIFF
--- a/cloud/vmware/vmware_portgroup.py
+++ b/cloud/vmware/vmware_portgroup.py
@@ -106,6 +106,9 @@ def main():
             raise SystemExit("Unable to locate Physical Host.")
         host_system = host.keys()[0]
 
+        if find_host_portgroup_by_name(host_system, portgroup_name):
+            module.exit_json(changed=False)
+
         changed = create_port_group(host_system, portgroup_name, vlan_id, switch_name)
 
         module.exit_json(changed=changed)


### PR DESCRIPTION
##### Issue Type:

<!-- Please pick one and delete the rest: -->
- Bugfix Pull Request
##### Plugin Name:

vmware_portgroup
##### Summary:

vmware_portgroup is not idempotent - running the play twice throws an error. This fix will prevent the error from happening, but it doesn't add any additional functionality.

Opening this pull request in response to the previous code review.
The pull request to ansible module_utils got closed https://github.com/ansible/ansible/pull/15002 so this one is possible now.
##### Example:

The error looked like this

```
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_args": {"hostname": "192.168.41.162", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "portgroup_name": "network-1", "switch_name": "switch-1", "username": "root", "validate_certs": false, "vlan_id": 0}, "module_name": "vmware_portgroup"}, "msg": "A specified parameter was not correct: "}
```

and not it passes

```
ok: [localhost] => {"changed": false, "invocation": {"module_args": {"hostname": "192.168.41.162", "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "portgroup_name": "network-1", "switch_name": "switch-1", "username": "root", "validate_certs": false, "vlan_id": 0}, "module_name": "vmware_portgroup"}}
```
