### PR TITLE
system/puppet: add --tags parameter

### DIFF
--- a/system/puppet.py
+++ b/system/puppet.py
@@ -112,6 +112,9 @@ EXAMPLES = '''
 # Run puppet using a specific piece of Puppet code. Has no effect with a
 # puppetmaster.
 - puppet: execute='include ::mymodule'
+
+# Run puppet using a specific tags
+- puppet: tags=update,nginx
 '''
 
 

--- a/system/puppet.py
+++ b/system/puppet.py
@@ -80,6 +80,12 @@ options:
     required: false
     default: None
     version_added: "2.1"
+  tags:
+    description:
+      - Comma-separated list of puppet tags without spaces to be used.
+    required: false
+    default: None
+    version_added: "2.1"
   execute:
     description:
       - Execute a specific piece of Puppet code. It has no effect with
@@ -147,6 +153,7 @@ def main():
             facter_basename=dict(default='ansible'),
             environment=dict(required=False, default=None),
             certname=dict(required=False, default=None),
+            tags=dict(required=False, default=None),
             execute=dict(required=False, default=None),
         ),
         supports_check_mode=True,
@@ -211,6 +218,8 @@ def main():
             cmd += " --show_diff"
         if p['environment']:
             cmd += " --environment '%s'" % p['environment']
+        if p['tags']:
+            cmd += " --tags '%s'" % p['tags']
         if p['certname']:
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
@@ -227,6 +236,8 @@ def main():
             cmd += " --certname='%s'" % p['certname']
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
+        if p['tags']:
+            cmd += " --tags '%s'" % p['tags']
         if module.check_mode:
             cmd += "--noop "
         else:

--- a/system/puppet.py
+++ b/system/puppet.py
@@ -82,7 +82,7 @@ options:
     version_added: "2.1"
   tags:
     description:
-      - Comma-separated list of puppet tags without spaces to be used.
+      - A comma-separated list of puppet tags to be used.
     required: false
     default: None
     version_added: "2.1"
@@ -156,7 +156,7 @@ def main():
             facter_basename=dict(default='ansible'),
             environment=dict(required=False, default=None),
             certname=dict(required=False, default=None),
-            tags=dict(required=False, default=None),
+            tags=dict(required=False, default=None, type='list'),
             execute=dict(required=False, default=None),
         ),
         supports_check_mode=True,
@@ -222,7 +222,7 @@ def main():
         if p['environment']:
             cmd += " --environment '%s'" % p['environment']
         if p['tags']:
-            cmd += " --tags '%s'" % p['tags']
+            cmd += " --tags '%s'" % ','.join(p['tags'])
         if p['certname']:
             cmd += " --certname='%s'" % p['certname']
         if module.check_mode:
@@ -240,7 +240,7 @@ def main():
         if p['execute']:
             cmd += " --execute '%s'" % p['execute']
         if p['tags']:
-            cmd += " --tags '%s'" % p['tags']
+            cmd += " --tags '%s'" % ','.join(p['tags'])
         if module.check_mode:
             cmd += "--noop "
         else:


### PR DESCRIPTION
--tags [1] is used to apply a part of the node’s catalog.

In puppet:
puppet agent --tags update,monitoring

In ansible:
puppet: tags=update,monitoring

[1] https://docs.puppetlabs.com/puppet/latest/reference/lang_tags.html#restricting-catalog-runs
