### PR TITLE
Add proper type to path and link

### DIFF
--- a/system/alternatives.py
+++ b/system/alternatives.py
@@ -67,8 +67,8 @@ def main():
     module = AnsibleModule(
         argument_spec = dict(
             name = dict(required=True),
-            path = dict(required=True),
-            link = dict(required=False),
+            path = dict(required=True, type='path'),
+            link = dict(required=False, type='path'),
         ),
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

alternatives
##### Summary:

Add proper type to path and link
Since both of them are pathx, it should be checked using the
proper type.
