### PR TITLE
do not set a default config for lxc containers

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -57,7 +57,6 @@ options:
         description:
           - Path to the LXC configuration file.
         required: false
-        default: /etc/lxc/default.conf
     lv_name:
         description:
           - Name of the logical volume, defaults to the container name.
@@ -1687,7 +1686,6 @@ def main():
             ),
             config=dict(
                 type='str',
-                default='/etc/lxc/default.conf'
             ),
             vg_name=dict(
                 type='str',

--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -57,6 +57,7 @@ options:
         description:
           - Path to the LXC configuration file.
         required: false
+        default: null
     lv_name:
         description:
           - Name of the logical volume, defaults to the container name.


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lxc_container
##### ANSIBLE VERSION

2.0.0-0.5.beta3
##### SUMMARY

do not set a default config for lxc containers otherwise deploying user-containers fail as these require information from ~/.config/lxc/default.conf. that file is loaded by default by the the LXC if no --config was supplied

Signed-off-by: Evgeni Golov evgeni@golov.de
