### PR TITLE
Honouring verify_ssl when using username/password for authentication …

### DIFF
--- a/source_control/gitlab_project.py
+++ b/source_control/gitlab_project.py
@@ -357,7 +357,7 @@ def main():
     # or with login_token
     try:
         if use_credentials:
-            git = gitlab.Gitlab(host=server_url)
+            git = gitlab.Gitlab(host=server_url, verify_ssl=verify_ssl)
             git.login(user=login_user, password=login_password)
         else:
             git = gitlab.Gitlab(server_url, token=login_token, verify_ssl=verify_ssl)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

gitlab_project module
##### ANSIBLE VERSION

devel
##### SUMMARY

verify_sssl is not honoured when using username/password for authentication
