### PR TITLE
Adding `timedatectl` module for timezone etc setting.

### DIFF
--- a/system/timedatectl.py
+++ b/system/timedatectl.py
@@ -69,7 +69,11 @@ def main():
             if spec['type']!='bool':
                 spec['new_value'] = module.params[arg]
             else:
-                spec['new_value'] = 'yes' if module.params[arg] else 'no'
+                # spec['new_value'] = 'yes' if module.params[arg] else 'no'
+                if module.params[arg]:
+                    spec['new_value'] = 'yes'
+                else:
+                    spec['new_value'] = 'no'
             # Check the old value, which is written in `old_state`.
             # Below regex is to find the value.
             regex = re.compile(spec['name']+r':\s*([^\n]+)\n')

--- a/system/timedatectl.py
+++ b/system/timedatectl.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+import re
+
+DOCUMENTATION = '''
+---
+module: timedatectl
+short_description: Execute `timedatectl` command to set timezone, etc
+description:
+  - Execute `timedatectl` command to set timezone, date/time or enable NTP.
+  - See `man timedatectl` for details.
+version_added: "2.1.0"
+options:
+  ntp:
+    description:
+      - Enable/Disable clock synchronization using NTP.
+      - Default is to keep current setting.
+    required: false
+    choices: [ "yes", "no" ]
+    default: null
+  time:
+    description:
+      - Set current date and/or time of the system clock, specified in the format I(2012-10-30 18:17:16).
+      - Default is to keep current setting.
+    required: false
+    default: null
+  timezone:
+    description:
+      - Set time zone of the system clock, specified in the format I(Asia/Tokyo).
+      - Default is to keep current setting.
+    required: false
+    default: null
+requirements: [ "timedatectl command" ]
+author: "Shinichi TAMURA @tmshn"
+'''
+
+EXAMPLES='''
+- name: set timezone to Asia/Tokyo
+  timedatectl: timezone=Asia/Tokyo
+'''
+
+
+def main():
+    # Arguments setting
+    # * 'name' is not required key to construct AnsibleModule,
+    #   but it is used to check if change will happen.
+    arguments = dict(
+        ntp       = dict(default=None,  required=False, type='bool',    name='NTP enabled'),
+        time      = dict(default=None,  required=False, type='str',     name='Local time'),
+        timezone  = dict(default=None,  required=False, type='str',     name='Timezone'),
+    )
+
+    # Construct 'module'
+    module = AnsibleModule(
+        argument_spec       = arguments,
+        supports_check_mode = True,
+        required_one_of     = [ arguments.keys() ],
+    )
+    # Commands to execute to make some change.
+    # (shell command will be added if needed)
+    commands = []
+
+    # Check the current state
+    old_state = module.run_command('timedatectl status', check_rc=True)[1] # Get stdout
+    # module.exit_json(changed=False, msg=old_state)
+
+    for arg,spec in arguments.iteritems():
+        # Check old value, which is written in `old_state`.
+        # Below regex is to find the value.
+        regex     = re.compile(spec['name']+r':\s*([^\n]+)\n')
+        old_value = regex.search(old_state).group(1)
+        new_value = module.params[arg]
+        if (new_value is not None) and (new_value not in old_value):
+            # then, change should happen!
+            commands.append('timedatectl set-%s %s' % (arg, new_value))
+
+    # Make changes
+    if not module.check_mode:
+        for command in commands:
+            module.run_command(command, check_rc=True)
+
+    # Check the current state and return.
+    new_state = module.run_command('timedatectl status', check_rc=True)[1] # Get stdout
+    message   = old_state + "\n|\nv\n\n" + new_state
+    module.exit_json(changed=( len(commands)>0 ), msg=message)
+
+from ansible.module_utils.basic import *
+
+if __name__ == '__main__':
+    main()

--- a/system/timedatectl.py
+++ b/system/timedatectl.py
@@ -1,6 +1,23 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+# (c) 2016, Shinichi TAMURA (@tmshn)
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
 import re
 
 DOCUMENTATION = '''


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME
- timedatectl
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 3c3061378b) last updated 2016/04/18 09:57:34 (GMT +900)
  lib/ansible/modules/core: (detached HEAD 795b3c25cd) last updated 2016/04/18 11:18:13 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 05068630ca) last updated 2016/04/18 11:24:30 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This module is used to configure timezone, time and/or NTP settings using the `timedatectl` command, which is much easier and safer than managing files in `/etc/`.

With the below task,

``` yaml
  tasks:
    # - name: install Japanese language pack
    #   apt: name=language-pack-ja state=latest
    - name: set timezone to JST
      timedatectl: timezone='Asia/Tokyo' ntp=yes
```

The verbose output at the first execution would be:

```
TASK [set timezone to JST] *****************************************************
task path: /Users/tmshn/Documents/vagrant/vagrant_playbook.yml:5
changed: [default] => {"changed": true, "changelogs": [{"changed": true, "command": "timedatectl set-timezone Asia/Tokyo", "name": "Timezone", "new_value": "Asia/Tokyo (JST, +0900)", "old_value": "UTC (UTC, +0000)"}, {"changed": false, "command": "", "name": "NTP enabled", "new_value": "yes", "old_value": "yes"}]}
```

Then, the output at the execution again would be:

```
TASK [set timezone to JST] *****************************************************
task path: /Users/tmshn/Documents/vagrant/vagrant_playbook.yml:5
ok: [default] => {"changed": false, "changelogs": [{"changed": false, "command": "", "name": "Timezone", "new_value": "Asia/Tokyo (JST, +0900)", "old_value": "Asia/Tokyo (JST, +0900)"}, {"changed": false, "command": "", "name": "NTP enabled", "new_value": "yes", "old_value": "yes"}]}
```
