### PR TITLE
Windows: win_regedit; Add support for managing binary registry data to win_regedit

### DIFF
--- a/windows/win_regedit.py
+++ b/windows/win_regedit.py
@@ -116,3 +116,16 @@ EXAMPLES = '''
     value: hello
     state: absent
 '''
+RETURN = '''
+data_changed:
+    description: whether this invocation changed the data in the registry value 
+    returned: always
+    type: boolean
+    sample: false
+data_type_changed:
+    description: whether this invocation changed the datatype of the registry value 
+    returned: always
+    type: boolean
+    sample: true
+'''
+

--- a/windows/win_regedit.py
+++ b/windows/win_regedit.py
@@ -43,7 +43,7 @@ options:
     aliases: []
   data:
     description:
-      - Registry Value Data
+      - Registry Value Data.  Binary data should be expressed as comma separated hex values.  An easy way to generate this is to run regedit.exe and use the 'Export' option to save the registry values to a file.  In the file binary values will look something like this: hex:be,ef,be,ef.  The 'hex:' prefix is optional. 
     required: false
     default: null
     aliases: []
@@ -93,6 +93,15 @@ EXAMPLES = '''
     value: hello
     data: 1337
     datatype: dword
+
+  # Creates Registry Key called MyCompany,
+  # a value within MyCompany Key called "hello", and
+  # binary data for the value "hello" as type "binary".
+  win_regedit:
+    key: HKCU:\Software\MyCompany
+    value: hello
+    data: hex:be,ef,be,ef,be,ef,be,ef,be,ef
+    datatype: binary
 
   # Delete Registry Key MyCompany
   # NOTE: Not specifying a value will delete the root key which means

--- a/windows/win_regedit.py
+++ b/windows/win_regedit.py
@@ -43,7 +43,7 @@ options:
     aliases: []
   data:
     description:
-      - Registry Value Data.  Binary data should be expressed as comma separated hex values.  An easy way to generate this is to run regedit.exe and use the 'Export' option to save the registry values to a file.  In the file binary values will look something like this: hex:be,ef,be,ef.  The 'hex:' prefix is optional. 
+      - Registry Value Data.  Binary data should be expressed as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional. 
     required: false
     default: null
     aliases: []
@@ -119,13 +119,12 @@ EXAMPLES = '''
 RETURN = '''
 data_changed:
     description: whether this invocation changed the data in the registry value 
-    returned: always
+    returned: success
     type: boolean
-    sample: false
+    sample: False
 data_type_changed:
     description: whether this invocation changed the datatype of the registry value 
-    returned: always
+    returned: success
     type: boolean
-    sample: true
+    sample: True
 '''
-


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

win_regedit
##### ANSIBLE VERSION

```
ansible 2.1.0 (win_regedit_binary_tests cca084c89d) last updated 2016/04/07 18:24:39 (GMT +100)
  lib/ansible/modules/core: (detached HEAD cf01087a30) last updated 2016/04/05 08:30:23 (GMT +100)
  lib/ansible/modules/extras: (add_binary_to_regedit 7a8d3cf392) last updated 2016/04/14 21:23:07 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

The current implementation of win_regedit will not let you manage binary data.
This is because it is expecting strings but powershell sees the binary data as a byte array.
I added logic to handle converting hex strings in module parameters into byte arrays, and a function
to test if the current registry data value matched the supplied registry data value.
If you export binary data using regedit, you get a string representation of the hex values with a 'hex:' prefix and comma separated values, so this is the preferred form for expressing binary data in module parameters.  However the conversion function allows the 'hex:' prefix to be omitted and the hex values to be separated by commas or colons.

I also added data_changed and data_type_changed boolean return values and documented these.

Not aware of an existing bug report for this, but fixes an issue I encountered while using Ansible.

I have a PR which adds integration tests for win_regedit which I will submit shortly.

Example: Running the following:

```
- name: remove registry key used for testing
  win_regedit:
    key: 'HKCU:\SOFTWARE\Cow Corp'
    state: absent
```

Before:

```
changed: [WIN-TEST] => {"changed": true}
```

After:

```
changed: [WIN-TEST] => {"changed": true, "data_changed": false, "data_type_changed": false}
```
