### PR TITLE
Resolve error case where state=present fails

### DIFF
--- a/packaging/os/svr4pkg.py
+++ b/packaging/os/svr4pkg.py
@@ -227,7 +227,7 @@ def main():
 
     # Only return failed=False when the returncode is known to be good as there may be more
     # undocumented failure return codes
-    if rc not in (0, 2, 10, 20):
+    if rc not in (None, 0, 2, 10, 20):
         result['failed'] = True
     else:
         result['failed'] = False


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- packaging/os/svr4pkg.py
##### ANSIBLE VERSION

```
ansible 2.0.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

But also probaby anything since then since this file hasn't changed since may 2015
##### SUMMARY

Add "None" to checked options because the variable `rc` is not changed from `None` if the package is already installed.

If you run this once to install a package it works. If you run it a second time you end up with changed == False , failed == True

state=present fails here when the package is already installed because rc is still set to none (192-199) when state=present
