### PR TITLE
Change success status code to 202

### DIFF
--- a/monitoring/datadog_event.py
+++ b/monitoring/datadog_event.py
@@ -142,7 +142,7 @@ def post_event(module):
     headers = {"Content-Type": "application/json"}
 
     (response, info) = fetch_url(module, uri, data=json_body, headers=headers)
-    if info['status'] == 200:
+    if info['status'] == 202:
         response_body = response.read()
         response_json = module.from_json(response_body)
         if response_json['status'] == 'ok':


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

datadog_event
##### ANSIBLE VERSION

```
ansible 2.0.2.0
```
##### SUMMARY

As I already mentioned here: https://github.com/ansible/ansible-modules-extras/commit/a1b11826625b7f48d517b088651dc5ed4d6eb9d6#diff-d04a476e5d71372918cb6e7e5b39a683R120 @jimi-c added some "hidden" additional check in his urllib commit and broke the datadog_event module as Datadog answers with an 202 in case of success (http://docs.datadoghq.com/api/#troubleshooting).
