### PR TITLE
Added modules to manage Atomic Host Platform (host and image)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -117,7 +117,7 @@ install:
   - pip install git+https://github.com/ansible/ansible.git@devel#egg=ansible
   - pip install git+https://github.com/sivel/ansible-testing.git#egg=ansible_testing
 script:
-  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py|database/influxdb/influxdb.*\.py|database/mssql/mssql_db\.py|/letsencrypt\.py|network/f5/bigip.*\.py|bmc/ipmi/.*\.py' .
+  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py|database/influxdb/influxdb.*\.py|database/mssql/mssql_db\.py|/letsencrypt\.py|network/f5/bigip.*\.py|bmc/ipmi/.*\.py|system/atomic_.*\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
   - python3.4 -m compileall -fq . -x $(echo "$PY3_EXCLUDE_LIST"| tr ' ' '|')

--- a/system/atomic_host.py
+++ b/system/atomic_host.py
@@ -25,18 +25,24 @@ description:
     - Rebooting of Atomic host platform should be done outside this module
 version_added: "2.2"
 author: "Saravanan KR @krsacme"
+notes:
+    - Host should be an atomic platform (verified by existence of '/run/ostree-booted' file)
 options:
     revision:
         description:
           - The version number of the atomic host to be deployed. Providing ```latest``` will upgrade to the latest available version.
         required: false
         default: latest
+        aliases: ["version"]
 '''
 
 EXAMPLES = '''
 
 # Upgrade the atomic host platform to the latest version (atomic host upgrade)
 - atomic_host: revision=latest
+
+# Deploy a specific revision as the atomic host (atomic host deploy 23.130)
+- atomic_host: revision=23.130
 
 '''
 
@@ -74,14 +80,13 @@ def core(module):
 def main():
     module = AnsibleModule(
                 argument_spec = dict(
-                    revision = dict(default='latest', required=False),
+                    revision = dict(default='latest', required=False, aliases=["version"]),
                 ),
             )
 
-    # Verify that the platform supports atomic command
-    rc, out, err = module.run_command('atomic -v', check_rc=False)
-    if rc != 0:
-        module.fail_json(msg="Error in running atomic command", err=err)
+    # Verify that the platform is atomic host
+    if not os.path.exists("/run/ostree-booted"):
+        module.fail_json(msg="Module atomic_host is applicable for Atomic Host Platforms only")
 
     try:
         core(module)

--- a/system/atomic_host.py
+++ b/system/atomic_host.py
@@ -1,0 +1,95 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public licenses
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION='''
+---
+module: atomic_host
+short_description: Manage the atomic host platform
+description:
+    - Manage the atomic host platform
+    - Rebooting of Atomic host platform should be done outside this module
+version_added: "2.2"
+author: "Saravanan KR @krsacme"
+options:
+    revision:
+        description:
+          - The version number of the atomic host to be deployed. Providing ```latest``` will upgrade to the latest available version.
+        required: false
+        default: latest
+'''
+
+EXAMPLES = '''
+
+# Upgrade the atomic host platform to the latest version (atomic host upgrade)
+- atomic_host: revision=latest
+
+'''
+
+RETURN = '''
+msg:
+    description: The command standard output
+    returned: always
+    type: string
+    sample: 'Already on latest'
+'''
+
+def core(module):
+    revision = module.params['revision']
+    args = []
+
+    if revision == 'latest':
+        args = ['atomic', 'host', 'upgrade']
+    else:
+        args = ['atomic', 'host', 'deploy', revision]
+
+    out = {}
+    err = {}
+    rc = 0
+
+    rc, out, err = module.run_command(args, check_rc=False)
+
+    if rc == 77 and revision == 'latest':
+        module.exit_json(msg="Already on latest")
+    elif rc != 0:
+        module.fail_json(rc=rc, msg=err)
+    else:
+        module.exit_json(msg=out, changed=True)
+
+
+def main():
+    module = AnsibleModule(
+                argument_spec = dict(
+                    revision = dict(default='latest', required=False),
+                ),
+            )
+
+    # Verify that the platform supports atomic command
+    rc, out, err = module.run_command('atomic -v', check_rc=False)
+    if rc != 0:
+        module.fail_json(msg="Error in running atomic command", err=err)
+
+    try:
+        core(module)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/system/atomic_host.py
+++ b/system/atomic_host.py
@@ -27,6 +27,9 @@ version_added: "2.2"
 author: "Saravanan KR @krsacme"
 notes:
     - Host should be an atomic platform (verified by existence of '/run/ostree-booted' file)
+requirements:
+  - atomic
+  - "python >= 2.6"
 options:
     revision:
         description:
@@ -58,6 +61,8 @@ def core(module):
     revision = module.params['revision']
     args = []
 
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
+
     if revision == 'latest':
         args = ['atomic', 'host', 'upgrade']
     else:
@@ -70,7 +75,7 @@ def core(module):
     rc, out, err = module.run_command(args, check_rc=False)
 
     if rc == 77 and revision == 'latest':
-        module.exit_json(msg="Already on latest")
+        module.exit_json(msg="Already on latest", changed=False)
     elif rc != 0:
         module.fail_json(rc=rc, msg=err)
     else:

--- a/system/atomic_image.py
+++ b/system/atomic_image.py
@@ -29,6 +29,7 @@ notes:
     - Host should be support ```atomic``` command
 requirements:
   - atomic
+  - "python >= 2.6"
 options:
     name:
         description:
@@ -81,6 +82,8 @@ def core(module):
     state = module.params['state']
     started = module.params['started']
     is_upgraded = False
+
+    module.run_command_environ_update = dict(LANG='C', LC_ALL='C', LC_MESSAGES='C')
 
     if state == 'present' or state == 'latest':
         if state == 'latest':

--- a/system/atomic_image.py
+++ b/system/atomic_image.py
@@ -1,0 +1,128 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION='''
+---
+module: atomic_image
+short_description: Manage the container images on the atomic host platform
+description:
+    - Manage the container images on the atomic host platform
+    - Allows to execute the commands on the container images
+    - Commands ```install``` and ```run``` will download the container image if not present already
+version_added: "2.2"
+author: "Saravanan KR @krsacme"
+notes:
+    - Host should be an atomic platform (verified by existence of '/run/ostree-booted' file)
+requirements:
+  - atomic
+options:
+    name:
+        description:
+          - Name of the container image
+        required: True
+        default: null
+    upgrade:
+        description:
+          - Forcefully upgrade if the container, even if the container is already running
+        required: False
+        choices: ["yes", "no"]
+        default: no
+    state:
+        description:
+          - The state of the container image
+        required: False
+        choices: ["started", "stopped"]
+        default: started
+'''
+
+EXAMPLES = '''
+
+# Execute the run command on rsyslog container image (atomic run rhel7/rsyslog)
+- atomic_image: name=rhel7/rsyslog state=started
+
+'''
+
+RETURN = '''
+msg:
+    description: The command standard output
+    returned: always
+    type: string
+    sample: [u'Using default tag: latest ...']
+'''
+
+def do_upgrade(module, image):
+    args = ['atomic', 'update', '--force', image]
+    rc, out, err = module.run_command(args, check_rc=False)
+    if rc != 0: # something went wrong emit the msg
+        module.fail_json(rc=rc, msg=err)
+    elif 'Image is up to date' in out:
+        return False
+
+    return True
+
+
+def core(module):
+    image = module.params['name']
+    upgrade = module.params['upgrade']
+    state = module.params['state']
+    is_upgraded = False
+
+    if state == 'started':
+        if upgrade:
+            is_upgraded = do_upgrade(module, image)
+        args = ['atomic', 'run', image]
+    elif state == 'stopped':
+        args = ['atomic', 'stop', image]
+
+    out = {}
+    err = {}
+    rc = 0
+    rc, out, err = module.run_command(args, check_rc=False)
+
+    if rc != 0: # something went wrong emit the msg
+        module.fail_json(rc=rc, msg=err)
+    elif state == 'started' and 'Container is running' in out:
+        module.exit_json(result=out, changed=is_upgraded)
+    else:
+        module.exit_json(msg=out, changed=True)
+
+
+def main():
+    module = AnsibleModule(
+                argument_spec = dict(
+                    name    = dict(default=None, required=True),
+                    upgrade = dict(default='no', type='bool'),
+                    state   = dict(default='started', choices=['started', 'stopped']),
+                ),
+            )
+
+    # Verify that the platform supports atomic command
+    rc, out, err = module.run_command('atomic -v', check_rc=False)
+    if rc != 0:
+        module.fail_json(msg="Error in running atomic command", err=err)
+
+    try:
+        core(module)
+    except Exception as e:
+        module.fail_json(msg=str(e))
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

atomic_host
atomic_image
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = /usr/share/my_modules/
```
##### SUMMARY

Atomic Host Plaform provides atomic command to manage the host and to manage the container images on the host. Details of the command can be found at [1]. Added 2 modules in here:
atomic_host :- Module to mange the host itself, upgrade or rollback
atomic_image :- Module to manage the container images

[1] http://www.projectatomic.io/docs/usr-bin-atomic/, https://github.com/projectatomic/atomic/
