### PR TITLE
blockinfile: do not always add newline at EOF

### DIFF
--- a/files/blockinfile.py
+++ b/files/blockinfile.py
@@ -280,7 +280,9 @@ def main():
     lines[n0:n0] = blocklines
 
     if lines:
-        result = '\n'.join(lines)+'\n'
+        result = '\n'.join(lines)
+        if original.endswith('\n'):
+            result += '\n'
     else:
         result = ''
     if original == result:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

blockinfile
##### ANSIBLE VERSION

2.1
##### SUMMARY

blockinfile should not always add a newline at the end of the file (that was removed by splitlines). therefore it will mark a task as changed that didn't modify the file. This request supersedes https://github.com/ansible/ansible-modules-extras/pull/2258 and https://github.com/ansible/ansible-modules-extras/pull/2260

ping @yaegashi @bcoca @sivel
