### PR TITLE
Port vca_nat and vca_fw to py3 compatible syntax

### DIFF
--- a/cloud/vmware/vca_fw.py
+++ b/cloud/vmware/vca_fw.py
@@ -184,7 +184,7 @@ def main():
 
     try:
         desired_rules = validate_fw_rules(fw_rules)
-    except VcaError, e:
+    except VcaError as e:
         module.fail_json(msg=e.message)
 
     result = dict(changed=False)

--- a/cloud/vmware/vca_nat.py
+++ b/cloud/vmware/vca_nat.py
@@ -154,7 +154,7 @@ def main():
 
     try:
         desired_rules = validate_nat_rules(nat_rules)
-    except VcaError, e:
+    except VcaError as e:
         module.fail_json(msg=e.message)
 
     rules = gateway.get_nat_rules()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

vca_nat, vca_fw
##### SUMMARY

Since they both depend on library that cannot run on python2.4,
cf https://github.com/ansible/ansible/pull/15870, we can use
directly the python 2.6 syntax, as seen on the porting doc.
