### PR TITLE
Add `active` and `inactive` states to the lvol module

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -300,8 +300,6 @@ def main():
     if state == 'present' and not size:
         if this_lv is None:
             module.fail_json(msg="No size given.")
-        else:
-            module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'])
 
     msg = ''
     if this_lv is None:
@@ -411,14 +409,14 @@ def main():
             lvchange_cmd = module.get_bin_path("lvchange", required=True)
             rc, _, err = module.run_command("%s -ay %s/%s" % (lvchange_cmd, vg, this_lv['name']))
             if rc == 0:
-                module.exit_json(changed=((not this_lv['active']) or changed))
+                module.exit_json(changed=((not this_lv['active']) or changed), vg=vg, lv=this_lv['name'], size=this_lv['size'])
             else:
                 module.fail_json(msg="Failed to activate logical volume %s" % (lv), rc=rc, err=err)
         else:
             lvchange_cmd = module.get_bin_path("lvchange", required=True)
             rc, _, err = module.run_command("%s -an %s/%s" % (lvchange_cmd, vg, this_lv['name']))
             if rc == 0:
-                module.exit_json(changed=(this_lv['active'] or changed))
+                module.exit_json(changed=(this_lv['active'] or changed), vg=vg, lv=this_lv['name'], size=this_lv['size'])
             else:
                 module.fail_json(msg="Failed to deactivate logical volume %s" % (lv), rc=rc, err=err)
 

--- a/system/lvol.py
+++ b/system/lvol.py
@@ -52,7 +52,7 @@ options:
       volume does not already exist then the C(size) option is required.
     required: false
   active:
-    version_added: "2.1"
+    version_added: "2.2"
     choices: [ "yes", "no" ]
     default: "yes"
     description:

--- a/system/lvol.py
+++ b/system/lvol.py
@@ -132,6 +132,12 @@ EXAMPLES = '''
 
 # Create a snapshot volume of the test logical volume.
 - lvol: vg=firefly lv=test snapshot=snap1 size=100m
+
+# Deactivate a logical volume
+- lvol: vg=firefly lv=test active=false
+
+# Create a deactivated logical volume
+- lvol: vg=firefly lv=test size=512g active=false
 '''
 
 import re

--- a/system/lvol.py
+++ b/system/lvol.py
@@ -338,6 +338,9 @@ def main():
             else:
                 module.fail_json(msg="Failed to remove logical volume %s" % (lv), rc=rc, err=err)
 
+        elif not size:
+            pass
+
         elif size_opt == 'l':
             ### Resize LV based on % value
             tool = None
@@ -377,9 +380,6 @@ def main():
                         module.exit_json(changed=False, vg=vg, lv=this_lv['name'], size=this_lv['size'])
                     else:
                         module.fail_json(msg="Unable to resize %s to %s%s" % (lv, size, size_unit), rc=rc, err=err)
-
-        elif not size:
-            pass
 
         else:
             ### resize LV based on absolute values

--- a/system/lvol.py
+++ b/system/lvol.py
@@ -402,14 +402,14 @@ def main():
             lvchange_cmd = module.get_bin_path("lvchange", required=True)
             rc, _, err = module.run_command("%s -ay %s/%s" % (lvchange_cmd, vg, this_lv['name']))
             if rc == 0:
-                module.exit_json(changed=(not this_lv['active']))
+                module.exit_json(changed=((not this_lv['active']) or changed))
             else:
                 module.fail_json(msg="Failed to activate logical volume %s" % (lv), rc=rc, err=err)
         elif state == 'inactive':
             lvchange_cmd = module.get_bin_path("lvchange", required=True)
             rc, _, err = module.run_command("%s -an %s/%s" % (lvchange_cmd, vg, this_lv['name']))
             if rc == 0:
-                module.exit_json(changed=this_lv['active'])
+                module.exit_json(changed=(this_lv['active'] or changed))
             else:
                 module.fail_json(msg="Failed to deactivate logical volume %s" % (lv), rc=rc, err=err)
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

lvol
##### ANSIBLE VERSION

2.1
##### SUMMARY

`lvol` lacks the ability to enable or disable a logical volume. My use case is having a VG persist across machine rebuilds - attaching that disk to a "new" machine means its volumes need to be activating before being used. My work around is to use the `command` module, but it seemed reasonable to add this to `lvol` itself.

The active and inactive states will do the right thing with 'changed', depending on the previous state of the volume.

```
TASK [lvol lv=test9-root state=active size=21G vg=containers] ****************
ok: [127.0.0.1]
```
