### PR TITLE
monitoring/zabbix_host: Fix (no) proxy handling

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -362,8 +362,9 @@ class Host(object):
         if set(list(template_ids)) != set(exist_template_ids):
             return True
 
-        if host['proxy_hostid'] != proxy_id:
-            return True
+        if proxy_id is not None:
+            if host['proxy_hostid'] != proxy_id:
+                return True
 
         return False
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

monitoring/zabbix_host
##### SUMMARY

When updating a host with no proxy explicitly set, the host was always reported as changed, because it was comparing `"0"` and `None`.
