### PR TITLE
Add shade version check to os_flavor_facts

### DIFF
--- a/cloud/openstack/os_flavor_facts.py
+++ b/cloud/openstack/os_flavor_facts.py
@@ -23,6 +23,9 @@ try:
 except ImportError:
     HAS_SHADE = False
 
+from distutils.version import StrictVersion
+
+
 DOCUMENTATION = '''
 ---
 module: os_flavor_facts
@@ -200,6 +203,9 @@ def main():
             if ram:
                 filters['ram'] = ram
             if filters:
+                # Range search added in 1.5.0
+                if StrictVersion(shade.__version__) < StrictVersion('1.5.0'):
+                    module.fail_json(msg="Shade >= 1.5.0 needed for this functionality")
                 flavors = cloud.range_search(flavors, filters)
 
         if limit is not None:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/openstack/os_flavor_facts.py
##### ANSIBLE VERSION

2.1
##### SUMMARY

The range_search() API was added to the shade library in version 1.5.0 so let's check for that and let the user know they need tovupgrade if they try to use it.
