### PR TITLE
Ansible testing exclusions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ script:
   - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
-  - ansible-validate-modules --exclude 'cloud/cloudstack/cs_template\.py|cloud/centurylink/clc_aa_policy\.py|cloud/centurylink/clc_alert_policy\.py|cloud/centurylink/clc_blueprint_package\.py|cloud/centurylink/clc_firewall_policy\.py|cloud/centurylink/clc_group\.py|cloud/centurylink/clc_loadbalancer\.py|cloud/centurylink/clc_modify_server\.py|cloud/centurylink/clc_publicip\.py|cloud/centurylink/clc_server\.py|cloud/centurylink/clc_server_snapshot\.py|cloud/docker/docker_login\.py|messaging/rabbitmq_binding\.py|messaging/rabbitmq_exchange\.py|messaging/rabbitmq_queue\.py|monitoring/circonus_annotation\.py|network/snmp_facts\.py|notification/sns\.py|cloud/cloudstack/cs_template\.py' .
+  - ansible-validate-modules --exclude 'cloud/cloudstack/cs_template\.py' .
   #- ./test-docs.sh extras

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ script:
   - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
-  - ansible-validate-modules --exclude 'cloud/cloudstack/cs_template\.py' .
+  - ansible-validate-modules .
   #- ./test-docs.sh extras

--- a/cloud/amazon/ec2_ami_copy.py
+++ b/cloud/amazon/ec2_ami_copy.py
@@ -88,9 +88,6 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-    
-if not HAS_BOTO:
-    module.fail_json(msg='boto required for this module')
 
 def copy_image(module, ec2):
     """
@@ -179,6 +176,9 @@ def main():
         tags=dict(type='dict')))
 
     module = AnsibleModule(argument_spec=argument_spec)
+
+    if not HAS_BOTO:
+        module.fail_json(msg='boto required for this module')
 
     try:
         ec2 = ec2_connect(module)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

```
.travis.yml
cloud/amazon/ec2_ami_copy.py
```
##### ANSIBLE VERSION

```
devel
```
##### SUMMARY

We no longer need any exclusions for extras due to fixes and changes to `ansible-testing`.

Additionally, there was an issue with how `ec2_ami_copy.py` attempted to fail when boto was not present.
