### PR TITLE
Reverse the unpack list operation

### DIFF
--- a/network/f5/bigip_monitor_http.py
+++ b/network/f5/bigip_monitor_http.py
@@ -317,7 +317,20 @@ def main():
         supports_check_mode=True
     )
 
-    (server,user,password,state,partition,validate_certs) = f5_parse_arguments(module)
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    if module.params['validate_certs']:
+        import ssl
+        if not hasattr(ssl, 'SSLContext'):
+            module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    state = module.params['state']
+    partition = module.params['partition']
+    validate_certs = module.params['validate_certs']
 
     parent_partition = module.params['parent_partition']
     name = module.params['name']

--- a/network/f5/bigip_monitor_tcp.py
+++ b/network/f5/bigip_monitor_tcp.py
@@ -315,7 +315,7 @@ def set_ipport(api, monitor, ipport):
 def main():
 
     # begin monitor specific stuff
-    argument_spec=f5_argument_spec();
+    argument_spec=f5_argument_spec()
     argument_spec.update(dict(
             name      = dict(required=True),
             type      = dict(default=DEFAULT_TEMPLATE_TYPE_CHOICE, choices=TEMPLATE_TYPE_CHOICES),
@@ -336,7 +336,20 @@ def main():
         supports_check_mode=True
     )
 
-    (server,user,password,state,partition,validate_certs) = f5_parse_arguments(module)
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    if module.params['validate_certs']:
+        import ssl
+        if not hasattr(ssl, 'SSLContext'):
+            module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    state = module.params['state']
+    partition = module.params['partition']
+    validate_certs = module.params['validate_certs']
 
     parent_partition = module.params['parent_partition']
     name = module.params['name']

--- a/network/f5/bigip_node.py
+++ b/network/f5/bigip_node.py
@@ -263,7 +263,7 @@ def get_node_monitor_status(api, name):
 
 
 def main():
-    argument_spec=f5_argument_spec();
+    argument_spec=f5_argument_spec()
     argument_spec.update(dict(
             session_state = dict(type='str', choices=['enabled', 'disabled']),
             monitor_state = dict(type='str', choices=['enabled', 'disabled']),
@@ -278,7 +278,20 @@ def main():
         supports_check_mode=True
     )
 
-    (server,user,password,state,partition,validate_certs) = f5_parse_arguments(module)
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    if module.params['validate_certs']:
+        import ssl
+        if not hasattr(ssl, 'SSLContext'):
+            module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    state = module.params['state']
+    partition = module.params['partition']
+    validate_certs = module.params['validate_certs']
 
     session_state = module.params['session_state']
     monitor_state = module.params['monitor_state']

--- a/network/f5/bigip_pool.py
+++ b/network/f5/bigip_pool.py
@@ -367,7 +367,20 @@ def main():
         supports_check_mode=True
     )
 
-    (server,user,password,state,partition,validate_certs) = f5_parse_arguments(module)
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    if module.params['validate_certs']:
+        import ssl
+        if not hasattr(ssl, 'SSLContext'):
+            module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    state = module.params['state']
+    partition = module.params['partition']
+    validate_certs = module.params['validate_certs']
 
     name = module.params['name']
     pool = fq_name(partition,name)

--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -314,7 +314,7 @@ def get_member_monitor_status(api, pool, address, port):
     return result
 
 def main():
-    argument_spec = f5_argument_spec();
+    argument_spec = f5_argument_spec()
     argument_spec.update(dict(
             session_state = dict(type='str', choices=['enabled', 'disabled']),
             monitor_state = dict(type='str', choices=['enabled', 'disabled']),
@@ -334,7 +334,21 @@ def main():
         supports_check_mode=True
     )
 
-    (server,user,password,state,partition,validate_certs) = f5_parse_arguments(module)
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    if module.params['validate_certs']:
+        import ssl
+        if not hasattr(ssl, 'SSLContext'):
+            module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    state = module.params['state']
+    partition = module.params['partition']
+    validate_certs = module.params['validate_certs']
+
     session_state = module.params['session_state']
     monitor_state = module.params['monitor_state']
     pool = fq_name(partition, module.params['pool'])

--- a/network/f5/bigip_virtual_server.py
+++ b/network/f5/bigip_virtual_server.py
@@ -378,7 +378,21 @@ def main():
         supports_check_mode=True
     )
 
-    (server,user,password,state,partition,validate_certs) = f5_parse_arguments(module)
+    if not bigsuds_found:
+        module.fail_json(msg="the python bigsuds module is required")
+
+    if module.params['validate_certs']:
+        import ssl
+        if not hasattr(ssl, 'SSLContext'):
+            module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
+
+    server = module.params['server']
+    user = module.params['user']
+    password = module.params['password']
+    state = module.params['state']
+    partition = module.params['partition']
+    validate_certs = module.params['validate_certs']
+
     name = fq_name(partition,module.params['name'])
     destination=module.params['destination']
     port=module.params['port']


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- bigip_monitor_http.py
- bigip_monitor_tcp.py
- bigip_node.py
- bigip_pool.py
- bigip_pool_member.py
- bigip_virtual_server.py
##### ANSIBLE VERSION

1.9.2
##### SUMMARY

Instead of doing an unpack, deliberately specify which parameters you
want to use. This allows us to flexibly add more parameters to the
f5_argument_spec without having to rewrite all the modules that use
it.

Functionally this commit changes nothing, it just provides for a
different way of accessing the parameters to the module
