### PR TITLE
Fix ec2_eni idempotence

### DIFF
--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -195,9 +195,6 @@ def create_eni(connection, module):
     instance_id = module.params.get("instance_id")
     if instance_id == 'None':
         instance_id = None
-        do_detach = True
-    else:
-        do_detach = False
     device_index = module.params.get("device_index")
     subnet_id = module.params.get('subnet_id')
     private_ip_address = module.params.get('private_ip_address')
@@ -212,7 +209,7 @@ def create_eni(connection, module):
             if instance_id is not None:
                 try:
                     eni.attach(instance_id, device_index)
-                except BotoServerError as ex:
+                except BotoServerError:
                     eni.delete()
                     raise
                 # Wait to allow creation / attachment to finish
@@ -372,7 +369,7 @@ def main():
     if region:
         try:
             connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
-        except (boto.exception.NoAuthHandlerFound, StandardError), e:
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError), e:
             module.fail_json(msg=str(e))
     else:
         module.fail_json(msg="region must be specified")
@@ -400,4 +397,5 @@ from ansible.module_utils.ec2 import *
 # this is magic, see lib/ansible/module_common.py
 #<<INCLUDE_ANSIBLE_MODULE_COMMON>>
 
-main()
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- ec2_eni
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 335d76cc3d) last updated 2016/04/21 16:11:01 (GMT -200)
  lib/ansible/modules/core: (devel b6e9efd2ef) last updated 2016/04/18 12:36:37 (GMT -200)
  lib/ansible/modules/extras: (ec2-eni-idempotent f91330073a) last updated 2016/04/21 17:15:52 (GMT -200)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix #2084 

With this patch it is possible to run ec2_eni multiple times with the same private ip/subnet pair:

```
$ ansible -i localhost, -c local -m ec2_eni -a 'private_ip_address=10.137.0.10 subnet_id=subnet-zzz state=present region=us-east-1' localhost
localhost | SUCCESS => {
    "changed": false, <<-- This wouldn't work
    "interface": {
        "description": "",
        "groups": {
            "sg-6b98a613": "default"
        },
        "id": "eni-51bb1311",
        "mac_address": "0a:ff:2b:b7:0b:91",
        "owner_id": "zzz",
        "private_ip_address": "10.137.0.10",
        "source_dest_check": true,
        "status": "available",
        "subnet_id": "subnet-zzz",
        "vpc_id": "vpc-3ee6fzzz"
    }
}
```
