### PR TITLE
win_regedit: Ensure that the module is idempotent

### DIFF
--- a/windows/win_regedit.ps1
+++ b/windows/win_regedit.ps1
@@ -155,7 +155,7 @@ if($state -eq "present") {
                 }
             }
             # Changes Only Data
-            elseif (-Not (Compare-RegistryData -ReferenceData $currentRegistryData -DifferenceData $registryData))
+            elseif ($currentRegistryData -ne $registryData)
             {
                 Try {
                     Set-ItemProperty -Path $registryKey -Name $registryValue -Value $registryData


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

win_regedit
##### ANSIBLE VERSION

```
2.1.0.0-0.3.rc3
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

Without this change a DWORD registry change of value data would always trigger a change.
After this change, it correctly reports OK a subsequent run, and CHANGED if the value data changes.
