### PR TITLE
Mark token as no_log, since that's used for auth

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -169,7 +169,7 @@ def main():
 
     module = AnsibleModule(
         argument_spec=dict(
-            token=dict(required=True),
+            token=dict(required=True, no_log=True),
             room=dict(required=True),
             msg=dict(required=True),
             msg_from=dict(default="Ansible", aliases=['from']),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

hipchat
