### PR TITLE
Escape room name in hipchat api v2 urls

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -147,7 +147,7 @@ def send_msg_v2(module, token, room, msg_from, msg, msg_format='text',
 
     POST_URL = api + NOTIFY_URI_V2
 
-    url = POST_URL.replace('{id_or_name}', room)
+    url = POST_URL.replace('{id_or_name}', urllib.pathname2url(room))
     data = json.dumps(body)
 
     if module.check_mode:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

hipchat
##### ANSIBLE VERSION

2.0.0.1
##### SUMMARY

Hipchat room names were not being encoded properly when using the hipchat v2 API. When the api is called with a room that contained special character name the URL would be mangled and the api would return a 400 response. 

The hipchat room name is now encoded using:  urllib.pathname2url

Before:

```
PLAY [all] ******************************************************************** 

TASK: [Send Hipchat notification AMI is finished baking] ********************** 
<localhost> REMOTE_MODULE hipchat room='release pipeline' api=https://api.hipchat.com/v2/ token=** msg='test message from Ansible! Hello!'
<localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1459975609.22-241864400016673 && echo $HOME/.ansible/tmp/ansible-tmp-1459975609.22-241864400016673']
<localhost> PUT /tmp/tmpzK2Ho6 TO /root/.ansible/tmp/ansible-tmp-1459975609.22-241864400016673/hipchat
<localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1459975609.22-241864400016673/hipchat; rm -rf /root/.ansible/tmp/ansible-tmp-1459975609.22-241864400016673/ >/dev/null 2>&1']
failed: [localhost] => {"failed": true}
msg: failed to send message, return status=400
...ignoring

```

After:

```
PLAY [all] ******************************************************************** 

TASK: [Send Hipchat notification AMI is finished baking] ********************** 
<localhost> REMOTE_MODULE hipchat room='release pipeline' api=https://api.hipchat.com/v2/ token=** msg='test message from Ansible! Hello!'
<localhost> EXEC ['/bin/sh', '-c', 'mkdir -p $HOME/.ansible/tmp/ansible-tmp-1459976273.55-137871830279509 && echo $HOME/.ansible/tmp/ansible-tmp-1459976273.55-137871830279509']
<localhost> PUT /tmp/tmp7s6_G7 TO /root/.ansible/tmp/ansible-tmp-1459976273.55-137871830279509/hipchat
<localhost> EXEC ['/bin/sh', '-c', u'LANG=en_US.UTF-8 LC_CTYPE=en_US.UTF-8 /usr/bin/python /root/.ansible/tmp/ansible-tmp-1459976273.55-137871830279509/hipchat; rm -rf /root/.ansible/tmp/ansible-tmp-1459976273.55-137871830279509/ >/dev/null 2>&1']
changed: [localhost] => {"changed": true, "msg": "test message from Ansible! Hello!", "msg_from": "Ansible", "room": "release pipeline"}

PLAY RECAP ******************************************************************** 
localhost                  : ok=1    changed=1    unreachable=0    failed=0   

```
