### PR TITLE
New preserve_node parameter to skip unreferenced node removal

### DIFF
--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -114,6 +114,13 @@ options:
             - Pool member ratio weight. Valid values range from 1 through 100. New pool members -- unless overriden with this value -- default to 1.
         required: false
         default: null
+    preserve_node:
+        description:
+            - When state is absent and the pool member is no longer referenced in other pools, the default behavior removes the unused node object. Setting this to 'yes' disables this behavior.
+        required: false
+        default: 'no'
+        choices: ['yes', 'no']
+        version_added: 2.1
 '''
 
 EXAMPLES = '''
@@ -317,7 +324,8 @@ def main():
             connection_limit = dict(type='int'),
             description = dict(type='str'),
             rate_limit = dict(type='int'),
-            ratio = dict(type='int')
+            ratio = dict(type='int'),
+            preserve_node = dict(type='bool', default=False)
         )
     )
 
@@ -337,6 +345,7 @@ def main():
     host = module.params['host']
     address = fq_name(partition, host)
     port = module.params['port']
+    preserve_node = module.params['preserve_node']
 
 
     # sanity check user supplied values
@@ -357,8 +366,11 @@ def main():
             if member_exists(api, pool, address, port):
                 if not module.check_mode:
                     remove_pool_member(api, pool, address, port)
-                    deleted = delete_node_address(api, address)
-                    result = {'changed': True, 'deleted': deleted}
+                    if preserve_node:
+                        result = {'changed': True}
+                    else:
+                        deleted = delete_node_address(api, address)
+                        result = {'changed': True, 'deleted': deleted}
                 else:
                     result = {'changed': True}
 


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request
##### COMPONENT NAME

bigip_pool_member.py
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 5fdac707fd) last updated 2016/03/28 16:49:40 (GMT -700)
```
##### SUMMARY

Implements the feature request in #1569.

When state is `absent` and the pool member is no longer referenced in other pools, the default module behavior removes the unused node object. A new parameter, `preserve_node`, has been introduced to override this behavior.
