### PR TITLE
Fix session-based kv acquire/release

### DIFF
--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -130,6 +130,13 @@ EXAMPLES = '''
     consul_kv:
       key: ansible/groups/dc1/somenode
       value: 'top_secret'
+
+  - name: Register a key/value pair with an associated session
+    consul_kv:
+      key: stg/node/server_birthday
+      value: 20160509
+      session: "{{ sessionid }}"
+      state: acquire
 '''
 
 import sys


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

consul_kv
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes https://github.com/ansible/ansible-modules-extras/issues/2155

Ensure that the `session` and `state` values are accepted as module parameters per the module documentation, that these parameters successfully invoke the `lock()` method, that the `lock()` method defines `consul_api`, and that the module only returns `changed` when a modification to the original values occurs.
