### PR TITLE
Added status code 201 for created ressources Fixes #2121

### DIFF
--- a/web_infrastructure/jira.py
+++ b/web_infrastructure/jira.py
@@ -187,7 +187,7 @@ def request(url, user, passwd, data=None, method=None):
                                headers={'Content-Type':'application/json',
                                         'Authorization':"Basic %s" % auth})
 
-    if info['status'] not in (200, 204):
+    if info['status'] not in (200, 201, 204):
         module.fail_json(msg=info['msg'])
 
     body = response.read()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

jira.py
##### ANSIBLE VERSION

```
2.0.2.0 (and earlier versions)
```
##### SUMMARY

Adding http status code 201 see also #2121 

<!---
"Fixes #2121" 
-->

If Jira is responding a 201 for a new created ressource, like a comment, the module will fail
with 
`fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "OK (unknown bytes)"}`
Adding the status code 201 will fix this.
