### PR TITLE
Use no_log for the password for maven_artifact module

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -299,7 +299,7 @@ def main():
             extension = dict(default='jar'),
             repository_url = dict(default=None),
             username = dict(default=None),
-            password = dict(default=None),
+            password = dict(default=None, no_log=True),
             state = dict(default="present", choices=["present","absent"]), # TODO - Implement a "latest" state
             dest = dict(type="path", default=None),
             validate_certs = dict(required=False, default=True, type='bool'),


### PR DESCRIPTION
##### Issue Type:
- Bugfix Pull Request
##### Plugin Name:

maven_artifact
##### Summary:

Tag password with no_log, to avoid security sensitive data to leak.
