### PR TITLE
cloudstack: cs_template: bug fixes

### DIFF
--- a/cloud/cloudstack/cs_template.py
+++ b/cloud/cloudstack/cs_template.py
@@ -168,7 +168,7 @@ options:
   display_text:
     description:
       - Display text of the template.
-    required: true
+    required: false
     default: null
   state:
     description:

--- a/cloud/cloudstack/cs_template.py
+++ b/cloud/cloudstack/cs_template.py
@@ -89,8 +89,8 @@ options:
     default: false
   cross_zones:
     description:
-      - Whether the template should be syned across zones.
-      - Only used if C(state) is present.
+      - Whether the template should be syned or removed across zones.
+      - Only used if C(state) is present or absent.
     required: false
     default: false
   project:
@@ -220,6 +220,7 @@ EXAMPLES = '''
 - local_action:
     module: cs_template
     name: systemvm-4.2
+    cross_zones: yes
     state: absent
 '''
 
@@ -560,7 +561,9 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
 
             args            = {}
             args['id']      = template['id']
-            args['zoneid']  = self.get_zone(key='id')
+
+            if not self.module.params.get('cross_zones'):
+                args['zoneid']  = self.get_zone(key='id')
 
             if not self.module.check_mode:
                 res = self.cs.deleteTemplate(**args)
@@ -620,6 +623,7 @@ def main():
         required_together=required_together,
         mutually_exclusive = (
             ['url', 'vm'],
+            ['zone', 'cross_zones'],
         ),
         supports_check_mode=True
     )

--- a/cloud/cloudstack/cs_template.py
+++ b/cloud/cloudstack/cs_template.py
@@ -470,6 +470,12 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
 
 
     def register_template(self):
+        required_params = [
+            'format',
+            'url',
+            'hypervisor',
+        ]
+        self.module.fail_on_missing_params(required_params=required_params)
         template = self.get_template()
         if not template:
             self.result['changed'] = True
@@ -536,9 +542,6 @@ class AnsibleCloudStackTemplate(AnsibleCloudStack):
         args['url']    = self.module.params.get('url')
         args['mode']   = self.module.params.get('mode')
         args['zoneid'] = self.get_zone(key='id')
-
-        if not args['url']:
-            self.module.fail_json(msg="Missing required arguments: url")
 
         self.result['changed'] = True
 
@@ -613,14 +616,9 @@ def main():
         poll_async = dict(type='bool', default=True),
     ))
 
-    required_together = cs_required_together()
-    required_together.extend([
-        ['format', 'url', 'hypervisor'],
-    ])
-
     module = AnsibleModule(
         argument_spec=argument_spec,
-        required_together=required_together,
+        required_together=cs_required_together(),
         mutually_exclusive = (
             ['url', 'vm'],
             ['zone', 'cross_zones'],


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cs_template
##### ANSIBLE VERSION

```
2.0
```
##### SUMMARY

`state=absent` did not remove template in all zones, only in one zone.
In this fix, we reused the `cross_zones` arg to also allow removal of templates across all zones. 
While users usually want to remove templates in all zones, implementing the fix this way is backwards compatible.
