### PR TITLE
correct command line argument for nmcli autoconnect

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -630,7 +630,7 @@ class Nmcli(object):
             cmd.append('ipv6.dns')
             cmd.append(self.dns6)
         if self.autoconnect is not None:
-            cmd.append('autoconnect')
+            cmd.append('connection.autoconnect')
             cmd.append(self.autoconnect)
             # Can't use MTU with team
         return cmd


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

nmcli
##### ANSIBLE VERSION

```
ansible 1.9.4
  configured module search path = None
```
##### SUMMARY

When an existing connection is going to be modified the nmcli con mod command will be called. The property name for the autoconnect setting is wrong, it is not prefixed with 'connection.'. Likely just a small oversight since all other properties are correctly prefixed. Currently when trying to change the autoconnect properties (assuming connection named 'em1' exists already):

```
$ ansible somehost -m nmcli conn_name=em1 type=ethernet state=present autoconnect=yes  # or autoconnect=no
...
msg: Error: invalid <setting>.<property> 'autoconnect'.
```

With the named fix the autoconnect setting is correctly applied.
