### PR TITLE
the ansible version constant is now in a different place

### DIFF
--- a/files/blockinfile.py
+++ b/files/blockinfile.py
@@ -244,7 +244,7 @@ def main():
     marker1 = re.sub(r'{mark}', 'END', marker)
     if present and block:
         # Escape seqeuences like '\n' need to be handled in Ansible 1.x
-        if module.constants['ANSIBLE_VERSION'].startswith('1.'):
+        if module.ansible_version.startswith('1.'):
             block = re.sub('', block, '')
         blocklines = [marker0] + block.splitlines() + [marker1]
     else:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

blockinfile
##### ANSIBLE VERSION

```
2.1 and devel
```
##### SUMMARY

Storage of ansible module constants has changed and so this needs to be adjusted.
