### PR TITLE
adding a purge_tables option to be able to disable the purge of existing associations when adding new ones

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -16,7 +16,7 @@
 DOCUMENTATION = '''
 ---
 module: ec2_vpc_route_table
-version_added: "2.2"
+version_added: 2.2
 short_description: Manage route tables for AWS virtual private clouds
 description:
     - Manage route tables for AWS virtual private clouds
@@ -65,6 +65,7 @@ options:
   purge_tables:
     description:
       - "If set to true, existing associations will be purged"
+    version_added: 2.2
 extends_documentation_fragment:
     - aws
     - ec2

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -16,10 +16,10 @@
 DOCUMENTATION = '''
 ---
 module: ec2_vpc_route_table
-version_added: 2.2
 short_description: Manage route tables for AWS virtual private clouds
 description:
     - Manage route tables for AWS virtual private clouds
+version_added: "2.0"
 author: Robert Estelle (@erydo), Rob White (@wimnat)
 options:
   lookup:

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -16,10 +16,10 @@
 DOCUMENTATION = '''
 ---
 module: ec2_vpc_route_table
+version_added: "2.2"
 short_description: Manage route tables for AWS virtual private clouds
 description:
     - Manage route tables for AWS virtual private clouds
-version_added: "2.0"
 author: Robert Estelle (@erydo), Rob White (@wimnat)
 options:
   lookup:


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ansible-modules-extras/cloud/amazon/ec2_vpc_route_table.py
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 21f2556662) last updated 2016/04/28 13:52:40 (GMT +1100)
```
##### SUMMARY

When associating a subnet to an existing AWS routing table, all existing associations are purged by default. This change allows for not purging, i.e. it allows to add new associations without removin existing one by adding a "purge_tables = False" parameter.

The rationale is that it is possible to do exactly that through the AWS GUI or boto.  
