### PR TITLE
ip module feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,6 @@ env:
       network/f5/bigip_pool_member.py
       network/f5/bigip_pool.py
       network/f5/bigip_virtual_server.py
-      network/ip.py
       network/nmcli.py
       network/openvswitch_bridge.py
       network/openvswitch_port.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,7 @@ env:
       network/f5/bigip_pool_member.py
       network/f5/bigip_pool.py
       network/f5/bigip_virtual_server.py
+      network/ip.py
       network/nmcli.py
       network/openvswitch_bridge.py
       network/openvswitch_port.py

--- a/network/ip.py
+++ b/network/ip.py
@@ -72,6 +72,10 @@ EXAMPLES = '''
 
 '''
 
+RETURN = '''
+---
+'''
+
 import ipaddress
 
 def parse_ip(text):

--- a/network/ip.py
+++ b/network/ip.py
@@ -498,7 +498,7 @@ def main():
         # add an IF to a bridge
         if kind == 'port':
             
-            if state=="present":
+            if state == "present":
                 if not (dev and link):    
                     module.fail_json(msg='valid device and bridge required')
                 if not link.is_bridge():
@@ -509,7 +509,7 @@ def main():
                 else:
                     dev.set_master(link)
                     module.exit_json(changed=True)
-            if state=="absent":
+            if state == "absent":
                 if not (dev):    
                     module.fail_json(msg='valid device required')
                     

--- a/network/ip.py
+++ b/network/ip.py
@@ -85,9 +85,9 @@ def parse_ip(text):
     except ipaddress.AddressValueError:
         try:
             addr = ipaddress.IPv4Interface(text)
-        except Exception as e:
+        except Exception, e:
             raise Exception(e)
-    except Exception as e:
+    except Exception, e:
         raise Exception(e)
         
     return(addr)
@@ -117,7 +117,7 @@ def main():
     
     try:
         setto=parse_ip(u''+params['addr'])
-    except Exception as e:
+    except Exception, e:
         module.fail_json(msg='invalid address: '+str(e))
     
     devids = ip.link_lookup(ifname=params['dev'])
@@ -156,7 +156,7 @@ def main():
                     ip.addr('delete', index=devid, address=setto.ip.compressed, prefixlen=setto.network.prefixlen)
                     changed=True
                     
-        except NetlinkError as e:
+        except NetlinkError, e:
             module.fail_json(msg='could not perform operation: '+str(e))
             
         module.exit_json( changed=changed)
@@ -174,7 +174,7 @@ def main():
         if params['via'] != None:
             try:
                 via=parse_ip(u''+params['via'])
-            except Exception as e:
+            except Exception, e:
                 module.fail_json(msg='invalid via address: '+str(e))
         
         present=False
@@ -202,7 +202,7 @@ def main():
                 if params['state']=='absent':
                     try:
                         ip.route('delete',dst=str(dst.network),oif=oif)
-                    except NetlinkError as e:
+                    except NetlinkError, e:
                         module.fail_json(msg='could not delete route: '+str(e))
                     
                     module.exit_json(changed=True)
@@ -220,7 +220,7 @@ def main():
                     ip.route('add', dst=str(setto.network), oif=devid)
                 else:
                     ip.route('add', dst=str(setto.network), gateway=str(via.ip), oif=devid)
-            except NetlinkError as e:
+            except NetlinkError, e:
                 module.fail_json(msg='could not add route: '+str(e))
                 
             module.exit_json(changed=True)

--- a/network/ip.py
+++ b/network/ip.py
@@ -21,13 +21,13 @@ author: "Felix Engelmann (@felix-engelmann)"
 short_description: Wrapper of the linux ip tool
 requirements: [ pyroute2 ]
 description:
-    - Performs linux ip address manipulations for interfaces and route adjustments
+    - Performs linux ip address manipulations for interfaces and route adjustments.
 options:
     mode:
         required: true
         choices: [ address, route ]
         description:
-            - Whether to change an address or a route
+            - Whether to change an address or a route.
     state:
         required: false
         default: "present"
@@ -40,7 +40,7 @@ options:
         aliases: [ net ]
         description:
             - The address to set or remove with prefix length. (e.g. 2001:db8::2/64, 10.0.0.2/24, 10.0.0.2/255.255.255.0)
-              For nets the default route is specified by 0.0.0.0/0 or ::/0
+              For nets the default route is specified by 0.0.0.0/0 or ::/0 .
     dev:
         required: true
         description:
@@ -48,7 +48,7 @@ options:
     via:
         required: false
         description:
-            - ip address of gateway for manipulating routes.
+            - IP address of gateway for manipulating routes.
 '''
 
 EXAMPLES = '''
@@ -72,10 +72,6 @@ EXAMPLES = '''
 
 '''
 
-
-from pyroute2 import IPRoute
-from pyroute2.netlink.exceptions import NetlinkError
-from pyroute2.netlink import AF_INET6, AF_INET
 import ipaddress
 
 def parse_ip(text):
@@ -93,6 +89,7 @@ def parse_ip(text):
     return(addr)
 
 def main():
+    
     module = AnsibleModule(
         argument_spec = dict(
             mode  = dict(choices=['address','route'], default=None, required=True),
@@ -102,6 +99,13 @@ def main():
             via   = dict(default=None),
         ),
     )
+    
+    try:
+        from pyroute2 import IPRoute
+        from pyroute2.netlink.exceptions import NetlinkError
+        from pyroute2.netlink import AF_INET6, AF_INET
+    except:
+        module.fail_json(msg='pyroute2 not installed')
     
     ip = IPRoute()
     

--- a/network/ip.py
+++ b/network/ip.py
@@ -1,0 +1,93 @@
+#!/usr/bin/python
+
+from pyroute2 import IPRoute
+from pyroute2.netlink.exceptions import NetlinkError
+import ipaddress
+
+def parse_ip(text):
+    addr=None
+    try:
+        addr = ipaddress.IPv6Interface(text)
+    except ipaddress.AddressValueError:
+        try:
+            addr = ipaddress.IPv4Interface(text)
+        except Exception as e:
+            raise Exception(e)
+    except Exception as e:
+        raise Exception(e)
+        
+    return(addr)
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            mode  = dict(choices=['address','route'], default=None, required=True),
+            state = dict(choices=['present','absent'], default='present'),
+            addr  = dict(default=None),
+            prefixlen  = dict(default=None, type='int'),
+            dev   = dict(default=None),
+        ),
+    )
+    
+    ip = IPRoute()
+    
+    params = module.params
+    
+    if params['mode'] == 'address':
+        
+        if params['addr'] == None or params['dev'] == None:
+            module.fail_json(msg='addr and dev are mandator parameters')
+    
+        devids = ip.link_lookup(ifname=params['dev'])
+    
+        if len(devids) != 1:
+            module.fail_json(dev=params['dev'],msg='device does not exist')
+        devid=devids[0]
+    
+        devaddrs = ip.get_addr(index=devid)
+        
+        try:
+            setto=parse_ip(u''+params['addr'])
+        except Exception as e:
+            module.fail_json(addr=params['addr'],msg='invalid address: '+str(e))
+        
+        ifaddrs = []
+        for ad in devaddrs:
+            ifip=list(filter(lambda x: x[0] == 'IFA_ADDRESS' , ad["attrs"]))[0][1]
+            prefix=ad['prefixlen']
+            
+            ipobj = parse_ip(u''+ifip+"/"+str(prefix))
+            if ipobj:
+                ifaddrs.append(ipobj)
+            
+        changed=False
+        
+        try:
+            if params["state"] == 'present':
+                if setto not in ifaddrs:
+                    ip.addr('add', index=devid, address=setto.ip.compressed, prefixlen=setto.network.prefixlen)
+                    changed=True
+            
+                #clean up possible same addresses with different netmasks
+                for ad in filter(lambda x: x != setto and x.ip == setto.ip, ifaddrs):
+                    ip.addr('delete', index=devid, address=ad.ip.compressed, prefixlen=ad.network.prefixlen)
+                    changed=True
+            elif params["state"] == 'absent':
+                if setto in ifaddrs:
+                    ip.addr('delete', index=devid, address=setto.ip.compressed, prefixlen=setto.network.prefixlen)
+                    changed=True
+                    
+        except NetlinkError as e:
+            module.fail_json(addr=params['addr'],msg='could not perform operation: '+str(e))
+            
+        module.exit_json(addr=setto.ip.compressed,prefixlen=setto.network.prefixlen, changed=changed)
+        
+    elif params['mode'] == 'route':
+        module.fail_json(msg='Not yet implemented')
+    
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/network/ip.py
+++ b/network/ip.py
@@ -1,4 +1,62 @@
 #!/usr/bin/python
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ip
+version_added: 0.1
+author: "Felix Engelmann (@felix-engelmann)"
+short_description: Wrapper of the linux ip tool
+requirements: [ pyroute2 ]
+description:
+    - Performs linux ip address manipulations for interfaces and route adjustments
+options:
+    mode:
+        required: true
+        choices: [ address, route ]
+        description:
+            - Whether to change an address or a route
+    state:
+        required: false
+        default: "present"
+        choices: [ present, absent ]
+        description:
+            - Whether the address should be assigned to the interface or removed
+              respectively whether the route should be set or removed
+    addr:
+        required: false
+        description:
+            - The address to set or remove with prefix length (e.g. 2001:db8::2/64, 10.0.0.2/24, 10.0.0.2/255.255.255.0)
+    dev:
+        required: false
+        description:
+            - The device to set or remove the address from.
+'''
+
+EXAMPLES = '''
+# set address 2001:db8::42/64 to interface eth0
+- ip: mode=address addr=2001:db8::42/64 dev=eth0 state=present
+
+# change prefix length (watch out that any other assignments of same address with different prefix will be deleted)
+- ip: mode=address addr=2001:db8::42/112 dev=eth0 state=present
+
+# remove address from interface eth0
+- ip: mode=address addr=2001:db8::42/112 dev=eth0 state=absent
+
+'''
+
 
 from pyroute2 import IPRoute
 from pyroute2.netlink.exceptions import NetlinkError
@@ -24,7 +82,6 @@ def main():
             mode  = dict(choices=['address','route'], default=None, required=True),
             state = dict(choices=['present','absent'], default='present'),
             addr  = dict(default=None),
-            prefixlen  = dict(default=None, type='int'),
             dev   = dict(default=None),
         ),
     )

--- a/network/ip/ip_addr.py
+++ b/network/ip/ip_addr.py
@@ -1,0 +1,315 @@
+#!/usr/bin/python
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ip_addr
+version_added: 2.2
+author: "Felix Engelmann (@felix-engelmann)"
+short_description: Changing addresses of network interfaces
+requirements: [ pyroute2 ]
+description:
+    - Performs linux ip address manipulations for interfaces.
+options:
+    state:
+        required: false
+        default: "present"
+        choices: [ present, absent ]
+        description:
+            - Whether the address should be assigned to the interface or removed
+    addr:
+        required: false
+        description:
+            - The address to set or remove with prefix length. (e.g. 2001:db8::2/64, 10.0.0.2/24, 10.0.0.2/255.255.255.0)
+    dev:
+        required: true
+        description:
+            - The interface to set or remove the address from.
+'''
+
+EXAMPLES = '''
+# set address 2001:db8::42/64 to interface eth0
+- ip: mode=address addr=2001:db8::42/64 dev=eth0 state=present
+
+# change prefix length (watch out that any other assignments of same address with different prefix will be deleted)
+- ip: mode=address addr=2001:db8::42/112 dev=eth0 state=present
+
+# remove address from interface eth0
+- ip: mode=address addr=2001:db8::42/112 dev=eth0 state=absent
+
+'''
+
+RETURN = '''
+---
+'''
+
+from ansible.module_utils.pycompat24 import get_exception
+
+try:
+    from pyroute2 import IPRoute
+    from pyroute2.netlink.exceptions import NetlinkError
+    from pyroute2.netlink import AF_INET6, AF_INET
+    import ipaddress
+    HAS_PYROUTE=1
+except ImportError:
+    HAS_PYROUTE=0
+
+ip=None
+module=None
+
+def parse_ip(text):
+    addr=None
+    if text:
+        if text == 'v4default':
+            addr=ipaddress.IPv4Interface(u'0.0.0.0/0')
+        elif text == 'v6default':
+            addr=ipaddress.IPv6Interface(u'::/0')
+        else:
+            try:
+                # is it an IPv6
+                addr = ipaddress.IPv6Interface(u''+text)
+            except ipaddress.AddressValueError:
+                try:
+                    # fall back to parse it as IPv4
+                    addr = ipaddress.IPv4Interface(u''+text)
+                except Exception:
+                    e = get_exception()
+                    module.fail_json(msg='can not parse ip %s : %s'%(text,str(e)))
+            except Exception:
+                e = get_exception()
+                module.fail_json(msg='can not parse ip %s: %s'%(text,str(e)))
+    return(addr)
+
+#object to hold all important information of a device
+class Device(object):
+    
+    def __init__(self,name,devid,addresses,state,master,kind,vlanid,link):
+        self.name=name
+        self.id=devid
+        self.addresses=addresses
+        self.state=state
+        self.master=master
+        self.kind=kind
+        self.vlanid=vlanid
+        self.link=link
+        
+    def is_bridge(self):
+        return self.kind == 'bridge'
+        
+    def is_vlan(self,vlan_id,link):
+        return ( self.kind == 'vlan' and self.vlanid == vlan_id and self.link == link.id )
+        
+    def is_veth(self):
+        return self.kind == 'veth'
+    
+    def is_up(self):
+        return self.state == 'UP'
+    
+    # check if addr is assigned to this IF. Prefix has to match.
+    def has_address(self, addr):
+        return addr in self.addresses
+    
+    # check if ip is assiged. Prefixes can differ.
+    def get_addr_diff_lens(self, addr):
+        return [x for x in self.addresses if x.ip == addr.ip and x.network != addr.network]
+        
+    # adds address to interface (not reflected in local data)
+    def add_addr(self, addr):
+        try:
+            ip.addr('add', index=self.id, address=addr.ip.compressed, prefixlen=addr.network.prefixlen)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not add address %s to device %s: %s'%(addr.ip.compressed,self.name,str(e)) )
+    
+    # deletes address from interface (not reflected in local data)
+    def del_addr(self, addr):
+        try:
+            ip.addr('delete', index=self.id, address=addr.ip.compressed, prefixlen=addr.network.prefixlen)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not delete address %s from device %s: %s'%(addr.ip.compressed,self.name,str(e)) )
+    
+    
+    def set_master(self,master):
+        try:
+            ip.link("set", index=self.id, master=master.id)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not add device %s to bridge %s: %s'%(self.name,master.name,str(e)) )
+            
+    def set_up(self):
+        try:
+            ip.link("set", index=self.id, state="up")
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not up device %s: %s'%(self.name,str(e)) )
+    
+    def del_master(self):
+        try:
+            ip.link("set", index=self.id, master=0)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not remove device %s from bridge: %s'%(self.name,str(e)) )
+    
+    def delete(self):
+        try:
+            if self.kind:
+                ip.link("del",index=self.id)
+            else:
+                # system interface
+                ip.link("set", index=self.id, state="down")      
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not delete or down device %s: %s'%(self.name,str(e)) )
+    
+    # factory device from device name
+    @staticmethod
+    def factoryDeviceFromName(ifname):
+        devids = ip.link_lookup(ifname=ifname)
+        if len(devids) != 1:
+            return None
+        else:
+            # fetch address related information
+            devaddrs = ip.get_addr(index=devids[0])
+            
+            addrs=[]
+            
+            for addr in devaddrs:
+                ifip = addr.get_attr('IFA_ADDRESS')
+                prefixlen = addr['prefixlen']
+                
+                addrobj = parse_ip(ifip+"/"+str(prefixlen))
+                if addrobj:
+                    addrs.append(addrobj)
+        
+            # fetch link related information
+            link = ip.get_links(devids[0])[0]
+            
+            linkstate  = link.get_attr('IFLA_OPERSTATE')
+            linkmaster = link.get_attr('IFLA_MASTER')
+            linklink   = link.get_attr('IFLA_LINK')
+            
+            linkkind=None
+            linkinfo = link.get_attr('IFLA_LINKINFO')
+            vlanid = None
+            if linkinfo:
+                linkkind=linkinfo.get_attr('IFLA_INFO_KIND')
+                if linkkind == 'vlan':
+                    infodata = linkinfo.get_attr('IFLA_INFO_DATA')
+                    vlanid = infodata.get_attr('IFLA_VLAN_ID')
+            
+             
+            return Device(ifname,devids[0],addrs,linkstate,linkmaster,linkkind,vlanid,linklink)
+            
+    # factory to create new bridge
+    @staticmethod
+    def factoryCreateBridge(ifname):
+        try:
+            ip.link("add",ifname=ifname,kind="bridge")
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='could not create bridge %s: %s'%(ifname,str(e)))
+        
+        return Device.factoryDeviceFromName(ifname)
+        
+    # factory to create new vLan
+    @staticmethod
+    def factoryCreateVLAN(ifname,vlan_id,link):
+        try:
+            ip.link("add",ifname=ifname,kind="vlan",vlan_id=vlan_id,link=link.id)
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='could not create vlan %s tag %d on device %s: %s'%(ifname,vlan_id,link.name,str(e)))
+        
+        return Device.factoryDeviceFromName(ifname)
+    
+    @staticmethod
+    def factoryCreateVeth(ifname,peer):
+        try:
+            if peer:
+                ip.link("add",ifname=ifname,kind="veth",peer=peer)
+            else:
+                ip.link("add",ifname=ifname,kind="veth")
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='could not create veth %s peer %d: %s'%(ifname,peer,str(e)))
+        
+        return Device.factoryDeviceFromName(ifname)
+    
+    def dump(self):
+        print("if: %s (%d) %s"%(self.name,self.id,self.state))
+        if self.vlanid:
+            print(" vlan: %d"%(self.vlanid,))
+        for a in self.addresses:
+            print(" - %s/%d"%(a.ip.compressed,a.network.prefixlen))
+    
+def main():
+    # new Ansible module
+    global module
+    module = AnsibleModule(
+        argument_spec = dict(
+            state = dict(choices=['present','absent'], default='present'),
+            addr  = dict(default=None),
+            dev   = dict(default=None,required=True),
+            ),
+    )
+    
+    # this module can not work without pyroute2 and needs ipaddress for IP manipulations
+    # ipaddress is shipped with python
+    
+    if not HAS_PYROUTE:
+        module.fail_json(msg='pyroute2 is not installed')
+    
+    global ip    
+    ip = IPRoute()
+    
+    # parameters and their processing
+    params    = module.params
+    state     = params['state']
+    addr      = parse_ip(params['addr'])
+    dev       = Device.factoryDeviceFromName(params['dev'])
+    dev_name  = params['dev']
+     
+    # check for required arguments
+    if not (dev and addr):    
+        module.fail_json(msg='valid device and address required')
+    
+    if dev.has_address(addr):
+        if state == "present":
+            module.exit_json(changed=False)
+        else:
+            dev.del_addr(addr)
+            module.exit_json(changed=True)
+    else:
+        if state == "present":
+            dev.add_addr(addr)
+            # clean up possible equal addresses with different prefix length
+            for badaddr in dev.get_addr_diff_lens(addr):
+                dev.del_addr(badaddr)
+            
+            module.exit_json(changed=True)
+        else:
+            changed=False
+            # delete all prefixes with of this ip
+            for badaddr in dev.get_addr_diff_lens(addr):
+                dev.del_addr(badaddr)
+                changed=True
+            
+            module.exit_json(changed=changed)
+                
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/network/ip/ip_link.py
+++ b/network/ip/ip_link.py
@@ -1,0 +1,434 @@
+#!/usr/bin/python
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: ip_link
+version_added: 2.2
+author: "Felix Engelmann (@felix-engelmann)"
+short_description: Change the physical layer interface properties
+requirements: [ pyroute2 ]
+description:
+    - Performs linux ip link manipulations for interfaces as well as creating and managing virtual interfaces (VLAN, bridge, ...).
+options:
+    state:
+        required: false
+        default: "present"
+        choices: [ present, absent ]
+        description:
+            - Whether the interface should be brought up or down
+    dev:
+        required: true
+        description:
+            - The interface to bring up/down or the name of the new link.
+    kind:
+        required: false
+        choices: [ bridge, vlan, veth, port ]
+        description:
+            - Type of link to create or to set/remove interface as port of bridge.
+    link:
+        required: false
+        aliases: [ peer, master ]
+        description:
+            - The interface name of the parent link for vlan or second peer for veth interfaces.
+    vlan_id:
+        required: false
+        description:
+            - The vlan ID for vlan interfaces.
+'''
+
+EXAMPLES = '''
+# create bridge br0
+- ip: mode=link dev=br0 kind=bridge
+
+# add eth0 to bridge br0
+- ip: mode=link dev=eth0 kind=port master=br0
+
+# remove eth0 from bridge
+- ip: mode=link dev=eth0 kind=port state=absent
+
+# create a veth interface pair of v1p0 and v1p1
+- ip: mode=link dev=v1p0 kind=veth peer=v1p1
+
+# add vlan interface with id 42 onto eth0
+- ip: mode=link dev=v100 kind=vlan link=eth0 vlan_id=42
+
+# delete interface br0
+- ip: mode=link dev=br0 state=absent 
+
+# bring up existing interface
+- ip: mode=link dev=eth1 
+
+# bring down pyhsical interface
+- ip: mode=link dev=eth1 state=absent 
+
+'''
+
+RETURN = '''
+---
+'''
+
+from ansible.module_utils.pycompat24 import get_exception
+
+try:
+    from pyroute2 import IPRoute
+    from pyroute2.netlink.exceptions import NetlinkError
+    from pyroute2.netlink import AF_INET6, AF_INET
+    import ipaddress
+    HAS_PYROUTE=1
+except ImportError:
+    HAS_PYROUTE=0
+
+ip=None
+module=None
+
+def parse_ip(text):
+    addr=None
+    if text:
+        if text == 'v4default':
+            addr=ipaddress.IPv4Interface(u'0.0.0.0/0')
+        elif text == 'v6default':
+            addr=ipaddress.IPv6Interface(u'::/0')
+        else:
+            try:
+                # is it an IPv6
+                addr = ipaddress.IPv6Interface(u''+text)
+            except ipaddress.AddressValueError:
+                try:
+                    # fall back to parse it as IPv4
+                    addr = ipaddress.IPv4Interface(u''+text)
+                except Exception:
+                    e = get_exception()
+                    module.fail_json(msg='can not parse ip %s : %s'%(text,str(e)))
+            except Exception:
+                e = get_exception()
+                module.fail_json(msg='can not parse ip %s: %s'%(text,str(e)))
+    return(addr)
+
+#object to hold all important information of a device
+class Device(object):
+    
+    def __init__(self,name,devid,addresses,state,master,kind,vlanid,link):
+        self.name=name
+        self.id=devid
+        self.addresses=addresses
+        self.state=state
+        self.master=master
+        self.kind=kind
+        self.vlanid=vlanid
+        self.link=link
+        
+    def is_bridge(self):
+        return self.kind == 'bridge'
+        
+    def is_vlan(self,vlan_id,link):
+        return ( self.kind == 'vlan' and self.vlanid == vlan_id and self.link == link.id )
+        
+    def is_veth(self):
+        return self.kind == 'veth'
+    
+    def is_up(self):
+        return self.state == 'UP'
+    
+    # check if addr is assigned to this IF. Prefix has to match.
+    def has_address(self, addr):
+        return addr in self.addresses
+    
+    # check if ip is assiged. Prefixes can differ.
+    def get_addr_diff_lens(self, addr):
+        return [x for x in self.addresses if x.ip == addr.ip and x.network != addr.network]
+        
+    # adds address to interface (not reflected in local data)
+    def add_addr(self, addr):
+        try:
+            ip.addr('add', index=self.id, address=addr.ip.compressed, prefixlen=addr.network.prefixlen)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not add address %s to device %s: %s'%(addr.ip.compressed,self.name,str(e)) )
+    
+    # deletes address from interface (not reflected in local data)
+    def del_addr(self, addr):
+        try:
+            ip.addr('delete', index=self.id, address=addr.ip.compressed, prefixlen=addr.network.prefixlen)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not delete address %s from device %s: %s'%(addr.ip.compressed,self.name,str(e)) )
+    
+    
+    def set_master(self,master):
+        try:
+            ip.link("set", index=self.id, master=master.id)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not add device %s to bridge %s: %s'%(self.name,master.name,str(e)) )
+            
+    def set_up(self):
+        try:
+            ip.link("set", index=self.id, state="up")
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not up device %s: %s'%(self.name,str(e)) )
+    
+    def del_master(self):
+        try:
+            ip.link("set", index=self.id, master=0)
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not remove device %s from bridge: %s'%(self.name,str(e)) )
+    
+    def delete(self):
+        try:
+            if self.kind:
+                ip.link("del",index=self.id)
+            else:
+                # system interface
+                ip.link("set", index=self.id, state="down")      
+        except NetlinkError:
+            e = get_exception()
+            module.fail_json(msg='could not delete or down device %s: %s'%(self.name,str(e)) )
+    
+    # factory device from device name
+    @staticmethod
+    def factoryDeviceFromName(ifname):
+        devids = ip.link_lookup(ifname=ifname)
+        if len(devids) != 1:
+            return None
+        else:
+            # fetch address related information
+            devaddrs = ip.get_addr(index=devids[0])
+            
+            addrs=[]
+            
+            for addr in devaddrs:
+                ifip = addr.get_attr('IFA_ADDRESS')
+                prefixlen = addr['prefixlen']
+                
+                addrobj = parse_ip(ifip+"/"+str(prefixlen))
+                if addrobj:
+                    addrs.append(addrobj)
+        
+            # fetch link related information
+            link = ip.get_links(devids[0])[0]
+            
+            linkstate  = link.get_attr('IFLA_OPERSTATE')
+            linkmaster = link.get_attr('IFLA_MASTER')
+            linklink   = link.get_attr('IFLA_LINK')
+            
+            linkkind=None
+            linkinfo = link.get_attr('IFLA_LINKINFO')
+            vlanid = None
+            if linkinfo:
+                linkkind=linkinfo.get_attr('IFLA_INFO_KIND')
+                if linkkind == 'vlan':
+                    infodata = linkinfo.get_attr('IFLA_INFO_DATA')
+                    vlanid = infodata.get_attr('IFLA_VLAN_ID')
+            
+             
+            return Device(ifname,devids[0],addrs,linkstate,linkmaster,linkkind,vlanid,linklink)
+            
+    # factory to create new bridge
+    @staticmethod
+    def factoryCreateBridge(ifname):
+        try:
+            ip.link("add",ifname=ifname,kind="bridge")
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='could not create bridge %s: %s'%(ifname,str(e)))
+        
+        return Device.factoryDeviceFromName(ifname)
+        
+    # factory to create new vLan
+    @staticmethod
+    def factoryCreateVLAN(ifname,vlan_id,link):
+        try:
+            ip.link("add",ifname=ifname,kind="vlan",vlan_id=vlan_id,link=link.id)
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='could not create vlan %s tag %d on device %s: %s'%(ifname,vlan_id,link.name,str(e)))
+        
+        return Device.factoryDeviceFromName(ifname)
+    
+    @staticmethod
+    def factoryCreateVeth(ifname,peer):
+        try:
+            if peer:
+                ip.link("add",ifname=ifname,kind="veth",peer=peer)
+            else:
+                ip.link("add",ifname=ifname,kind="veth")
+        except Exception:
+            e = get_exception()
+            module.fail_json(msg='could not create veth %s peer %d: %s'%(ifname,peer,str(e)))
+        
+        return Device.factoryDeviceFromName(ifname)
+    
+    def dump(self):
+        print("if: %s (%d) %s"%(self.name,self.id,self.state))
+        if self.vlanid:
+            print(" vlan: %d"%(self.vlanid,))
+        for a in self.addresses:
+            print(" - %s/%d"%(a.ip.compressed,a.network.prefixlen))
+    
+def main():
+    # new Ansible module
+    global module
+    module = AnsibleModule(
+        argument_spec = dict(
+            state = dict(choices=['present','absent'], default='present'),
+            dev   = dict(default=None,required=True),
+            via   = dict(default=None),
+            kind  = dict(choices=['bridge','vlan','veth','port'],default=None),
+            link  = dict(default=None,aliases=['peer','master']),
+            vlan_id= dict(default=None,type='int'),
+        ),
+    )
+    
+    # this module can not work without pyroute2 and needs ipaddress for IP manipulations
+    # ipaddress is shipped with python
+    
+    if not HAS_PYROUTE:
+        module.fail_json(msg='pyroute2 is not installed')
+    
+    global ip    
+    ip = IPRoute()
+    
+    # parameters and their processing
+    params    = module.params
+    state     = params['state']
+    dev       = Device.factoryDeviceFromName(params['dev'])
+    dev_name  = params['dev']
+    via       = parse_ip(params['via'])
+    kind      = params['kind']
+    link      = Device.factoryDeviceFromName(params['link'])
+    link_name = params['link']
+    vlan_id   = params['vlan_id']
+        
+    # add an IF to a bridge
+    if kind == 'port':
+        
+        if state == "present":
+            if not (dev and link):    
+                module.fail_json(msg='valid device and bridge required')
+            if not link.is_bridge():
+                module.fail_json(msg='bridge is not a bridge')
+                
+            if dev.master == link.id:
+                module.exit_json(changed=False)
+            else:
+                dev.set_master(link)
+                module.exit_json(changed=True)
+        if state == "absent":
+            if not (dev):    
+                module.fail_json(msg='valid device required')
+                
+            if dev.master == None:
+                module.exit_json(changed=False)
+            else:
+                dev.del_master()
+                module.exit_json(changed=True)
+    
+    # create bridge
+    elif kind == 'bridge':
+        
+        if dev:
+            if dev.is_bridge():
+                if state == "present":
+                    module.exit_json(changed=False)
+                else:
+                    dev.delete()
+                    module.exit_json(changed=True)
+            else:
+                module.fail_json(msg='device %s exists but is not a bridge'%(dev.name,))
+        else:
+            if state == "absent":
+                module.exit_json(changed=False)
+            else:
+                Device.factoryCreateBridge(dev_name)
+                module.exit_json(changed=True)
+    
+    elif kind == 'vlan':
+        
+        if state == "present" and not (link and vlan_id):    
+            module.fail_json(msg='valid parent device and tag required')
+        
+        if dev:
+            if dev.is_vlan(vlan_id,link):
+                if state == "present":
+                    module.exit_json(changed=False)
+                else:
+                    dev.delete()
+                    module.exit_json(changed=True)
+            else:
+                module.fail_json(msg='existing device %s does not match'%(dev.name,))
+        else:
+            if state == "present":
+                Device.factoryCreateVLAN(dev_name,vlan_id,link)
+                module.exit_json(changed=True)
+            else:
+                module.exit_json(changed=False)
+    
+    elif kind == 'veth':
+        # there is no mean to check which is the peer interface.
+        
+        if link:
+            if not link.is_veth():
+                module.fail_json(msg='existing peer device %s is no veth'%(link.name,))
+                
+        if dev:
+            if dev.is_veth():
+                if state == "present":
+                    module.exit_json(changed=False)
+                else:
+                    dev.delete()
+                    module.exit_json(changed=True)
+            else:
+                module.fail_json(msg='existing device %s is no veth'%(dev.name,))
+        else:
+            if state == "present":
+                Device.factoryCreateVeth(dev_name,link_name)
+                module.exit_json(changed=True)
+            else:
+                module.exit_json(changed=False)
+    
+    #else up or down/delete interface
+    else:
+        
+        if state == "present":
+            if dev:
+                if dev.is_up():
+                    module.exit_json(changed=False)
+                else:
+                    dev.set_up()
+                    module.exit_json(changed=True)
+            else:
+                module.fail_json(msg='could not bring up %s, device does not exist'%(dev_name,))
+        else:
+            if dev:
+                if dev.kind:
+                    # we can delete non system devices
+                    dev.delete()
+                    module.exit_json(changed=True)
+                else:
+                    if dev.is_up():
+                        dev.delete()
+                        module.exit_json(changed=True)
+                    else:
+                        module.exit_json(changed=False)
+            else:
+                module.exit_json(changed=False)
+            
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->

ip
##### ANSIBLE VERSION

```
ansible 2.0.1.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The `ip` module aimes to provide the same functionality as the linux `ip` tool. Especially setting explicit routes which is not possible with the `nmcli` module. It uses the `netlink` socket which is abstracted by the `pyroute2` library. The module is capable of assigning and removing addresses to and from interfaces as well as managing routes.

The module is built with IPv6-first in focus, but is completely backwards compatible by automatic detection.

With further development, other functionality of the `ip` tool can be easily integrated to manage links and roles as well as refine the current operations by e.g. adding options for sophisticated routing. 

This new feature is a bit dangerous, because one can easily cut the connection to the maschine by removing vital routes, but with care it is very powerful and allows to integrate the network management such as simple routing into ansible playbooks.

It removes the hacking with the `command` module which can not provide idempotency without files and is bad at distinguishing real changes from problems.

I hope the general interest for this module is as high as mine and I would be happy to maintain and continue development for this module.

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->
