### PR TITLE
The current module supporting F5 BIGIP pool creation does not support…

### DIFF
--- a/network/f5/bigip_pool.py
+++ b/network/f5/bigip_pool.py
@@ -393,11 +393,11 @@ def main():
 
     # sanity check user supplied values
 
-    if (host and not port) or (port and not host):
+    if (host and port is None) or (port is not None and not host):
         module.fail_json(msg="both host and port must be supplied")
 
-    if 1 > port > 65535:
-        module.fail_json(msg="valid ports must be in range 1 - 65535")
+    if 0 > port or port > 65535:
+        module.fail_json(msg="valid ports must be in range 0 - 65535")
 
     if monitors:
         if len(monitors) == 1:
@@ -505,6 +505,10 @@ def main():
                         set_action_on_service_down(api, pool, service_down_action)
                     result = {'changed': True}
                 if (host and port) and not member_exists(api, pool, address, port):
+                    if not module.check_mode:
+                        add_pool_member(api, pool, address, port)
+                    result = {'changed': True}
+                if (host and port == 0) and not member_exists(api, pool, address, port):
                     if not module.check_mode:
                         add_pool_member(api, pool, address, port)
                     result = {'changed': True}


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

Networking/F5/bigip_pool.py
##### ANSIBLE VERSION

```
ansible 2.0.0 (v2_final 816b20af0b) last updated 2016/03/25 16:14:47 (GMT -400)
```
##### SUMMARY

The current module supporting F5 BIGIP pool creation does not support a setup where the port number must be zero to signify the pool will listen on multiple ports. This change implements that functionality and fixes an illogical conditional.
