### PR TITLE
Add thin pool / volume managment to lvol (originally PR #1422) 

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -63,6 +63,7 @@ options:
     version_added: "2.0"
     description:
     - Free-form options to be passed to the lvcreate command
+<<<<<<< HEAD
   snapshot:
     version_added: "2.1"
     description:
@@ -72,6 +73,11 @@ options:
     version_added: "2.2"
     description:
     - Comma separated list of physical volumes e.g. /dev/sda,/dev/sdb
+=======
+  thinpool:
+    description:
+    - The thin pool volume name. When you want to create thinprovisioning volume, specify thin pool volume name.
+>>>>>>> add functionality to create thin pool / volume on Linux LVM to lvol module
     required: false
 notes:
   - Filesystems on top of the volume are not resized.
@@ -114,8 +120,16 @@ EXAMPLES = '''
 # Remove the logical volume.
 - lvol: vg=firefly lv=test state=absent force=yes
 
+<<<<<<< HEAD
 # Create a snapshot volume of the test logical volume.
 - lvol: vg=firefly lv=test snapshot=snap1 size=100m
+=======
+# Create a thin pool of 512g.
+- lvol: vg=firefly thinpool=testpool size=512g
+
+# Create a thin volume of 128g.
+- lvol: vg=firefly lv=test thinpool=testpool size=128g
+>>>>>>> add functionality to create thin pool / volume on Linux LVM to lvol module
 '''
 
 import re
@@ -163,13 +177,17 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             vg=dict(required=True),
-            lv=dict(required=True),
+            lv=dict(type='str'),
             size=dict(type='str'),
             opts=dict(type='str'),
             state=dict(choices=["absent", "present"], default='present'),
             force=dict(type='bool', default='no'),
+<<<<<<< HEAD
             snapshot=dict(type='str', default=None),
             pvs=dict(type='str')
+=======
+            thinpool=dict(type='str'),
+>>>>>>> add functionality to create thin pool / volume on Linux LVM to lvol module
         ),
         supports_check_mode=True,
     )
@@ -190,6 +208,7 @@ def main():
     opts = module.params['opts']
     state = module.params['state']
     force = module.boolean(module.params['force'])
+    thinpool = module.params['thinpool']
     size_opt = 'L'
     size_unit = 'm'
     snapshot = module.params['snapshot']
@@ -265,12 +284,30 @@ def main():
 
     lvs = parse_lvs(current_lvs)
 
+<<<<<<< HEAD
     if snapshot is None:
         check_lv = lv
     else:
         check_lv = snapshot
     for test_lv in lvs:
         if test_lv['name'] == check_lv:
+=======
+    if thinpool and lv:
+        for test_lv in lvs:
+            if test_lv['name'] == thinpool:
+                break
+        else:
+            module.fail_json(msg="Thin poll %s does not exist." % thinpool)
+
+    if thinpool and not lv:
+        target = thinpool
+    elif lv:
+        target = lv
+    else:
+        module.fail_json(msg="lv param is required unless thinpool param is specified.")
+
+    for test_lv in lvs:
+        if test_lv['name'] == target:
             this_lv = test_lv
             break
     else:
@@ -294,6 +331,16 @@ def main():
                     cmd = "%s %s -%s %s%s -s -n %s %s %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, snapshot, opts, vg, lv)
                 else:
                     cmd = "%s %s -n %s -%s %s%s %s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, pvs)
+                if thinpool and lv:
+                    if size_opt == 'l':
+                       module.fail_json(changed=False, msg="Thin volume sizing with percentage not supported.")
+                    size_opt = 'V'
+
+                    cmd = "%s %s -n %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg, thinpool)
+                elif thinpool and not lv:
+                    cmd = "%s %s -%s %s%s %s -T %s/%s" % (lvcreate_cmd, yesopt, size_opt, size, size_unit, opts, vg, thinpool)
+                else:
+                    cmd = "%s %s -n %s -%s %s%s %s %s" % (lvcreate_cmd, yesopt, lv, size_opt, size, size_unit, opts, vg)
                 rc, _, err = module.run_command(cmd)
                 if rc == 0:
                     changed = True


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

lvol
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

I have taken the stale PR #1422, originally by @KlabKatsumi and resolved the merge conflict.
I also addressed the suggestions by @mscherer and @haad

Below is the (slightly updated) verbatim description of the original PR.
- Adds `thinpool` parameter. change `lv`parameter to not required (now using `required_one_of`).

To create a thin pool, specify `thinpool` ,`vg` and `size` parameter and omit `lv` parameter.
It will create a thin pool named according to the `thinpool` parameter.

To create a thin volume, specify both `thinpool`' and `lv` parameter (as well as `vg` and `size` parameter). This will create a thin volume in the `thinpool` pool, named by the `lv` parameter.

Thin volume and pool can be deleted by setting `state` to `absent`.
Thin volume is resizable like a normal volume.
Thin pool can be extend, but not reduced. This is a limitation of Linux's LVM.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
