### PR TITLE
Handle empty IPS publishers

### DIFF
--- a/packaging/os/pkg5_publisher.py
+++ b/packaging/os/pkg5_publisher.py
@@ -180,13 +180,14 @@ def get_publishers(module):
             publishers[name]['origin'] = []
             publishers[name]['mirror'] = []
 
-        publishers[name][values['type']].append(values['uri'])
+        if values['type'] is not None:
+            publishers[name][values['type']].append(values['uri'])
 
     return publishers
 
 
 def unstringify(val):
-    if val == "-":
+    if val == "-" or val == '':
         return None
     elif val == "true":
         return True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`packaging/os/pkg5_publisher.py`
##### SUMMARY

It turns out it's possible to set up a publisher with no URIs.  Handle this gracefully.

Fixes #975.
