### PR TITLE
Reindent with_items, fix #1849

### DIFF
--- a/files/blockinfile.py
+++ b/files/blockinfile.py
@@ -144,10 +144,10 @@ EXAMPLES = r"""
     block: |
       {{item.name}} {{item.ip}}
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{item.name}}"
-    with_items:
-        - { name: host1, ip: 10.10.1.10 }
-        - { name: host2, ip: 10.10.1.11 }
-        - { name: host3, ip: 10.10.1.12 }
+  with_items:
+      - { name: host1, ip: 10.10.1.10 }
+      - { name: host2, ip: 10.10.1.11 }
+      - { name: host3, ip: 10.10.1.12 }
 """
 
 


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

blockinfile
##### Summary:

the example is not correctly indented, as reported in #1849
