### PR TITLE
Allow passing domain name on os_project

### DIFF
--- a/cloud/openstack/os_project.py
+++ b/cloud/openstack/os_project.py
@@ -161,6 +161,22 @@ def main():
     state = module.params['state']
 
     try:
+        if domain:
+            opcloud = shade.operator_cloud(**module.params)
+            try:
+                # We assume admin is passing domain id
+                dom = opcloud.get_domain(domain)['id']
+                domain = dom
+            except:
+                # If we fail, maybe admin is passing a domain name.
+                # Note that domains have unique names, just like id.
+                try:
+                    dom = opcloud.search_domains(filters={'name': domain})[0]['id']
+                    domain = dom
+                except:
+                    # Ok, let's hope the user is non-admin and passing a sane id
+                    pass
+        
         cloud = shade.openstack_cloud(**module.params)
         project = cloud.get_project(name)
 


### PR DESCRIPTION
##### Issue Type:
- Feature Pull Request
##### Plugin Name:

os_project
##### Summary:

Domain names are unique, just like domain ids.
If user authenticated on the Ansible module is a cloud admin, he/she should be able
to pass a domain name, search it, and once we have it we pass the domain id value
as required on the create_project shade call.
##### Example:

```
ubuntu@devstack:~$ cat test_os_domain.yml 

---
- hosts: localhost
  connection: local
  gather_facts: false
  tasks:
  - os_project:
      cloud: devstack-admin
      state: present
      name: openstackci
      description: OpenStack CI project
      domain_id: infra

ubuntu@devstack:~$ ansible-playbook -i inventory test_os_domain.yml -e "@resources.yml" -vvv
No config file found; using defaults

PLAYBOOK: test_os_domain.yml ***************************************************
1 plays in test_os_domain.yml

PLAY [localhost] ***************************************************************

TASK [os_project] **************************************************************
task path: /home/ubuntu/test_os_domain.yml:6
ESTABLISH LOCAL CONNECTION FOR USER: ubuntu
localhost EXEC /bin/sh -c '( umask 22 && mkdir -p "` echo $HOME/.ansible/tmp/ansible-tmp-1458646189.42-108482931610329 `" && echo "` echo $HOME/.ansible/tmp/ansible-tmp-1458646189.42-108482931610329 `" )'
localhost PUT /tmp/tmpeH44h1 TO /home/ubuntu/.ansible/tmp/ansible-tmp-1458646189.42-108482931610329/os_project
localhost EXEC /bin/sh -c 'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/env python /home/ubuntu/.ansible/tmp/ansible-tmp-1458646189.42-108482931610329/os_project; rm -rf "/home/ubuntu/.ansible/tmp/ansible-tmp-1458646189.42-108482931610329/" > /dev/null 2>&1'
changed: [localhost] => {"changed": true, "invocation": {"module_args": {"api_timeout": null, "auth": null, "auth_type": null, "availability_zone": null, "cacert": null, "cert": null, "cloud": "devstack-admin", "description": "OpenStack CI project", "enabled": true, "endpoint_type": "public", "key": null, "name": "openstackci", "region_name": null, "state": "present", "timeout": 180, "verify": true, "wait": true}, "module_name": "os_project"}, "project": {"HUMAN_ID": false, "NAME_ATTR": "name", "description": "OpenStack CI project", "domain_id": "92d5bcbeb0da4227b31f276a552d3700", "enabled": true, "human_id": null, "id": "2f394d2be66c4f3ab18378e8af7f1b24", "is_domain": false, "links": {"self": "http://192.168.200.12:35357/v3/projects/2f394d2be66c4f3ab18378e8af7f1b24"}, "name": "openstackci", "parent_id": "92d5bcbeb0da4227b31f276a552d3700", "project_name": "openstackci"}}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```
