### PR TITLE
Adding install_options to homebrew_cask (see #544)

### DIFF
--- a/packaging/os/homebrew_cask.py
+++ b/packaging/os/homebrew_cask.py
@@ -44,6 +44,7 @@ options:
             - options flags to install a package
         required: false
         default: null
+        version_added: "2.1"
 '''
 EXAMPLES = '''
 - homebrew_cask: name=alfred state=present

--- a/packaging/os/homebrew_cask.py
+++ b/packaging/os/homebrew_cask.py
@@ -50,8 +50,8 @@ EXAMPLES = '''
 - homebrew_cask: name=alfred state=present
 - homebrew_cask: name=alfred state=absent
 - homebrew_cask: name=alfred state=present install_options="appdir=/Applications"
-- homebrew_cask: name=alfred state=present install_options="--debug appdir=/Applications"
-- homebrew_cask: name=alfred state=absent install_options="--force"
+- homebrew_cask: name=alfred state=present install_options="debug,appdir=/Applications"
+- homebrew_cask: name=alfred state=absent install_options="force"
 '''
 
 import os.path

--- a/packaging/os/homebrew_cask.py
+++ b/packaging/os/homebrew_cask.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # (c) 2013, Daniel Jaouen <dcj24@cornell.edu>
+# (c) 2016, Indrajit Raychaudhuri <irc+code@indrajit.com>
 #
 # This module is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -20,6 +21,7 @@ DOCUMENTATION = '''
 ---
 module: homebrew_cask
 author:
+    - "Indrajit Raychaudhuri (@indrajitr)"
     - "Daniel Jaouen (@danieljaouen)"
     - "Enric Lluelles (@enriclluelles)"
 short_description: Install/uninstall homebrew casks.
@@ -46,7 +48,9 @@ options:
 EXAMPLES = '''
 - homebrew_cask: name=alfred state=present
 - homebrew_cask: name=alfred state=absent
-- homebrew_cask: name=alfred state=absent install_options="appdir=/Applications"
+- homebrew_cask: name=alfred state=present install_options="appdir=/Applications"
+- homebrew_cask: name=alfred state=present install_options="--debug appdir=/Applications"
+- homebrew_cask: name=alfred state=absent install_options="--force"
 '''
 
 import os.path
@@ -538,4 +542,3 @@ from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()
-


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

homebrew_cask
##### ANSIBLE VERSION

```
ansible 2.1.0 (devel 283532e11d) last updated 2016/02/22 15:53:47 (GMT -500)
  lib/ansible/modules/core: (detached HEAD 8d126bd877) last updated 2016/02/22 15:53:57 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD f6c5ed987f) last updated 2016/02/22 15:53:57 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY
- Folded in #544 by @enriclluelles 
- Added additional examples for parameter `install_options`
- Added self as maintainer

NB: This PR should supersede  #544 which is failing in travis.
