### PR TITLE
message template variable fix

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -107,7 +107,7 @@ datadog_monitor:
   name: "Test monitor"
   state: "present"
   query: "datadog.agent.up".over("host:host1").last(2).count_by_status()"
-  message: "Some message."
+  message: "Host [[host.name]] with IP [[host.ip]] is failing to report to datadog."
   api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
   app_key: "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"
 

--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -63,7 +63,7 @@ options:
         description: ["The name of the alert."]
         required: true
     message:
-        description: ["A message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events."]
+        description: ["A message to include with notifications for this monitor. Email notifications can be sent to specific users by using the same '@username' notation as events. Monitor message template variables can be accessed by using double square brackets, i.e '[[' and ']]'."]
         required: false
         default: null
     silenced:
@@ -176,6 +176,9 @@ def main():
     elif module.params['state'] == 'unmute':
         unmute_monitor(module)
 
+def _fix_template_vars(message):
+    return message.replace('[[', '{{').replace(']]', '}}')
+
 
 def _get_monitor(module):
     for monitor in api.Monitor.get_all():
@@ -187,7 +190,7 @@ def _get_monitor(module):
 def _post_monitor(module, options):
     try:
         msg = api.Monitor.create(type=module.params['type'], query=module.params['query'],
-                                 name=module.params['name'], message=module.params['message'],
+                                 name=module.params['name'], message=_fix_template_vars(module.params['message']),
                                  options=options)
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
@@ -204,7 +207,7 @@ def _equal_dicts(a, b, ignore_keys):
 def _update_monitor(module, monitor, options):
     try:
         msg = api.Monitor.update(id=monitor['id'], query=module.params['query'],
-                                 name=module.params['name'], message=module.params['message'],
+                                 name=module.params['name'], message=_fix_template_vars(module.params['message']),
                                  options=options)
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

datadog_monitor.py
##### ANSIBLE VERSION

```
ansible 1.9.2
  configured module search path = None
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Due to ansible/jinja2 templating, it is difficult to use the monitor message template variables as they need to be surrounded by `{{` and `}}`, this change addresses that issue by allowing the user to use `[[` and `]]` instead. @skornehl, I am not sure if this is something you would approve, as it does change some base functionality, but I will say that I have tried everything to escape those curly braces on the ansible side. Ansible variables are resolved recursively so this is a real tricky problem.  Please let me know if there is anything you would like for me to change. Thanks!
