### PR TITLE
zypper: (Bugfix) Remove global option --verbose from command option position

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -140,7 +140,7 @@ def get_installed_state(m, packages):
     "get installed state of packages"
 
     cmd = get_cmd(m, 'search')
-    cmd.extend(['--match-exact', '--verbose', '--installed-only'])
+    cmd.extend(['--match-exact', '--details', '--installed-only'])
     cmd.extend(packages)
     return parse_zypper_xml(m, cmd, fail_not_found=False)[0]
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

zypper
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 2cc50c6dc6) last updated 2016/05/13 12:31:07 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a7e45db9e6) last updated 2016/05/13 12:38:41 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD cd03f10b9c) last updated 2016/05/13 12:38:48 (GMT +200)
```
##### SUMMARY

Remove a global zypper option from the wrong position

Before:

```
server1 | FAILED! => {
    "changed": false,
    "cmd": [
        "/usr/bin/zypper",
        "--quiet",
        "--non-interactive",
        "--xmlout",
        "search",
        "--type",
        "package",
        "--match-exact",
        "--verbose",
        "--installed-only",
        "tcpdump"
    ],
    "failed": true,
    "msg": "Zypper run command failed with return code 2.",
    "rc": 2,
    "stderr": "Unknown option '--verbose'\n",
    "stdout": "<?xml version='1.0'?>\n<stream>\n</stream>\n",
    "stdout_lines": [
        "<?xml version='1.0'?>",
        "<stream>",
        "</stream>"
    ]
}
```

After:

```
server1 | SUCCESS => {
    "changed": false,
    "name": [
        "tcpdump"
    ],
    "rc": 0,
    "state": "installed"
}
```

@robinro Or is the verbose option necessary? Should we change/drop the --quiet?

fixes https://github.com/ansible/ansible-modules-extras/issues/2218
