### PR TITLE
restore version_added in dynamodb_table.py

### DIFF
--- a/cloud/amazon/dynamodb_table.py
+++ b/cloud/amazon/dynamodb_table.py
@@ -18,6 +18,7 @@ DOCUMENTATION = """
 ---
 module: dynamodb_table
 short_description: Create, update or delete AWS Dynamo DB tables.
+version_added: "2.0"
 description:
   - Create or delete AWS Dynamo DB tables.
   - Can update the provisioned throughput on existing tables.


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

dynamodb_table
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /home/bob/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

```
make -C docsite
rendering: docker_login
rendering: dpkg_selections
rendering: dynamodb_table
*** ERROR: missing version_added in: dynamodb_table ***
make: *** [modules] Error 1
```

After this works

Spotted while looking at test-docs.sh which is disabled in Travis (I'll look at getting this running again)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-extras/1935)

<!-- Reviewable:end -->
