### PR TITLE
Lxc container config fixes

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -424,6 +424,8 @@ lxc_container:
             sample: True
 """
 
+import re
+
 try:
     import lxc
 except ImportError:
@@ -748,9 +750,10 @@ class LxcContainerManagement(object):
             key = key.strip()
             value = value.strip()
             new_entry = '%s = %s\n' % (key, value)
+            keyre = re.compile(r'%s(\s+)?=' % key)
             for option_line in container_config:
                 # Look for key in config
-                if option_line.startswith(key):
+                if keyre.match(option_line):
                     _, _value = option_line.split('=', 1)
                     config_value = ' '.join(_value.split())
                     line_index = container_config.index(option_line)

--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -745,6 +745,8 @@ class LxcContainerManagement(object):
 
         config_change = False
         for key, value in parsed_options:
+            key = key.strip()
+            value = value.strip()
             new_entry = '%s = %s\n' % (key, value)
             for option_line in container_config:
                 # Look for key in config


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

lxc_container
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 005dc84aa7) last updated 2016/04/10 12:57:27 (GMT +200)
  lib/ansible/modules/core: (detached HEAD c52f475c64) last updated 2016/04/10 12:57:46 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 5abb914315) last updated 2016/04/10 12:57:50 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

There are three bugs in the handling of `container_config` in `lxc_container`:
- entries that share the same prefix might end up overwritten or written in the wrong order
- duplicate entries with different whitespace are not handled properly
###### Example for 1:

old config:

```
lxc.network.ipv4.gateway=auto
lxc.network.ipv4=192.0.2.1
```

change `lxc.network.ipv4=192.0.2.1` to `lxc.network.ipv4=192.0.2.2` in the playbook and rerun it, you end up with the following config:

```
lxc.network.ipv4.gateway=auto
lxc.network.ipv4=192.0.2.2
lxc.network.ipv4=192.0.2.1
```
###### Example for 2:

the following will produce four entries, even though they are technically identical:

```
container_config:
  - "lxc.network.flags=up"
  - "lxc.network.flags =up"
  - "lxc.network.flags= up"
  - "lxc.network.flags = up"
```
