### PR TITLE
Fix arguments for pushover module

### DIFF
--- a/notification/pushover.py
+++ b/notification/pushover.py
@@ -95,9 +95,9 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             msg=dict(required=True),
-            app_token=dict(required=True),
-            user_key=dict(required=True),
-            pri=dict(required=False, default=0),
+            app_token=dict(required=True, no_log=True),
+            user_key=dict(required=True, no_log=True),
+            pri=dict(required=False, default='0', choices=['-2','-1','0','1','2']),
         ),
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

pushover
##### SUMMARY

Since user_key and app_token are used for authentication, I
suspect both of them should be kept secret.

According to the API manual, https://pushover.net/api
priority go from -2 to 2, so the argument should be constrained.
