### PR TITLE
GCE : Fix image family handling with libcloud > 0.20.1

### DIFF
--- a/cloud/google/gce_img.py
+++ b/cloud/google/gce_img.py
@@ -114,6 +114,7 @@ EXAMPLES = '''
 import sys
 
 try:
+  import libcloud
   from libcloud.compute.types import Provider
   from libcloud.compute.providers import get_driver
   from libcloud.common.google import GoogleBaseError

--- a/cloud/google/gce_img.py
+++ b/cloud/google/gce_img.py
@@ -38,6 +38,12 @@ options:
       - an optional description
     required: false
     default: null
+  family:
+    description:
+      - an optional family name
+    required: false
+    default: null
+    version_added: "2.2"
   source:
     description:
       - the source disk or the Google Cloud Storage URI to create the image from
@@ -128,6 +134,7 @@ def create_image(gce, name, module):
   zone = module.params.get('zone')
   desc = module.params.get('description')
   timeout = module.params.get('timeout')
+  family = module.params.get('family')
 
   if not source:
     module.fail_json(msg='Must supply a source', changed=False)
@@ -147,10 +154,14 @@ def create_image(gce, name, module):
     except GoogleBaseError, e:
       module.fail_json(msg=str(e), changed=False)
 
+  gce_extra_args = {}
+  if family is not None:
+    gce_extra_args['family'] = family
+
   old_timeout = gce.connection.timeout
   try:
     gce.connection.timeout = timeout
-    gce.ex_create_image(name, volume, desc, False)
+    gce.ex_create_image(name, volume, desc, use_existing=False, **gce_extra_args)
     return True
   except ResourceExistsError:
     return False
@@ -175,6 +186,7 @@ def main():
   module = AnsibleModule(
       argument_spec=dict(
           name=dict(required=True),
+          family=dict(),
           description=dict(),
           source=dict(),
           state=dict(default='present', choices=['present', 'absent']),
@@ -193,7 +205,12 @@ def main():
 
   name = module.params.get('name')
   state = module.params.get('state')
+  family = module.params.get('family')
   changed = False
+
+  if family is not None and hasattr(libcloud, '__version__') and libcloud.__version__ <= '0.20.1':
+    module.fail_json(msg="Apache Libcloud 1.0.0+ is required to use 'family' option",
+                     changed=False)
 
   # user wants to create an image.
   if state == 'present':


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

gce_img
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

Currently, when using libcloud > 0.20.1, all created GCE images will all belong to a same image family named `false`, which is obviously bogus.

More information about images families here : https://cloud.google.com/compute/docs/images/create-delete-deprecate-private-images#setting_families

The root cause is that the gce.ex_create_image API changed in libcloud 1.0.0, introduced a new 'family' argument in the middle of the function signature, and ansible doesn't use named arguments, making ansible passe `False` to the family argument instead of `use_existing` as intended.

This pull requests both addresses this issue, and also introduce the ability to specify in which family an image should be created.
