### PR TITLE
Added more details for for ecs_service load_balancers doc

### DIFF
--- a/cloud/amazon/ecs_service.py
+++ b/cloud/amazon/ecs_service.py
@@ -50,7 +50,7 @@ options:
         required: false
     load_balancers:
         description:
-          - The list of ELBs defined for this service
+          - The list of ELBs defined for this service.  Each ELB should have loadBalancerName, containerName and containerPort defined. Also role parameter should be defined if we are defining laod_balancers.
         required: false
 
     desired_count:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```

each load balancer dict  should define loadBalancerName, containerName and containerPort. This was not mentioned on the Ansible doc. but it is available on boto doc here:  http://boto3.readthedocs.io/en/latest/reference/services/ecs.html
