### PR TITLE
add 'behavior' attribute to consul_session

### DIFF
--- a/clustering/consul_session.py
+++ b/clustering/consul_session.py
@@ -50,6 +50,13 @@ options:
             to Consul and not required.
         required: false
         default: None
+    behavior:
+        description:
+          - the optional behavior that can be attached to the session when it
+            is created. This can be set to either ‘release’ or ‘delete’. This
+            controls the behavior when a session is invalidated.
+        default: release
+        required: false
     delay:
         description:
           - the optional lock delay that can be attached to the session when it
@@ -188,6 +195,7 @@ def update_session(module):
     checks = module.params.get('checks')
     datacenter = module.params.get('datacenter')
     node = module.params.get('node')
+    behavior = module.params.get('behavior')
 
     consul_client = get_consul_api(module)
 
@@ -195,6 +203,7 @@ def update_session(module):
         
         session = consul_client.session.create(
             name=name,
+            behavior=behavior,
             node=node,
             lock_delay=validate_duration('delay', delay),
             dc=datacenter,
@@ -203,6 +212,7 @@ def update_session(module):
         module.exit_json(changed=True,
                          session_id=session,
                          name=name,
+                         behavior=behavior,
                          delay=delay,
                          checks=checks,
                          node=node)
@@ -249,6 +259,8 @@ def main():
     argument_spec = dict(
         checks=dict(default=None, required=False, type='list'),
         delay=dict(required=False,type='str', default='15s'),
+        behavior=dict(required=False,type='str', default='release',
+                      choices=['release', 'delete']),
         host=dict(default='localhost'),
         port=dict(default=8500, type='int'),
         scheme=dict(required=False, default='http'),

--- a/clustering/consul_session.py
+++ b/clustering/consul_session.py
@@ -50,13 +50,6 @@ options:
             to Consul and not required.
         required: false
         default: None
-    behavior:
-        description:
-          - the optional behavior that can be attached to the session when it
-            is created. This can be set to either ‘release’ or ‘delete’. This
-            controls the behavior when a session is invalidated.
-        default: release
-        required: false
     delay:
         description:
           - the optional lock delay that can be attached to the session when it
@@ -107,6 +100,14 @@ options:
         required: false
         default: True
         version_added: "2.1"
+    behavior:
+        description:
+          - the optional behavior that can be attached to the session when it
+            is created. This can be set to either ‘release’ or ‘delete’. This
+            controls the behavior when a session is invalidated.
+        default: release
+        required: false
+        version_added: "2.2"
 """
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

consul_session
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Implements https://github.com/ansible/ansible-modules-extras/issues/2154

python-consul provides the [behavior parameter](http://python-consul.readthedocs.io/en/latest/#consul.base.Consul.Session)  when creating a session:

`behavior` can be set to either ‘release’ or ‘delete’. This controls the behavior when a session is invalidated. By default, this is ‘release’, causing any locks that are held to be released. Changing this to ‘delete’ causes any locks that are held to be deleted. ‘delete’ is useful for creating ephemeral key/value entries

``` yaml
    - name: Register new session
      consul_session:
        name: "{{ consul_session_name }}"
        behavior: delete
```
