### PR TITLE
Remove dead code from pacman module

### DIFF
--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -301,9 +301,6 @@ def main():
 
     pacman_path = module.get_bin_path('pacman', True)
 
-    if not os.path.exists(pacman_path):
-        module.fail_json(msg="cannot find pacman, in path %s" % (pacman_path))
-
     p = module.params
 
     # normalize the state parameter


### PR DESCRIPTION
The manual check to see if get_bin_path() returned anything is
redundant, because we pass True to the required parameter of
get_bin_path(). This automatically causes the task to fail if the pacman
binary isn't available. Therefore, the code within the if statement
being removed is never called.
