### PR TITLE
Update win_iis_webapplication.ps1

### DIFF
--- a/windows/win_iis_webapplication.ps1
+++ b/windows/win_iis_webapplication.ps1
@@ -124,9 +124,11 @@ try {
 
 # Result
 $application = Get-WebApplication -Site $site -Name $name
-$result.application = New-Object psobject @{
-  PhysicalPath = $application.PhysicalPath
-  ApplicationPool = $application.applicationPool
+if ($application)
+{
+    $result.application = New-Object psobject @{
+      PhysicalPath = $application.PhysicalPath
+      ApplicationPool = $application.applicationPool
+    }
 }
-
 Exit-Json $result


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

win_iis_webapplication
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

In the win_iis_webapplication module, this is an error when the state is absent.

Fix issue #15390
