### PR TITLE
Fix pkgutil "upgrade_catalog must be one of" err

### DIFF
--- a/packaging/os/pkgutil.py
+++ b/packaging/os/pkgutil.py
@@ -54,8 +54,7 @@ options:
     description:
       - If you want to refresh your catalog from the mirror, set this to (C(yes)).
     required: false
-    choices: ["yes", "no"]
-    default: no
+    default: False
     version_added: "2.1"
 '''
 
@@ -130,7 +129,7 @@ def main():
             name = dict(required = True),
             state = dict(required = True, choices=['present', 'absent','latest']),
             site = dict(default = None),
-            update_catalog = dict(required = False, default = "no", type='bool', choices=["yes","no"]),
+            update_catalog = dict(required = False, default = False, type='bool'),
         ),
         supports_check_mode=True
     )


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

packaging/os/pkgutil
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel eb31faa7f5) last updated 2016/05/02 11:30:45 (GMT -400)
  lib/ansible/modules/core: (detached HEAD b6ad3b6773) last updated 2016/05/02 09:26:36 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 1846de2809) last updated 2016/05/02 09:26:36 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = ['/home/adrian/ansible-2.0.2-1/lib/ansible/modules/']
```
##### SUMMARY

Fixes https://github.com/ansible/ansible-modules-extras/issues/2144

NOTE: _COMPLETELY UNTESTED_

The arg spec for update_catalog include 'type=bool'
and 'choices=["yes", "no"] which can never both be
true.

Remove the 'choices' directive, and update doc string.

Fixes #2144
