### PR TITLE
Added portenforce module

### DIFF
--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -78,10 +78,11 @@ def netStatParse(raw):
         if listening_search:
             splitted = line.split()
             conns = re.search('[^ ]+:([^ ]+)', splitted[3])
+            pidstr = ''
             if 'tcp' in splitted[0]:
                 proto = 'tcp'
                 pidstr = splitted[6]
-            else:
+            elif 'udp' in splitted[0]:
                 proto = 'udp'
                 pidstr = splitted[5]
             pids = re.search('([0-9]+)/', pidstr)

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -140,8 +140,8 @@ def main():
     # get just the pids to avoid duplicates across protocols
     pids = list()
     for p in killed:
-    	if p['pid'] not in pids:
-    		pids.append(p['pid'])
+        if p['pid'] not in pids:
+            pids.append(p['pid'])
 
     # kill! kill!
     if not module.check_mode:

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -112,11 +112,11 @@ def applyWhitelist(portspids, whitelist=list()):
 
 def getPidSTime(pid):
     p1 = Popen(['ps', '-o', 'lstart', '-p', str(pid)], stdout=PIPE, stderr=PIPE)
-    p2 = Popen(['grep', '^[^ ]'], stdin=p1.stdout, stdout=PIPE, stderr=PIPE)
-    p1.stdout.close()
-    p3 = Popen(['tr', '-d', '"\n"'], stdin=p2.stdout, stdout=PIPE, stderr=PIPE)
-    p2.stdout.close()
-    stime = p3.communicate()[0]
+    ps_output = p1.communicate()[0]
+    stime = ''
+    for line in iter(ps_output.splitlines()):
+        if 'started' not in line:
+            stime = line
     return stime
 
 def main():

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python
+# encoding: utf-8
+
+# (c) 2016, Nathan Davison <ndavison85@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: portenforce
+author:
+    - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
+version_added: "2.1"
+description:
+    - Kill processes listening on TCP and UDP ports not defined in the whitelists.
+short_description: Kill processes listening on TCP and UDP ports not defined in the whitelists.
+options:
+  whitelist_tcp:
+    description:
+      - A list of TCP ports to allow.
+    required: false
+    type: "list"
+  whitelist_udp:
+    description:
+      - A list of UDP ports to allow.
+    required: false
+    type: "list"
+'''
+
+EXAMPLES = '''
+- name: only allow TCP 80, 443, and 22
+  portenforce:
+    whitelist_tcp:
+      - 22
+      - 80
+      - 443
+'''
+
+RETURN = '''
+killed:
+  description: A list of pids that were killed.
+  type: list
+  contains:
+    pid:
+      description: The pid of a killed process.
+      type: int
+      sample: 1223
+    port:
+      description: The port the killed pid was listening on.
+      type: int
+      sample: 443
+    proto:
+      description: The protocol, TCP or UDP, of the listening connection.
+      type: string
+      sample: 'tcp'
+'''
+
+import re
+from subprocess import Popen, PIPE
+
+def netStatParse(raw):
+	results = list()
+	for line in iter(raw.splitlines()):
+		listening_search = re.search('[^ ]+:[^ ]+', line)
+		if listening_search:
+			splitted = line.split()
+			conns = re.search('[^ ]+:([^ ]+)', splitted[3])
+			proto = 'tcp' if 'tcp' in splitted[0] else 'udp'
+			pidstr = splitted[6] if proto == 'tcp' else splitted[5]
+			pids = re.search('([0-9]+)/', pidstr)
+			if conns and pids:
+				port = conns.group(1)
+				pid = pids.group(1)
+				result = dict(pid=int(pid), port=int(port), proto=proto)
+				if result not in results:
+					results.append(result)
+			elif not pids:
+				raise EnvironmentError('Could not get the pids for the listening ports - possibly a permission issue')
+	return results
+
+def applyWhitelist(portspids, whitelist=list()):
+	kill_pids = list()
+	for p in portspids:
+		if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
+			if dict(pid=p['pid'], port=p['port'], proto=p['proto']) not in kill_pids:
+				kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto']))
+	return kill_pids
+
+def main():
+
+	module = AnsibleModule(
+		argument_spec = dict(
+			whitelist_tcp = dict(required=False, type='list', default=list()),
+			whitelist_udp = dict(required=False, type='list', default=list())
+		),
+		supports_check_mode=True
+	)
+
+	result = {}
+	result['changed'] = False
+	result['killed'] = list()
+
+	try:
+		# which TCP ports are listening for connections?
+		p1 = Popen(['netstat', '-plnt'], stdout=PIPE, stderr=PIPE)
+		output_tcp = p1.communicate()[0]
+		kill_tcp = netStatParse(output_tcp)
+
+		# which UDP ports are listening for connections?
+		p1 = Popen(['netstat', '-plnu'], stdout=PIPE, stderr=PIPE)
+		output_udp = p1.communicate()[0]
+		kill_udp = netStatParse(output_udp)
+	except EnvironmentError as err:
+		module.fail_json(msg=str(err))
+
+	# gather all the pids to kill
+	kill_pids_tcp = applyWhitelist(kill_tcp, module.params['whitelist_tcp'])
+	kill_pids_udp = applyWhitelist(kill_udp, module.params['whitelist_udp'])
+	killed = list(kill_pids_tcp)
+	killed.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
+
+	# kill! kill!
+	if not module.check_mode:
+		for p in killed:
+			p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
+
+	if killed:
+		result['changed'] = True
+		result['killed'] = killed
+
+	module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -73,6 +73,7 @@ killed:
 '''
 
 import re
+import os
 from subprocess import Popen, PIPE
 
 def netStatParse(raw):
@@ -168,7 +169,7 @@ def main():
     if not module.check_mode:
         for p in kill_unique:
             if p['stime'] == getPidSTime(p['pid']):
-                p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
+                os.kill(p['pid'], 15)
 
     if kill_all:
         result['changed'] = True

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -131,16 +131,22 @@ def main():
     except EnvironmentError, err:
         module.fail_json(msg=str(err))
 
-    # gather all the pids to kill
+    # gather details of the pids to kill
     kill_pids_tcp = applyWhitelist(kill_tcp, module.params['whitelist_tcp'])
     kill_pids_udp = applyWhitelist(kill_udp, module.params['whitelist_udp'])
     killed = list(kill_pids_tcp)
     killed.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
 
+    # get just the pids to avoid duplicates across protocols
+    pids = list()
+    for p in killed:
+    	if p['pid'] not in pids:
+    		pids.append(p['pid'])
+
     # kill! kill!
     if not module.check_mode:
-        for p in killed:
-            p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
+        for pid in pids:
+            p1 = Popen(['kill', str(pid)], stdout=PIPE)
 
     if killed:
         result['changed'] = True

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -80,9 +80,10 @@ def netStatParse(raw):
 			conns = re.search('[^ ]+:([^ ]+)', splitted[3])
 			if 'tcp' in splitted[0]:
 				proto = 'tcp'
+				pidstr = splitted[6]
 			else:
 				proto = 'udp'
-			pidstr = splitted[6] if proto == 'tcp' else splitted[5]
+				pidstr = splitted[5]
 			pids = re.search('([0-9]+)/', pidstr)
 			if conns and pids:
 				port = conns.group(1)

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -74,6 +74,7 @@ killed:
 
 import re
 import os
+import platform
 from subprocess import Popen, PIPE
 
 def netStatParse(raw):
@@ -120,6 +121,9 @@ def main():
         ),
         supports_check_mode=True
     )
+
+    if platform.system() != 'Linux':
+        module.fail_json(msg='This module requires Linux.')
 
     def getPidSTime(pid):
         ps_cmd = module.get_bin_path('ps', True)

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -23,7 +23,7 @@ DOCUMENTATION = '''
 module: portenforce
 author:
     - '"Nathan Davison (@ndavison)" <ndavison85@gmail.com>'
-version_added: "2.1"
+version_added: "2.2"
 description:
     - Kill processes listening on TCP and UDP ports not defined in the whitelists.
 short_description: Kill processes listening on TCP and UDP ports not defined in the whitelists.

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -66,6 +66,10 @@ killed:
       description: The protocol, TCP or UDP, of the listening connection.
       type: string
       sample: 'tcp'
+    stime:
+      description: The start time of the killed process.
+      type: string
+      sample: Thu Apr 21 17:30:16 2016
 '''
 
 import re
@@ -85,11 +89,12 @@ def netStatParse(raw):
             elif 'udp' in splitted[0]:
                 proto = 'udp'
                 pidstr = splitted[5]
-            pids = re.search('([0-9]+)/', pidstr)
+            pids = re.search('([0-9]+)/(.*)', pidstr)
             if conns and pids:
                 port = conns.group(1)
                 pid = pids.group(1)
-                result = dict(pid=int(pid), port=int(port), proto=proto)
+                name = pids.group(2)
+                result = dict(pid=int(pid), port=int(port), proto=proto, name=name)
                 if result not in results:
                     results.append(result)
             elif not pids:
@@ -100,9 +105,18 @@ def applyWhitelist(portspids, whitelist=list()):
     kill_pids = list()
     for p in portspids:
         if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
-            if dict(pid=p['pid'], port=p['port'], proto=p['proto']) not in kill_pids:
-                kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto']))
+            if dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']) not in kill_pids:
+                kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']))
     return kill_pids
+
+def getPidSTime(pid):
+    p1 = Popen(['ps', '-o', 'lstart', '-p', str(pid)], stdout=PIPE, stderr=PIPE)
+    p2 = Popen(['grep', '^[^ ]'], stdin=p1.stdout, stdout=PIPE, stderr=PIPE)
+    p1.stdout.close()
+    p3 = Popen(['tr', '-d', '"\n"'], stdin=p2.stdout, stdout=PIPE, stderr=PIPE)
+    p2.stdout.close()
+    stime = p3.communicate()[0]
+    return stime
 
 def main():
 
@@ -123,34 +137,42 @@ def main():
         p1 = Popen(['netstat', '-plnt'], stdout=PIPE, stderr=PIPE)
         output_tcp = p1.communicate()[0]
         kill_tcp = netStatParse(output_tcp)
+        for i, p in enumerate(kill_tcp):
+            p['stime'] = getPidSTime(p['pid']) 
+            kill_tcp[i] = p
 
         # which UDP ports are listening for connections?
         p1 = Popen(['netstat', '-plnu'], stdout=PIPE, stderr=PIPE)
         output_udp = p1.communicate()[0]
         kill_udp = netStatParse(output_udp)
+        for i, p in enumerate(kill_udp):
+            p['stime'] = getPidSTime(p['pid']) 
+            kill_udp[i] = p
+
     except EnvironmentError, err:
         module.fail_json(msg=str(err))
 
     # gather details of the pids to kill
     kill_pids_tcp = applyWhitelist(kill_tcp, module.params['whitelist_tcp'])
     kill_pids_udp = applyWhitelist(kill_udp, module.params['whitelist_udp'])
-    killed = list(kill_pids_tcp)
-    killed.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
+    kill_all = list(kill_pids_tcp)
+    kill_all.extend(x for x in kill_pids_udp if x not in kill_pids_tcp)
 
     # get just the pids to avoid duplicates across protocols
-    pids = list()
-    for p in killed:
-        if p['pid'] not in pids:
-            pids.append(p['pid'])
+    kill_unique = list()
+    for p in kill_all:
+        if p['pid'] not in kill_unique:
+            kill_unique.append(p)
 
     # kill! kill!
     if not module.check_mode:
-        for pid in pids:
-            p1 = Popen(['kill', str(pid)], stdout=PIPE)
+        for p in kill_unique:
+            if p['stime'] == getPidSTime(p['pid']):
+                p1 = Popen(['kill', str(p['pid'])], stdout=PIPE)
 
-    if killed:
+    if kill_all:
         result['changed'] = True
-        result['killed'] = killed
+        result['killed'] = kill_all
 
     module.exit_json(**result)
 

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -78,7 +78,10 @@ def netStatParse(raw):
 		if listening_search:
 			splitted = line.split()
 			conns = re.search('[^ ]+:([^ ]+)', splitted[3])
-			proto = 'tcp' if 'tcp' in splitted[0] else 'udp'
+			if 'tcp' in splitted[0]:
+				proto = 'tcp'
+			else:
+				proto = 'udp'
 			pidstr = splitted[6] if proto == 'tcp' else splitted[5]
 			pids = re.search('([0-9]+)/', pidstr)
 			if conns and pids:

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -127,7 +127,7 @@ def main():
 		p1 = Popen(['netstat', '-plnu'], stdout=PIPE, stderr=PIPE)
 		output_udp = p1.communicate()[0]
 		kill_udp = netStatParse(output_udp)
-	except EnvironmentError as err:
+	except EnvironmentError, err:
 		module.fail_json(msg=str(err))
 
 	# gather all the pids to kill

--- a/system/portenforce.py
+++ b/system/portenforce.py
@@ -106,8 +106,9 @@ def applyWhitelist(portspids, whitelist=list()):
     kill_pids = list()
     for p in portspids:
         if int(p['port']) not in whitelist and str(p['port']) not in whitelist:
-            if dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']) not in kill_pids:
-                kill_pids.append(dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime']))
+            to_kill = dict(pid=p['pid'], port=p['port'], proto=p['proto'], name=p['name'], stime=p['stime'])
+            if to_kill not in kill_pids:
+                kill_pids.append(to_kill)
     return kill_pids
 
 def main():


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

portenforce
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 3c3061378b) last updated 2016/04/18 19:52:38 (GMT +1100)
  lib/ansible/modules/core: (detached HEAD 5409ed1b28) last updated 2016/04/18 19:52:51 (GMT +1100)
  lib/ansible/modules/extras: (detached HEAD 3afe117730) last updated 2016/04/18 19:53:03 (GMT +1100)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This module allows the user to define whitelists for TCP and/or UDP ports that a host is allowed to have processes listening on, killing processes that are listening on a port not in the whitelist. This is designed to be a small component in a larger offensive security Ansible setup.
