### PR TITLE
Fix for https://github.com/ansible/ansible-modules-extras/issues/2090

### DIFF
--- a/windows/win_regedit.ps1
+++ b/windows/win_regedit.ps1
@@ -118,8 +118,8 @@ else
 
 }
 
-if($registryDataType -eq "binary" -and $registryData -ne $null) {
-   $registryData = Convert-RegExportHexStringToByteArray($registryData)
+if($registryDataType -eq "binary" -and $registryData -ne $null -and $registryData.GetType().Name -eq 'String') {
+      $registryData = Convert-RegExportHexStringToByteArray($registryData)
 }
 
 if($state -eq "present") {

--- a/windows/win_regedit.py
+++ b/windows/win_regedit.py
@@ -43,7 +43,7 @@ options:
     aliases: []
   data:
     description:
-      - Registry Value Data.  Binary data should be expressed as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional. 
+      - Registry Value Data.  Binary data should be expressed a yaml byte array or as comma separated hex values.  An easy way to generate this is to run C(regedit.exe) and use the I(Export) option to save the registry values to a file.  In the exported file binary values will look like C(hex:be,ef,be,ef).  The C(hex:) prefix is optional. 
     required: false
     default: null
     aliases: []
@@ -96,11 +96,22 @@ EXAMPLES = '''
 
   # Creates Registry Key called MyCompany,
   # a value within MyCompany Key called "hello", and
-  # binary data for the value "hello" as type "binary".
+  # binary data for the value "hello" as type "binary"
+  # data expressed as comma separated list
   win_regedit:
     key: HKCU:\Software\MyCompany
     value: hello
     data: hex:be,ef,be,ef,be,ef,be,ef,be,ef
+    datatype: binary
+
+  # Creates Registry Key called MyCompany,
+  # a value within MyCompany Key called "hello", and
+  # binary data for the value "hello" as type "binary"
+  # data expressed as yaml array of bytes
+  win_regedit:
+    key: HKCU:\Software\MyCompany
+    value: hello
+    data: [0xbe,0xef,0xbe,0xef,0xbe,0xef,0xbe,0xef,0xbe,0xef]
     datatype: binary
 
   # Delete Registry Key MyCompany


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

win_regedit
##### ANSIBLE VERSION

```
ansible 2.1.0 (ame_2090_tests 773b9ada94) last updated 2016/04/26 18:32:58 (GMT +100)
  lib/ansible/modules/core: (detached HEAD 804a8e6378) last updated 2016/04/25 18:17:32 (GMT +100)
  lib/ansible/modules/extras: (detached HEAD 3031105e78) last updated 2016/04/26 18:28:44 (GMT +100)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes https://github.com/ansible/ansible-modules-extras/issues/2090

Works by only modifying the incoming registry data if it is a string representation and leaves the object array which you get when you express the data as yaml array of bytes alone.

```
before:

An exception occurred during task execution. The full traceback is:
At C:\Users\Administrator\AppData\Local\Temp\ansible-tmp-1461605846.44-111194627256823\win_regedit.ps1:348 char:57
+    $registryData = Convert-RegExportHexStringToByteArray($registryData)
+                                                         ~~~~~~~~~~~~~~~
fatal: [WIN-TESTBOX]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "win_regedit"}, "msg": "Cannot process argument transformation on parameter 'String'. Cannot convert value to type System.String."}

after
changed: [WIN-TESTBOX] => {"changed": true, "data_changed": true, "data_type_changed": true, "invocation": {"module_name": "win_regedit"}}


```
