### PR TITLE
Expect 204 status when using hipchat v2 api.

### DIFF
--- a/notification/hipchat.py
+++ b/notification/hipchat.py
@@ -155,7 +155,10 @@ def send_msg_v2(module, token, room, msg_from, msg, msg_format='text',
         module.exit_json(changed=False)
 
     response, info = fetch_url(module, url, data=data, headers=headers, method='POST')
-    if info['status'] == 200:
+
+    # https://www.hipchat.com/docs/apiv2/method/send_room_notification shows
+    # 204 to be the expected result code.
+    if info['status'] in [200, 204]:
         return response.read()
     else:
         module.fail_json(msg="failed to send message, return status=%s" % str(info['status']))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

notifications/hipchat.py
##### ANSIBLE VERSION

```
ansible 2.1.0 (http_error_non_200_json 33a2564d03) last updated 2016/04/25 14:57:32 (GMT -400)
  lib/ansible/modules/core: (detached HEAD b6ad3b6773) last updated 2016/05/02 09:26:36 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 1846de2809) last updated 2016/05/02 09:26:36 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = ['/home/adrian/ansible-2.0.2-1/lib/ansible/modules/']

<!--- Paste verbatim output from “ansible --version” between quotes -->
```
##### SUMMARY

Fixes #2143 . Except 204 as a valid response when posting room notications with the hipchat v2 api.

Note: I'm not setup for hipchat, so haven't actually tested this. So HEADS UP.

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```

When posting to the room notication api with hipchat
v2 api, the expected return code is 204, as per:
https://www.hipchat.com/docs/apiv2/method/send_room_notification

fixes #2143
