### PR TITLE
Fix the interface handling code to allow immediate changes.  Also fixes switching an interface between zones.

### DIFF
--- a/system/firewalld.py
+++ b/system/firewalld.py
@@ -213,6 +213,18 @@ def remove_source(zone, source):
 # interface handling
 #
 def get_interface(zone, interface):
+    if interface in fw.getInterfaces(zone):
+        return True
+    else:
+        return False
+
+def change_zone_of_interface(zone, interface):
+    fw.changeZoneOfInterface(zone, interface)
+
+def remove_interface(zone, interface):
+    fw.removeInterface(zone, interface)
+
+def get_interface_permanent(zone, interface):
     fw_zone = fw.config().getZoneByName(zone)
     fw_settings = fw_zone.getSettings()
     if interface in fw_settings.getInterfaces():
@@ -220,13 +232,20 @@ def get_interface(zone, interface):
     else:
         return False
 
-def add_interface(zone, interface):
+def change_zone_of_interface_permanent(zone, interface):
     fw_zone = fw.config().getZoneByName(zone)
     fw_settings = fw_zone.getSettings()
-    fw_settings.addInterface(interface)
-    fw_zone.update(fw_settings)
+    old_zone_name = fw.config().getZoneOfInterface(interface)
+    if old_zone_name != zone:
+        if old_zone_name:
+            old_zone_obj = fw.config().getZoneByName(old_zone_name)
+            old_zone_settings = old_zone_obj.getSettings()
+            old_zone_settings.removeInterface(interface) # remove from old
+            old_zone_obj.update(old_zone_settings)
+        fw_settings.addInterface(interface)              # add to new
+        fw_zone.update(fw_settings)
 
-def remove_interface(zone, interface):
+def remove_interface_permanent(zone, interface):
     fw_zone = fw.config().getZoneByName(zone)
     fw_settings = fw_zone.getSettings()
     fw_settings.removeInterface(interface)
@@ -535,23 +554,44 @@ def main():
             msgs.append("Changed rich_rule %s to %s" % (rich_rule, desired_state))
 
     if interface != None:
-        is_enabled = get_interface(zone, interface)
-        if desired_state == "enabled":
-            if is_enabled == False:
-                if module.check_mode:
-                    module.exit_json(changed=True)
+        if permanent:
+            is_enabled = get_interface_permanent(zone, interface)
+            msgs.append('Permanent operation')
+            if desired_state == "enabled":
+                if is_enabled == False:
+                    if module.check_mode:
+                        module.exit_json(changed=True)
 
-                add_interface(zone, interface)
-                changed=True
-                msgs.append("Added %s to zone %s" % (interface, zone))
-        elif desired_state == "disabled":
-            if is_enabled == True:
-                if module.check_mode:
-                    module.exit_json(changed=True)
+                    change_zone_of_interface_permanent(zone, interface)
+                    changed=True
+                    msgs.append("Changed %s to zone %s" % (interface, zone))
+            elif desired_state == "disabled":
+                if is_enabled == True:
+                    if module.check_mode:
+                        module.exit_json(changed=True)
 
-                remove_interface(zone, interface)
-                changed=True
-                msgs.append("Removed %s from zone %s" % (interface, zone))
+                    remove_interface_permanent(zone, interface)
+                    changed=True
+                    msgs.append("Removed %s from zone %s" % (interface, zone))
+        if immediate or not permanent:
+            is_enabled = get_interface(zone, interface)
+            msgs.append('Non-permanent operation')
+            if desired_state == "enabled":
+                if is_enabled == False:
+                    if module.check_mode:
+                        module.exit_json(changed=True)
+
+                    change_zone_of_interface(zone, interface)
+                    changed=True
+                    msgs.append("Changed %s to zone %s" % (interface, zone))
+            elif desired_state == "disabled":
+                if is_enabled == True:
+                    if module.check_mode:
+                        module.exit_json(changed=True)
+
+                    remove_interface(zone, interface)
+                    changed=True
+                    msgs.append("Removed %s from zone %s" % (interface, zone))
 
     if masquerade != None:
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

firewalld
##### ANSIBLE VERSION

```
ansible 2.1.0 (stable-2.1 1e5708514b) last updated 2016/04/29 14:42:44 (GMT -400)
  lib/ansible/modules/core: (stable-2.1 babb97e473) last updated 2016/04/29 14:43:01 (GMT -400)
  lib/ansible/modules/extras: (interfacezone 9f2bc2853d) last updated 2016/05/02 11:17:28 (GMT -400)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This patch adds support for immediate changes to firewall configs when adding interfaces to zones.  (The prior patch only changed the permanent configs.)
In addition, the patch fixes the case where an interface is already bound to a zone, and the new config tries to bind it to a different zone.  Using the existing code in this case returns a ZONE_CONFLICT error.  The patch in the immediate case avoids using addInterface, and uses changeZoneOfInterface instead, and in the permanent case, removes the interface from the old zone first, and then adds it to the new zone.
