### PR TITLE
Add quotes and equals for set option documentation

### DIFF
--- a/network/openvswitch_port.py
+++ b/network/openvswitch_port.py
@@ -71,7 +71,7 @@ EXAMPLES = '''
 
 # Creates port eth6 and set ofport equal to 6.
 - openvswitch_port: bridge=bridge-loop port=eth6 state=present
-                    set Interface eth6 ofport_request=6
+                    set="Interface eth6 ofport_request=6"
 
 # Assign interface id server1-vifeth6 and mac address 52:54:00:30:6d:11
 # to port vifeth6 and setup port to be managed by a controller.


### PR DESCRIPTION
##### Issue Type:
- Docs Pull Request
##### Plugin Name:

openvswitch_port
##### Summary:

set is an option for the openvswitch_port module, however the documentation
example omitted the equals sign and quotes around the option value.
