### PR TITLE
Fixing incorrect option name for consul_acl

### DIFF
--- a/clustering/consul_acl.py
+++ b/clustering/consul_acl.py
@@ -40,7 +40,7 @@ options:
           - whether the ACL pair should be present or absent, defaults to present
         required: false
         choices: ['present', 'absent']
-    type:
+    token_type:
         description:
           - the type of token that should be created, either management or
             client, defaults to client

--- a/clustering/consul_acl.py
+++ b/clustering/consul_acl.py
@@ -40,7 +40,7 @@ options:
           - whether the ACL pair should be present or absent, defaults to present
         required: false
         choices: ['present', 'absent']
-    token_type:
+    type:
         description:
           - the type of token that should be created, either management or
             client, defaults to client
@@ -148,7 +148,7 @@ def update_acl(module):
     rules = module.params.get('rules')
     state = module.params.get('state')
     token = module.params.get('token')
-    token_type = module.params.get('token_type')
+    token_type = module.params.get('type')
     mgmt = module.params.get('mgmt_token')
     name = module.params.get('name')
     consul = get_consul_api(module, mgmt)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

consul_acl
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The code is looking for `token_type`. Updated the documentation to specify `token_type` instead of `type`.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Fixes #2213
