### PR TITLE
Use a python3 compatible notation for octal

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -568,7 +568,7 @@ def create_script(command):
         f.close()
 
     # Ensure the script is executable.
-    os.chmod(script_file, 0700)
+    os.chmod(script_file, int('0700',8))
 
     # Output log file.
     stdout_file = os.fdopen(tempfile.mkstemp(prefix='lxc-attach-script-log')[0], 'ab')
@@ -1371,7 +1371,7 @@ class LxcContainerManagement(object):
         :type source_dir: ``str``
         """
 
-        old_umask = os.umask(0077)
+        old_umask = os.umask(int('0077',8))
 
         archive_path = self.module.params.get('archive_path')
         if not os.path.isdir(archive_path):

--- a/monitoring/boundary_meter.py
+++ b/monitoring/boundary_meter.py
@@ -220,7 +220,7 @@ def download_request(module, name, apiid, apikey, cert_type):
                 cert_file = open(cert_file_path, 'w')
                 cert_file.write(body)
                 cert_file.close()
-                os.chmod(cert_file_path, 0600)
+                os.chmod(cert_file_path, int('0600', 8))
             except: 
                 module.fail_json("Could not write to certificate file")
 

--- a/system/cronvar.py
+++ b/system/cronvar.py
@@ -363,7 +363,7 @@ def main():
     res_args = dict()
 
     # Ensure all files generated are only writable by the owning user.  Primarily relevant for the cron_file option.
-    os.umask(022)
+    os.umask(int('022',8))
     cronvar = CronVar(module, user, cron_file)
 
     module.debug('cronvar instantiated - name: "%s"' % name)


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

boundary_meter, cronvar, lxc_container
##### SUMMARY

in order ot prepare for python3 compatibility, we should use this construct, as seen in https://github.com/ansible/ansible/blob/devel/docsite/rst/developing_modules_python3.rst 
