### PR TITLE
Fix ssl to be a bool, required to fix #1732

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -225,7 +225,7 @@ def main():
             database=dict(required=True, aliases=['db']),
             name=dict(required=True, aliases=['user']),
             password=dict(aliases=['pass']),
-            ssl=dict(default=False),
+            ssl=dict(default=False, type='bool'),
             roles=dict(default=None, type='list'),
             state=dict(default='present', choices=['absent', 'present']),
             update_password=dict(default="always", choices=["always", "on_create"]),


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

mongo_db_user
##### Summary:

ssl is supposed to be a bool, not a string. Since this was changed recently, it break type conversion and pymongo complain ( see  #1869 )
