### PR TITLE
PagerDuty maintenance window module: Update the status codes to look for

### DIFF
--- a/monitoring/pagerduty.py
+++ b/monitoring/pagerduty.py
@@ -203,7 +203,7 @@ def create(module, name, user, passwd, token, requester_id, service, hours, minu
 
     data = json.dumps(request_data)
     response, info = fetch_url(module, url, data=data, headers=headers, method='POST')
-    if info['status'] != 200:
+    if info['status'] != 201:
         module.fail_json(msg="failed to create the window: %s" % info['msg'])
 
     try:
@@ -229,7 +229,7 @@ def absent(module, name, user, passwd, token, requester_id, service):
 
     data = json.dumps(request_data)
     response, info = fetch_url(module, url, data=data, headers=headers, method='DELETE')
-    if info['status'] != 200:
+    if info['status'] != 204:
         module.fail_json(msg="failed to delete the window: %s" % info['msg'])
 
     try:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

pagerduty.py
##### ANSIBLE VERSION

```
ansible 2.0.2.0
```
##### SUMMARY

Creation of a maintenance window returns a 201, not a 200 (the PagerDuty Developer documentation is unfortunately incorrect). Deleting a maintenance window returns a 204.

The first change needed was noticed when running a playbook, the second one I noticed while looking at the code.

```
TASK [pagerduty : Create a maintenance window] ********************************* 
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "failed to create the window: OK (unknown bytes)"}
```
