### PR TITLE
fix indentation not being a multiple of four [E111]

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -203,19 +203,19 @@ def main():
     state = module.params['state']
 
     try:
-    	if replica_set:
-    	   client = MongoClient(login_host, int(login_port), replicaset=replica_set, ssl=ssl)
-    	else:
-    	   client = MongoClient(login_host, int(login_port), ssl=ssl)
+        if replica_set:
+            client = MongoClient(login_host, int(login_port), replicaset=replica_set, ssl=ssl)
+        else:
+            client = MongoClient(login_host, int(login_port), ssl=ssl)
 
         # try to authenticate as a target user to check if it already exists
         try:
-           client[db_name].authenticate(user, password)
-           if state == 'present':
-              module.exit_json(changed=False, user=user)
+            client[db_name].authenticate(user, password)
+            if state == 'present':
+                module.exit_json(changed=False, user=user)
         except OperationFailure:
-           if state == 'absent':
-              module.exit_json(changed=False, user=user)
+            if state == 'absent':
+                module.exit_json(changed=False, user=user)
 
         if login_user is None and login_password is None:
             mongocnf_creds = load_mongocnf()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

mongodb_user
##### ANSIBLE VERSION

```
ansible 1.9.4
  configured module search path = None
```
##### SUMMARY

Indentation in that file was not a multiple of 4.
This is causing an issue when typing `make install` in a freshly build copy of python (im testing against Python-2.7.11) when ansible is already installed in the system.
This is a copy of #2169 but with the correct branches.

```
#before fix
make install
[...]
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/__init__.py ...
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/mongodb_user.py ...
Sorry: TabError: inconsistent use of tabs and spaces in indentation (mongodb_user.py, line 212)
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/redis.py ...
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/riak.py ...
[...]

# afterthe fix
[...]
Listing /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc ...
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/__init__.py ...
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/mongodb_user.py ...
Compiling /usr/local/lib/python2.7/dist-packages/ansible/modules/extras/database/misc/redis.py ...
[...]
```
