### PR TITLE
pkgin: Fix bad regexp which did not catch packages such as p5-SVN-Notify

### DIFF
--- a/packaging/os/pkgin.py
+++ b/packaging/os/pkgin.py
@@ -164,7 +164,7 @@ def query_package(module, name):
 
             # Search for package, stripping version
             # (results in sth like 'gcc47-libs' or 'emacs24-nox11')
-            pkg_search_obj = re.search(r'^([a-zA-Z]+[0-9]*[\-]*\w*)-[0-9]', pkgname_with_version, re.M)
+            pkg_search_obj = re.search(r'^(.*?)\-[0-9][0-9.]*(nb[0-9]+)*', pkgname_with_version, re.M)
 
             # Do not proceed unless we have a match
             if not pkg_search_obj:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

plugin/module/packaging/os/pkgin.py
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
ansible 2.0.1.0
  config file = /Users/cfuhrman/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Correct regexp

The previous regexp did not catch packages with multiple '-' in them, such as p5-Perl-Tidy or py27-cached-property.  This commit makes use of a greedy match that matches up to the last '-' and has been tested using every package from pkgsrc-2016Q1 branch.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->

# Before
TASK [development : Install development tools] *********************************
ok: [cmf-stage7.local] => (item=bzr) => {"changed": false, "item": "bzr", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=colordiff) => {"changed": false, "item": "colordiff", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=fossil) => {"changed": false, "item": "fossil", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gawk) => {"changed": false, "item": "gawk", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gindent) => {"changed": false, "item": "gindent", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=git-base) => {"changed": false, "item": "git-base", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=git-docs) => {"changed": false, "item": "git-docs", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=global) => {"changed": false, "item": "global", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gmake) => {"changed": false, "item": "gmake", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=go) => {"changed": false, "item": "go", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gsed) => {"changed": false, "item": "gsed", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=mercurial) => {"changed": false, "item": "mercurial", "msg": "package(s) already present"}
failed: [cmf-stage7.local] => (item=p5-Perl-Tidy) => {"failed": true, "item": "p5-Perl-Tidy", "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-
1460182247.09-167034884425291/pkgin\", line 2195, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182247.09-167034884425291/pkgin\", line 229, in main\r\n    install_packages(module, pkg
in_path, pkgs)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182247.09-167034884425291/pkgin\", line 197, in install_packages\r\n    if query_package(module, pkgin_path, package):\r\n  File \"/root/.ansible/tmp
/ansible-tmp-1460182247.09-167034884425291/pkgin\", line 113, in query_package\r\n    pkgname_with_version, raw_state = package.split(splitchar)[0:2]\r\nValueError: need more than 1 value to unpack\r\n", "msg": 
"MODULE FAILURE", "parsed": false}
failed: [cmf-stage7.local] => (item=p5-Pod-Coverage) => {"failed": true, "item": "p5-Pod-Coverage", "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansibl
e-tmp-1460182247.38-129001078022597/pkgin\", line 2195, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182247.38-129001078022597/pkgin\", line 229, in main\r\n    install_packages(modul
e, pkgin_path, pkgs)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182247.38-129001078022597/pkgin\", line 197, in install_packages\r\n    if query_package(module, pkgin_path, package):\r\n  File \"/root/.ansib
le/tmp/ansible-tmp-1460182247.38-129001078022597/pkgin\", line 113, in query_package\r\n    pkgname_with_version, raw_state = package.split(splitchar)[0:2]\r\nValueError: need more than 1 value to unpack\r\n", "
msg": "MODULE FAILURE", "parsed": false}
failed: [cmf-stage7.local] => (item=p5-Test-Output) => {"failed": true, "item": "p5-Test-Output", "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-
tmp-1460182247.74-214918913224496/pkgin\", line 2195, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182247.74-214918913224496/pkgin\", line 229, in main\r\n    install_packages(module,
 pkgin_path, pkgs)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182247.74-214918913224496/pkgin\", line 197, in install_packages\r\n    if query_package(module, pkgin_path, package):\r\n  File \"/root/.ansible
/tmp/ansible-tmp-1460182247.74-214918913224496/pkgin\", line 113, in query_package\r\n    pkgname_with_version, raw_state = package.split(splitchar)[0:2]\r\nValueError: need more than 1 value to unpack\r\n", "ms
g": "MODULE FAILURE", "parsed": false}
failed: [cmf-stage7.local] => (item=p5-Test-Pod) => {"failed": true, "item": "p5-Test-Pod", "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/tmp/ansible-tmp-14
60182248.28-56369667505885/pkgin\", line 2195, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182248.28-56369667505885/pkgin\", line 229, in main\r\n    install_packages(module, pkgin_p
ath, pkgs)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182248.28-56369667505885/pkgin\", line 197, in install_packages\r\n    if query_package(module, pkgin_path, package):\r\n  File \"/root/.ansible/tmp/ansi
ble-tmp-1460182248.28-56369667505885/pkgin\", line 113, in query_package\r\n    pkgname_with_version, raw_state = package.split(splitchar)[0:2]\r\nValueError: need more than 1 value to unpack\r\n", "msg": "MODUL
E FAILURE", "parsed": false}
failed: [cmf-stage7.local] => (item=p5-Test-Pod-Coverage) => {"failed": true, "item": "p5-Test-Pod-Coverage", "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/root/.ansible/
tmp/ansible-tmp-1460182248.82-172614463219888/pkgin\", line 2195, in <module>\r\n    main()\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182248.82-172614463219888/pkgin\", line 229, in main\r\n    install_pack
ages(module, pkgin_path, pkgs)\r\n  File \"/root/.ansible/tmp/ansible-tmp-1460182248.82-172614463219888/pkgin\", line 197, in install_packages\r\n    if query_package(module, pkgin_path, package):\r\n  File \"/r
oot/.ansible/tmp/ansible-tmp-1460182248.82-172614463219888/pkgin\", line 113, in query_package\r\n    pkgname_with_version, raw_state = package.split(splitchar)[0:2]\r\nValueError: need more than 1 value to unpa
ck\r\n", "msg": "MODULE FAILURE", "parsed": false}
ok: [cmf-stage7.local] => (item=py27-paramiko) => {"changed": false, "item": "py27-paramiko", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=py27-curses) => {"changed": false, "item": "py27-curses", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=py27-curl) => {"changed": false, "item": "py27-curl", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=subversion-base) => {"changed": false, "item": "subversion-base", "msg": "package(s) already present"}

# After
TASK [development : Install development tools] *********************************
ok: [cmf-stage7.local] => (item=bzr) => {"changed": false, "item": "bzr", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=colordiff) => {"changed": false, "item": "colordiff", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=fossil) => {"changed": false, "item": "fossil", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gawk) => {"changed": false, "item": "gawk", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gindent) => {"changed": false, "item": "gindent", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=git-base) => {"changed": false, "item": "git-base", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=git-docs) => {"changed": false, "item": "git-docs", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=global) => {"changed": false, "item": "global", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gmake) => {"changed": false, "item": "gmake", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=go) => {"changed": false, "item": "go", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=gsed) => {"changed": false, "item": "gsed", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=mercurial) => {"changed": false, "item": "mercurial", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=p5-Perl-Tidy) => {"changed": false, "item": "p5-Perl-Tidy", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=p5-Pod-Coverage) => {"changed": false, "item": "p5-Pod-Coverage", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=p5-Test-Output) => {"changed": false, "item": "p5-Test-Output", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=p5-Test-Pod) => {"changed": false, "item": "p5-Test-Pod", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=p5-Test-Pod-Coverage) => {"changed": false, "item": "p5-Test-Pod-Coverage", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=py27-paramiko) => {"changed": false, "item": "py27-paramiko", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=py27-curses) => {"changed": false, "item": "py27-curses", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=py27-curl) => {"changed": false, "item": "py27-curl", "msg": "package(s) already present"}
ok: [cmf-stage7.local] => (item=subversion-base) => {"changed": false, "item": "subversion-base", "msg": "package(s) already present"}


```
