### PR TITLE
Idempotency fix in datadog_monitor.py

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -208,7 +208,7 @@ def _update_monitor(module, monitor, options):
                                  options=options)
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
-        elif _equal_dicts(msg, monitor, ['creator', 'overall_state']):
+        elif _equal_dicts(msg, monitor, ['creator', 'overall_state', 'modified']):
             module.exit_json(changed=False, msg=msg)
         else:
             module.exit_json(changed=True, msg=msg)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

datadog_monitor.py
##### ANSIBLE VERSION

```
ansible 1.9.2
  configured module search path = None
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

@skornehl, if you run this module twice with the exact same parameters, the second run always comes back as `changed`. After further investigation, it looks like the `modified` key when comparing `msg` and `monitor` is triggering this.  I believe `modified` should be added to the `ignore_keys` list.
