### PR TITLE
Check to see existence of same named/location system before creation.

### DIFF
--- a/cloud/softlayer/sl_vm.py
+++ b/cloud/softlayer/sl_vm.py
@@ -225,6 +225,16 @@ except ImportError:
 
 def create_virtual_instance(module):
 
+  instances = vsManager.list_instances(
+    hostname = module.params.get('hostname'),
+    domain = module.params.get('domain'),
+    datacenter = module.params.get('datacenter')
+  )
+  
+  if instances:
+    return False, None
+
+
   # Check if OS or Image Template is provided (Can't be both, defaults to OS)
   if (module.params.get('os_code') != None and module.params.get('os_code') != ''):
     module.params['image_id'] = ''
@@ -303,6 +313,7 @@ def cancel_instance(module):
 
 
 def main():
+
   module = AnsibleModule(
     argument_spec=dict(
       instance_id=dict(),
@@ -338,7 +349,7 @@ def main():
 
   elif module.params.get('state') == 'present':
       (changed, instance) = create_virtual_instance(module)
-      if module.params.get('wait') == True:
+      if module.params.get('wait') == True and instance:
         (changed, instance) = wait_for_instance(module, instance['id'])
 
   module.exit_json(changed=changed, instance=json.loads(json.dumps(instance, default=lambda o: o.__dict__)))


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

sl_vm.py
##### ANSIBLE VERSION

```
ansible 2.0.1.0

```
##### SUMMARY

The sl_vm module will create the same VM every single time it is run.  This is not desired, instead only create the VM if there is no existing VM with the same hostname and domain name in the same datacenter.
