### PR TITLE
amazon/GUIDELINES.md: Fix copy-paste typo

### DIFF
--- a/cloud/amazon/GUIDELINES.md
+++ b/cloud/amazon/GUIDELINES.md
@@ -80,7 +80,7 @@ except ImportError:
 def main():
 
     if not HAS_BOTO3:
-        module.fail_json(msg='boto required for this module')
+        module.fail_json(msg='boto3 required for this module')
 ```
 
 #### boto and boto3 combined


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

N/A
##### ANSIBLE VERSION

```
2.0.1.0
```
##### SUMMARY

This fixes a `boto` -> `boto3` typo in the AWS module writing guidelines. I think it'll reduce confusion for new authors, and hopefully encourage more people to write modules.
