### PR TITLE
Initiate permissions with empty list

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -139,7 +139,7 @@ class RabbitMqUser(object):
         self.bulk_permissions = bulk_permissions
 
         self._tags = None
-        self._permissions = None
+        self._permissions = list()
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
     def _exec(self, args, run_in_check_mode=False):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

rabbitmq_user
##### ANSIBLE VERSION

```
*
```
##### SUMMARY

This prevents failing when adding new user because `None` is not iterable.

Signed-off-by: Marian Rusu rusumarian91@gmail.com
