### PR TITLE
Don't bomb if original didn't exist

### DIFF
--- a/files/blockinfile.py
+++ b/files/blockinfile.py
@@ -281,7 +281,7 @@ def main():
 
     if lines:
         result = '\n'.join(lines)
-        if original.endswith('\n'):
+        if original and original.endswith('\n'):
             result += '\n'
     else:
         result = ''


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

blockinfile
##### ANSIBLE VERSION

```
ansible 2.1.0.0 (detached HEAD 2950839a17) last updated 2016/05/24 19:25:34 (GMT -400)
  lib/ansible/modules/core: (detached HEAD aa995806b9) last updated 2016/05/24 19:25:32 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD d1a4f703ce) last updated 2016/05/24 19:25:34 (GMT -400)
  config file = /home/allen/rx-deploy/deploy/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

This fixes a bug introduced in 70fa125. When the target file doesn't exist, blockinfile will bomb with a `AttributeError: 'NoneType' object has no attribute 'endswith'`
