### PR TITLE
fix security vulnerability in lxc module

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -571,7 +571,7 @@ def create_script(command):
         f.close()
 
     # Ensure the script is executable.
-    os.chmod(script_file, 1755)
+    os.chmod(script_file, 0700)
 
     # Get temporary directory.
     tempdir = tempfile.gettempdir()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lxc
##### SUMMARY

octal/decimal confusion makes script world-writable before executing it.

```
before:
  $ ls testit
  --wx-ws-wt 1 chris chris 0 Mar 31 22:42 testit

after:
  $ ls testit
  -rwx------ 1 chris chris 0 Mar 31 22:42 testit
```
