### PR TITLE
Allow port 0 as a valid pool member port

### DIFF
--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -341,11 +341,11 @@ def main():
 
     # sanity check user supplied values
 
-    if (host and not port) or (port and not host):
+    if (host and port is None) or (port is not None and not host):
         module.fail_json(msg="both host and port must be supplied")
 
-    if 1 > port > 65535:
-        module.fail_json(msg="valid ports must be in range 1 - 65535")
+    if 0 > port or port > 65535:
+        module.fail_json(msg="valid ports must be in range 0 - 65535")
 
     try:
         api = bigip_api(server, user, password, validate_certs)
@@ -427,4 +427,3 @@ def main():
 from ansible.module_utils.basic import *
 from ansible.module_utils.f5 import *
 main()
-


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

bigip_pool_member.py
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 5fdac707fd) last updated 2016/03/28 16:49:40 (GMT -700)
```
##### SUMMARY

Implements a fix similar to PR 1927.

The current bigip_pool_member module does not support specifying pool members with a port of 0. This functionality is required to support wildcard pool members. When a request is forwarded to a wildcard pool member, port translation is disabled automatically, and the same destination port requested by the client to the virtual server is used when connecting with the backend server. This change implements said functionality and corrects a non-functional bounds checking portion of code.
