### PR TITLE
Fixed netif params when create lxc container - Fixes #1217

### DIFF
--- a/cloud/misc/proxmox.py
+++ b/cloud/misc/proxmox.py
@@ -213,6 +213,9 @@ def create_instance(module, proxmox, vmid, node, disk, storage, cpus, memory, sw
   if VZ_TYPE =='lxc':
       kwargs['cpulimit']=cpus
       kwargs['rootfs']=disk
+      if 'netif' in kwargs:
+        kwargs.update(kwargs['netif'])
+        del kwargs['netif']
   else:
       kwargs['cpus']=cpus
       kwargs['disk']=disk


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

[proxmox](https://github.com/ansible/ansible-modules-extras/blob/devel/cloud/misc/proxmox.py)
##### ANSIBLE VERSION

```
ansible 2.0.1.0
```
##### SUMMARY

I found that the proxmox module needs process the "netif param". In the [proxmox docs](http://pve.proxmox.com/pve2-api-doc/) the netif param does not exist. The correct param is **net[n]**. I created these params from netif var, for example:

```
...

vars:
ct_netif: "{ 'net0':'gw=10.10.22.254,bridge=vmbr0,name=eth0,ip=10.10.22.1/24', 'net1':'gw=10.10.22.254,bridge=vmbr0,name=eth0,ip=10.10.22.2/24' }"
ct_ostemplate: "local:vztmpl/debian-8.0-standard_8.0-1_amd64.tar.gz"
ct_vmid: 101

tasks:
    - proxmox:
        api_user: "{{ proxmox_api_user }}"
        api_password: "{{ proxmox_api_password }}"
        api_host: "{{ proxmox_api_host }}"
        node: "{{ proxmox_node }}"
        vmid: "{{ ct_vmid }}"
        netif: "{{ ct_netif }}"
        ostemplate: "{{ ct_ostemplate }}"

```

Result before:

```
{'onboot': 0, 'force': 0, 'netif': {'net1': 'gw=10.10.22.254,bridge=vmbr0,name=eth0,ip=10.10.22.2/24', 'net0': 'gw=10.10.22.254,bridge=vmbr0,name=eth0,ip=10.10.22.1/24'}, 'ostemplate': 'local:vztmpl/debian-8.0-standard_8.0-1_amd64.tar.gz', 'cpuunits': 1000}"}
```

```
{"changed": false, "failed": true, "msg": "creation of lxc VM 101 failed with exception: 400 Bad Request"}
```

Result after:

``````
{'force': 0, 'cpuunits': 1000, 'ostemplate': 'local:vztmpl/debian-8.0-standard_8.0-1_amd64.tar.gz', 'net0': 'gw=10.10.22.254,bridge=vmbr0,name=eth0,ip=10.10.22.1/24', 'cpulimit': 1, 'onboot': 0, 'net1': 'gw=10.10.22.254,bridge=vmbr0,name=eth0,ip=10.10.22.2/24', 'rootfs': 3}```
Now the module runs as expected.
``````

```
{"changed": true, "msg": "deployed VM 101 from template local:vztmpl/debian-8.0-standard_8.0-1_amd64.tar.gz"}
```
