### PR TITLE
Add os_stack module for create, update and delete stack

### DIFF
--- a/cloud/openstack/os_stack.py
+++ b/cloud/openstack/os_stack.py
@@ -1,0 +1,171 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+from time import sleep
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+DOCUMENTATION = '''
+---
+module: os_stack
+short_description: Add/Remove Heat Stack
+extends_documentation_fragment: openstack
+version_added: "2.0"
+author: "Mathieu Bultel (matbu)"
+description:
+   - Add or Remove a Stack to an OpenStack Heat
+options:
+    state:
+      description:
+        - Indicate desired state of the resource
+      choices: ['present', 'absent']
+      required: false
+      default: present
+    name:
+      description:
+        - Name of the stack that should be created
+      required: true
+      default: None
+    template:
+      description:
+        - Path of the template file to use for the stack creation
+      required: false
+      default: None
+    environment_files:
+      description:
+        - List of environment files that should be used for the stack creation
+      required: false
+      default: None
+    parameters:
+      description:
+        - Dictionary of parameters for the stack creation
+      required: false
+    rollback:
+      description:
+        - Rollback stack creation
+      required: false
+      default: false
+    timeout:
+      description:
+        - Maximum number of seconds to wait for the stack creation
+      required: false
+      default: 180
+requirements:
+    - "python >= 2.6"
+    - "shade"
+'''
+EXAMPLES = '''
+---
+- name: create stack
+  ignore_errors: True
+  register: stack_create
+  os_heat:
+    name: "{{ stack_name }}"
+    state: present
+    template: "/path/to/my_stack.yaml"
+    environment_files:
+    - /path/to/resource-registry.yaml
+    - /path/to/environment.yaml
+    parameters:
+        os_user: {{ os_user }}
+        os_password: {{ os_password }}
+        os_tenant: {{ os_tenant }}
+        os_auth_url: {{ os_auth_url }}
+        bmc_flavor: m1.medium
+        bmc_image: CentOS
+        key_name: default
+        private_net: {{ private_net_param }}
+        node_count: 2
+        name: undercloud
+        image: CentOS
+        my_flavor: m1.large
+        external_net: {{ external_net_param }}
+'''
+
+def _create_stack(module, stack, cloud):
+    try:
+        stack = cloud.create_stack(module.params['name'],
+                                       template_file=module.params['template'],
+                                       environment_files=module.params['environment_files'],
+                                       timeout=module.params['timeout'],
+                                       wait=True,
+                                       rollback=module.params['rollback'],
+                                       **module.params['parameters'])
+
+        stack = cloud.get_stack(stack.id, None)
+        if stack.stack_status == 'CREATE_COMPLETE':
+            return stack
+        else:
+            return False
+            module.fail_json(msg = "Failure in creating stack: ".format(stack))
+    except shade.OpenStackCloudException as e:
+        module.fail_json(msg=e.message)
+
+def _system_state_change(module, stack, cloud):
+    state = module.params['state']
+    if state == 'present':
+        if not stack:
+            return True
+    if state == 'absent' and stack:
+        return True
+    return False
+
+def main():
+
+    argument_spec = openstack_full_argument_spec(
+        name=dict(required=True),
+        template=dict(default=None),
+        environment_files=dict(default=None, type='list'),
+        parameters=dict(default={}, type='dict'),
+        rollback=dict(default=False),
+        timeout=dict(default=180),
+        state=dict(default='present', choices=['absent', 'present']),
+    )
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec,
+                           supports_check_mode=True,
+                           **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    state = module.params['state']
+    name = module.params['name']
+    # Check for required parameters when state == 'present'
+    if state == 'present':
+        for p in ['template']:
+            if not module.params[p]:
+                module.fail_json(msg='%s required with present state' % p)
+
+    try:
+        cloud = shade.openstack_cloud(**module.params)
+        stack = cloud.get_stack(name)
+
+        if state == 'present':
+            if not stack:
+                stack = _create_stack(module, stack, cloud)
+                changed = True
+            else:
+                changed = False
+            module.exit_json(changed=changed,
+                             stack=stack,
+                             id=stack.id)
+        elif state == 'absent':
+            if not stack:
+                changed = False
+            else:
+                changed = True
+                if not cloud.delete_stack(name):
+                    module.fail_json(msg='delete stack failed for stack: %s' % name)
+            module.exit_json(changed=changed)
+    except shade.OpenStackCloudException as e:
+        module.fail_json(msg=e.message)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_stack.py
+++ b/cloud/openstack/os_stack.py
@@ -13,7 +13,7 @@ DOCUMENTATION = '''
 module: os_stack
 short_description: Add/Remove Heat Stack
 extends_documentation_fragment: openstack
-version_added: "2.0"
+version_added: "2.1"
 author: "Mathieu Bultel (matbu), Steve Baker (steveb)"
 description:
    - Add or Remove a Stack to an OpenStack Heat
@@ -83,6 +83,10 @@ EXAMPLES = '''
         image: CentOS
         my_flavor: m1.large
         external_net: {{ external_net_param }}
+'''
+
+RETURN = '''
+#
 '''
 
 def _create_stack(module, stack, cloud):

--- a/cloud/openstack/os_stack.py
+++ b/cloud/openstack/os_stack.py
@@ -1,6 +1,22 @@
 #!/usr/bin/python
 #coding: utf-8 -*-
 
+# (c) 2016, Mathieu Bultel <mbultel@redhat.com>
+# (c) 2016, Steve Baker <sbaker@redhat.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
 from time import sleep
 try:
     import shade


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```
- Add ansible module for creating and deleting heat stack
- Parameters:
  - stack name
  - template
  - environment_files (list)
  - parameters (dict)
  - timeout
  - rollback
  - state: In a near futur I would like to improve
    this module by providing a way updating the stack
    if already exist. Shade doesn't offer this functionality
    AFAIK
