### PR TITLE
rabbitmq_user: Properly initialize _permissions

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -139,7 +139,7 @@ class RabbitMqUser(object):
         self.bulk_permissions = bulk_permissions
 
         self._tags = None
-        self._permissions = None
+        self._permissions = []
         self._rabbitmqctl = module.get_bin_path('rabbitmqctl', True)
 
     def _exec(self, args, run_in_check_mode=False):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

rabbitmq_user
##### ANSIBLE VERSION

```
"ansible 2.2.0 (devel fbec9ce58b) last updated 2016/05/04 13:07:35 (GMT +200)"
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Initialize self._permissions to [] instead of None.
This prevents an issue where, if there are no users on the system, a call to self.get would not read any permissions into self._permissions, and it would stay set to None, which causes an issue when calling self.set_permissions.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #2162
