### PR TITLE
[zypper] Allow downgrading packages with zypper

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -181,7 +181,7 @@ def package_present(m, name, installed_state, package_type, disable_gpg_check, d
         # add global options before zypper command
         if disable_gpg_check:
             cmd.append('--no-gpg-checks')
-        cmd.extend(['install', '--auto-agree-with-licenses', '-t', package_type])
+        cmd.extend(['install', '--oldpackage', '--auto-agree-with-licenses', '-t', package_type])
         # add install parameter
         if disable_recommends and not old_zypper:
             cmd.append('--no-recommends')


### PR DESCRIPTION
##### zypper
##### ANSIBLE VERSION

```
ansible 1.9.4
```
##### SUMMARY

This change allows zypper to downgrade a package when requested to do so.
Currently, if the server has somepackage v2.0 and in your task file you have:

```
- zypper: name=somepackage-1.0 state=present
```

ansible will not install somepackage v1.0, and will leave v2.0 in the system.
By adding the `--oldpackage` option to the `zypper install` command, zypper WILL downgrade the package, which is what you intended.
The `--oldpackage` option has no effect if the package was not previously installed or if you are requesting to install an even newer version of the package.
