### PR TITLE
Network modules for Cisco ASA

### DIFF
--- a/network/asa/asa_acl.py
+++ b/network/asa/asa_acl.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = """
+---
+module: asa_acl
+version_added: "2.2"
+author: "Patrick Ogenstad (@ogenstad)"
+short_description: Manage access-lists on a Cisco ASA
+description:
+  - This module allows you to work with access-lists on a Cisco ASA device.
+extends_documentation_fragment: asa
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntanx as some commands are automatically modified by the
+        device config parser.
+    required: true
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a changed needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  Finally if match is set to I(exact), command lines
+        must be an equal match.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct
+    required: false
+    default: line
+    choices: ['line', 'block']
+  force:
+    description:
+      - The force argument instructs the module to not consider the
+        current devices running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+    required: false
+    default: false
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuruation to use as the base
+        config for comparision.
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+
+- asa_acl:
+    lines:
+      - access-list ACL-ANSIBLE extended permit tcp any any eq 82
+      - access-list ACL-ANSIBLE extended permit tcp any any eq www
+      - access-list ACL-ANSIBLE extended permit tcp any any eq 97
+      - access-list ACL-ANSIBLE extended permit tcp any any eq 98
+      - access-list ACL-ANSIBLE extended permit tcp any any eq 99
+    before: clear configure access-list ACL-ANSIBLE
+    match: strict
+    replace: block
+
+- asa_acl:
+    lines:
+      - access-list ACL-OUTSIDE extended permit tcp any any eq www
+      - access-list ACL-OUTSIDE extended permit tcp any any eq https
+     context: customer_a
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+responses:
+  description: The set of responses from issuing the commands on the device
+  retured: when not check_mode
+  type: list
+  sample: ['...', '...']
+"""
+
+def get_config(module):
+    config = module.params['config'] or dict()
+    if not config and not module.params['force']:
+        config = module.config
+    return config
+
+def check_input_acl(lines, module):
+    first_line = True
+    for line in lines:
+        ace = line.split()
+        if ace[0] != 'access-list':
+            module.fail_json(msg='All lines/commands must begin with "access-list" %s is not permitted' % ace[0])
+        if len(ace) <= 1:
+            module.fail_json(msg='All lines/commainds must contain the name of the access-list')
+        if first_line:
+            acl_name = ace[1]
+        else:
+            if acl_name != ace[1]:
+                module.fail_json(msg='All lines/commands must use the same access-list %s is not %s' % (ace[1], acl_name))
+        first_line = False
+
+    return 'access-list %s' % acl_name
+
+def main():
+
+    argument_spec = dict(
+        lines=dict(aliases=['commands'], required=True, type='list'),
+        before=dict(type='list'),
+        after=dict(type='list'),
+        match=dict(default='line', choices=['line', 'strict', 'exact']),
+        replace=dict(default='line', choices=['line', 'block']),
+        force=dict(default=False, type='bool'),
+        config=dict()
+    )
+
+    module = get_module(argument_spec=argument_spec,
+                        supports_check_mode=True)
+
+    lines = module.params['lines']
+
+    before = module.params['before']
+    after = module.params['after']
+
+    match = module.params['match']
+    replace = module.params['replace']
+
+    module.filter = check_input_acl(lines, module)
+    if not module.params['force']:
+        contents = get_config(module)
+        config = NetworkConfig(contents=contents, indent=1)
+
+        candidate = NetworkConfig(indent=1)
+        candidate.add(lines)
+
+        commands = candidate.difference(config, match=match, replace=replace)
+    else:
+        commands = []
+        commands.extend(lines)
+
+    result = dict(changed=False)
+
+    if commands:
+        if before:
+            commands[:0] = before
+
+        if after:
+            commands.extend(after)
+
+        if not module.check_mode:
+            commands = [str(c).strip() for c in commands]
+            response = module.configure(commands)
+            result['responses'] = response
+        result['changed'] = True
+
+    result['updates'] = commands
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.shell import *
+from ansible.module_utils.netcfg import *
+from ansible.module_utils.asa import *
+if __name__ == '__main__':
+    main()

--- a/network/asa/asa_command.py
+++ b/network/asa/asa_command.py
@@ -1,0 +1,169 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+
+DOCUMENTATION = """
+---
+module: asa_command
+version_added: "2.2"
+author: "Peter sprygada (@privateip)"
+short_description: Run arbitrary commands on Cisco ASA devices.
+description:
+  - Sends arbitrary commands to an ASA node and returns the results
+    read from the device. The M(asa_command) module includes an
+    argument that will cause the module to wait for a specific condition
+    before returning or timing out if the condition is not met.
+extends_documentation_fragment: asa
+options:
+  commands:
+    description:
+      - List of commands to send to the remote ios device over the
+        configured provider. The resulting output from the command
+        is returned. If the I(waitfor) argument is provided, the
+        module is not returned until the condition is satisfied or
+        the number of retires as expired.
+    required: true
+  waitfor:
+    description:
+      - List of conditions to evaluate against the output of the
+        command. The task will wait for a each condition to be true
+        before moving forward. If the conditional is not true
+        within the configured number of retries, the task fails.
+        See examples.
+    required: false
+    default: null
+  retries:
+    description:
+      - Specifies the number of retries a command should by tried
+        before it is considered failed. The command is run on the
+        target device every retry and evaluated against the
+        waitfor conditions.
+    required: false
+    default: 10
+  interval:
+    description:
+      - Configures the interval in seconds to wait between retries
+        of the command. If the command does not pass the specified
+        conditions, the interval indicates how long to wait before
+        trying the command again.
+    required: false
+    default: 1
+
+"""
+
+EXAMPLES = """
+
+- asa_command:
+    commands:
+      - show version
+  register: output
+
+- asa_command:
+    commands:
+      - show asp drop
+      - show memory
+    register: output
+
+- asa_command:
+    commands:
+      - show version
+    context: system
+"""
+
+RETURN = """
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: The value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+failed_conditions:
+  description: the conditionals that failed
+  retured: failed
+  type: list
+  sample: ['...', '...']
+"""
+
+import time
+import shlex
+import re
+
+def to_lines(stdout):
+    for item in stdout:
+        if isinstance(item, basestring):
+            item = str(item).split('\n')
+        yield item
+
+def main():
+    spec = dict(
+        commands=dict(type='list'),
+        waitfor=dict(type='list'),
+        retries=dict(default=10, type='int'),
+        interval=dict(default=1, type='int')
+    )
+
+    module = get_module(argument_spec=spec,
+                        supports_check_mode=True)
+
+    commands = module.params['commands']
+
+    retries = module.params['retries']
+    interval = module.params['interval']
+
+    try:
+        queue = set()
+        for entry in (module.params['waitfor'] or list()):
+            queue.add(Conditional(entry))
+    except AttributeError, exc:
+        module.fail_json(msg=exc.message)
+
+    result = dict(changed=False)
+
+    while retries > 0:
+        response = module.execute(commands)
+        result['stdout'] = response
+
+        for item in list(queue):
+            if item(response):
+                queue.remove(item)
+
+        if not queue:
+            break
+
+        time.sleep(interval)
+        retries -= 1
+    else:
+        failed_conditions = [item.raw for item in queue]
+        module.fail_json(msg='timeout waiting for value', failed_conditions=failed_conditions)
+
+    result['stdout_lines'] = list(to_lines(result['stdout']))
+    return module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.urls import *
+from ansible.module_utils.shell import *
+from ansible.module_utils.netcfg import *
+from ansible.module_utils.asa import *
+if __name__ == '__main__':
+        main()

--- a/network/asa/asa_config.py
+++ b/network/asa/asa_config.py
@@ -1,0 +1,222 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+DOCUMENTATION = """
+---
+module: asa_config
+version_added: "2.2"
+author: "Peter Sprygada (@privateip)"
+short_description: Manage Cisco ASA configuration sections
+description:
+  - Cisco ASA configurations use a simple block indent file sytanx
+    for segementing configuration into sections.  This module provides
+    an implementation for working with ASA configuration sections in
+    a deterministic way.
+extends_documentation_fragment: asa
+options:
+  lines:
+    description:
+      - The ordered set of commands that should be configured in the
+        section.  The commands must be the exact same commands as found
+        in the device running-config.  Be sure to note the configuration
+        command syntanx as some commands are automatically modified by the
+        device config parser.
+    required: true
+  parents:
+    description:
+      - The ordered set of parents that uniquely identify the section
+        the commands should be checked against.  If the parents argument
+        is omitted, the commands are checked against the set of top
+        level or global commands.
+    required: false
+    default: null
+  before:
+    description:
+      - The ordered set of commands to push on to the command stack if
+        a change needs to be made.  This allows the playbook designer
+        the opportunity to perform configuration commands prior to pushing
+        any changes without affecting how the set of commands are matched
+        against the system
+    required: false
+    default: null
+  after:
+    description:
+      - The ordered set of commands to append to the end of the command
+        stack if a changed needs to be made.  Just like with I(before) this
+        allows the playbook designer to append a set of commands to be
+        executed after the command set.
+    required: false
+    default: null
+  match:
+    description:
+      - Instructs the module on the way to perform the matching of
+        the set of commands against the current device config.  If
+        match is set to I(line), commands are matched line by line.  If
+        match is set to I(strict), command lines are matched with respect
+        to position.  Finally if match is set to I(exact), command lines
+        must be an equal match.
+    required: false
+    default: line
+    choices: ['line', 'strict', 'exact']
+  replace:
+    description:
+      - Instructs the module on the way to perform the configuration
+        on the device.  If the replace argument is set to I(line) then
+        the modified lines are pushed to the device in configuration
+        mode.  If the replace argument is set to I(block) then the entire
+        command block is pushed to the device in configuration mode if any
+        line is not correct
+    required: false
+    default: line
+    choices: ['line', 'block']
+  force:
+    description:
+      - The force argument instructs the module to not consider the
+        current devices running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+    required: false
+    default: false
+    choices: ['yes', 'no']
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task in a playbook.  The I(config) argument allows the
+        implementer to pass in the configuruation to use as the base
+        config for comparision.
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+
+- asa_config:
+    lines:
+      - network-object host 10.80.30.18
+      - network-object host 10.80.30.19
+      - network-object host 10.80.30.20
+    parents: ['object-group network OG-MONITORED-SERVERS']
+
+- asa_config:
+    host: "{{ inventory_hostname }}"
+    lines:
+      - message-length maximum client auto
+      - message-length maximum 512
+    match: line
+    parents: ['policy-map type inspect dns PM-DNS', 'parameters']
+    authorize: yes
+    auth_pass: cisco
+    username: admin
+    password: cisco
+    context: ansible
+
+- asa_config:
+    provider: "{{ cli }}"
+    host: "{{ inventory_hostname }}"
+    show_command: 'more system:running-config'
+    lines:
+      - ikev1 pre-shared-key S3cretVPNK3y
+    parents: tunnel-group 1.1.1.1 ipsec-attributes
+
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+responses:
+  description: The set of responses from issuing the commands on the device
+  retured: when not check_mode
+  type: list
+  sample: ['...', '...']
+"""
+
+def get_config(module):
+    config = module.params['config'] or dict()
+    if not config and not module.params['force']:
+        config = module.config
+    return config
+
+
+def main():
+
+    argument_spec = dict(
+        lines=dict(aliases=['commands'], required=True, type='list'),
+        parents=dict(type='list'),
+        before=dict(type='list'),
+        after=dict(type='list'),
+        match=dict(default='line', choices=['line', 'strict', 'exact']),
+        replace=dict(default='line', choices=['line', 'block']),
+        force=dict(default=False, type='bool'),
+        config=dict()
+    )
+
+    module = get_module(argument_spec=argument_spec,
+                        supports_check_mode=True)
+
+    lines = module.params['lines']
+    parents = module.params['parents'] or list()
+
+    before = module.params['before']
+    after = module.params['after']
+
+    match = module.params['match']
+    replace = module.params['replace']
+
+    if not module.params['force']:
+        contents = get_config(module)
+        config = NetworkConfig(contents=contents, indent=1)
+
+        candidate = NetworkConfig(indent=1)
+        candidate.add(lines, parents=parents)
+
+        commands = candidate.difference(config, path=parents, match=match, replace=replace)
+    else:
+        commands = parents
+        commands.extend(lines)
+
+    result = dict(changed=False)
+
+    if commands:
+        if before:
+            commands[:0] = before
+
+        if after:
+            commands.extend(after)
+
+        if not module.check_mode:
+            commands = [str(c).strip() for c in commands]
+            response = module.configure(commands)
+            result['responses'] = response
+        result['changed'] = True
+
+    result['updates'] = commands
+    module.exit_json(**result)
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.shell import *
+from ansible.module_utils.netcfg import *
+from ansible.module_utils.asa import *
+if __name__ == '__main__':
+    main()

--- a/network/asa/asa_template.py
+++ b/network/asa/asa_template.py
@@ -1,0 +1,173 @@
+#!/usr/bin/python
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+DOCUMENTATION = """
+---
+module: asa_template
+version_added: "2.2"
+author: "Peter sprygada (@privateip)"
+short_description: Manage Cisco ASA device configurations over SSH
+description:
+  - Manages Cisco ASA network device configurations over SSH.  This module
+    allows implementors to work with the device running-config.  It
+    provides a way to push a set of commands onto a network device
+    by evaluting the current running-config and only pushing configuration
+    commands that are not already configured.  The config source can
+    be a set of commands or a template.
+extends_documentation_fragment: asa
+options:
+  src:
+    description:
+      - The path to the config source.  The source can be either a
+        file with config or a template that will be merged during
+        runtime.  By default the task will first search for the source
+        file in role or playbook root folder in templates unless a full
+        path to the file is given.
+    required: true
+  force:
+    description:
+      - The force argument instructs the module not to consider the
+        current device running-config.  When set to true, this will
+        cause the module to push the contents of I(src) into the device
+        without first checking if already configured.
+    required: false
+    default: false
+    choices: [ "true", "false" ]
+  include_defaults:
+    description:
+      - The module, by default, will collect the current device
+        running-config to use as a base for comparision to the commands
+        in I(src).  Setting this value to true will cause the command
+        issued to add any necessary flags to collect all defaults as
+        well as the device configuration.  If the destination device
+        does not support such a flag, this argument is silently ignored.
+    required: false
+    default: false
+    choices: [ "true", "false" ]
+  backup:
+    description:
+      - When this argument is configured true, the module will backup
+        the running-config from the node prior to making any changes.
+        The backup file will be written to backup_{{ hostname }} in
+        the root of the playbook directory.
+    required: false
+    default: false
+    choices: [ "true", "false" ]
+  config:
+    description:
+      - The module, by default, will connect to the remote device and
+        retrieve the current running-config to use as a base for comparing
+        against the contents of source.  There are times when it is not
+        desirable to have the task get the current running-config for
+        every task.  The I(config) argument allows the implementer to
+        pass in the configuruation to use as the base config for
+        comparision.
+    required: false
+    default: null
+"""
+
+EXAMPLES = """
+- name: push a configuration onto the device
+  asa_template:
+    host: hostname
+    username: foo
+    src: config.j2
+
+- name: forceable push a configuration onto the device
+  asa_template:
+    host: hostname
+    username: foo
+    src: config.j2
+    force: yes
+
+- name: provide the base configuration for comparision
+  asa_template:
+    host: hostname
+    username: foo
+    src: candidate_config.txt
+    config: current_config.txt
+"""
+
+RETURN = """
+updates:
+  description: The set of commands that will be pushed to the remote device
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+responses:
+  description: The set of responses from issuing the commands on the device
+  retured: when not check_mode
+  type: list
+  sample: ['...', '...']
+"""
+
+def get_config(module):
+    config = module.params['config'] or dict()
+    if not config and not module.params['force']:
+        config = module.config
+    return config
+
+def main():
+    """ main entry point for module execution
+    """
+
+    argument_spec = dict(
+        src=dict(),
+        force=dict(default=False, type='bool'),
+        include_defaults=dict(default=True, type='bool'),
+        backup=dict(default=False, type='bool'),
+        config=dict(),
+    )
+
+    mutually_exclusive = [('config', 'backup'), ('config', 'force')]
+
+    module = get_module(argument_spec=argument_spec,
+                        mutually_exclusive=mutually_exclusive,
+                        supports_check_mode=True)
+
+    result = dict(changed=False)
+
+    candidate = NetworkConfig(contents=module.params['src'], indent=1)
+
+    contents = get_config(module)
+    if contents:
+        config = NetworkConfig(contents=contents, indent=1)
+        result['_backup'] = contents
+
+    if not module.params['force']:
+        commands = candidate.difference(config)
+    else:
+        commands = str(candidate).split('\n')
+
+    if commands:
+        if not module.check_mode:
+            commands = [str(c).strip() for c in commands]
+            response = module.configure(commands)
+            result['responses'] = response
+        result['changed'] = True
+
+    result['updates'] = commands
+    module.exit_json(**result)
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.shell import *
+from ansible.module_utils.netcfg import *
+from ansible.module_utils.asa import *
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### ANSIBLE VERSION

Target for Ansible 2.2
##### SUMMARY

New networking modules to manage Cisco ASA firewalls.

This PR requires that [this PR](https://github.com/ansible/ansible/pull/15992) is merged first. If they are accepted they will be able to use [these tests](https://github.com/ansible/test-network-modules/pull/1).
