### PR TITLE
Add ability to create event and query acl rules for a given acl token

### DIFF
--- a/clustering/consul_acl.py
+++ b/clustering/consul_acl.py
@@ -234,8 +234,12 @@ def yml_to_rules(module, yml_rules):
                 rules.add_rule('key', Rule(rule['key'], rule['policy']))
             elif ('service' in rule and 'policy' in rule):
                 rules.add_rule('service', Rule(rule['service'], rule['policy']))
+            elif ('event' in rule and 'policy' in rule):
+                rules.add_rule('event', Rule(rule['event'], rule['policy']))
+            elif ('query' in rule and 'policy' in rule):
+                rules.add_rule('query', Rule(rule['query'], rule['policy']))
             else:
-                module.fail_json(msg="a rule requires a key/service and a policy.")
+                module.fail_json(msg="a rule requires a key/service/event or query and a policy.")
     return rules
 
 template = '''%s "%s" {
@@ -243,7 +247,7 @@ template = '''%s "%s" {
 }
 '''
 
-RULE_TYPES = ['key', 'service']
+RULE_TYPES = ['key', 'service', 'event', 'query']
 
 class Rules:
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

consul_acl
##### ANSIBLE VERSION

```
ansible 2.0.1.0 (detached HEAD 870a4b8dc1) last updated 2016/03/21 14:29:55 (GMT +1000)
  lib/ansible/modules/core: (detached HEAD b4a4f74724) last updated 2016/03/21 14:30:01 (GMT +1000)
  lib/ansible/modules/extras: (detached HEAD b9f5838c78) last updated 2016/03/21 14:30:01 (GMT +1000)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Update existing module to allow for creation of query and event rules to a given acl token.
##### Before change: event and query policies were not allowed even though consul supports it.

```
fatal: [127.0.0.1]: FAILED! => {
        "changed": false,
        "failed": true,
        "msg": "a rule requires a key/service and a policy."
    }
```
##### After change:  updated to support event and query policies/rules:

```
ok: [127.0.0.1] => {
        "changed": false,
        "name": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
        "rules": [
            {
                "key": "",
                "policy": "read"
            },
            {
                "key": "apple/",
                "policy": "write"
            },
            {
                "policy": "write",
                "service": ""
            },
            {
                "event": "apple-",
                "policy": "write"
            },
            {
                "event": "",
                "policy": "read"
            },
            {
                "policy": "read",
                "query": ""
            }
        ],
        "token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
        "type": "client"
    }
```
