### PR TITLE
Use no_log=True for campfire module to avoid leaks

### DIFF
--- a/notification/campfire.py
+++ b/notification/campfire.py
@@ -73,7 +73,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             subscription=dict(required=True),
-            token=dict(required=True),
+            token=dict(required=True, no_log=True),
             room=dict(required=True),
             msg=dict(required=True),
             notify=dict(required=False,


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

campfire
