### PR TITLE
Fix Traceback on rabbitmq_user when "node" argument is used

### DIFF
--- a/messaging/rabbitmq_user.py
+++ b/messaging/rabbitmq_user.py
@@ -146,7 +146,7 @@ class RabbitMqUser(object):
         if not self.module.check_mode or (self.module.check_mode and run_in_check_mode):
             cmd = [self._rabbitmqctl, '-q']
             if self.node is not None:
-                cmd.append(['-n', self.node])
+                cmd.extend(['-n', self.node])
             rc, out, err = self.module.run_command(cmd + args, check_rc=True)
             return out.splitlines()
         return list()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

rabbitmq_user
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 3b69ef7e8b) last updated 2016/05/25 14:52:35 (GMT -500)
  lib/ansible/modules/core: (detached HEAD aa995806b9) last updated 2016/05/25 14:54:54 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD d1a4f703ce) last updated 2016/05/25 14:54:54 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

If the node argument is used, the command list was not being extended, but rather being appended, and an `AttributeErro`r was triggering when the path was being normalized in `ansible.module_utils.basic`, line 1987.

Bug was introduced in 84ca3ba7eecbcb9c1ebcfbcbb6ab98f97d1c097e.

```
Traceback (most recent call last):
  File "/tmp/ansible_ZRnKbW/ansible_module_rabbitmq_user.py", line 302, in <module>
    main()
  File "/tmp/ansible_ZRnKbW/ansible_module_rabbitmq_user.py", line 274, in main
    if rabbitmq_user.get():
  File "/tmp/ansible_ZRnKbW/ansible_module_rabbitmq_user.py", line 155, in get
    users = self._exec([list_users], True)
  File "/tmp/ansible_ZRnKbW/ansible_module_rabbitmq_user.py", line 150, in _exec
    rc, out, err = self.module.run_command(cmd + args, check_rc=True)
  File "/tmp/ansible_ZRnKbW/ansible_modlib.zip/ansible/module_utils/basic.py", line 1987, in run_command
  File "/usr/lib/python2.7/posixpath.py", line 261, in expanduser
    if not path.startswith(~):
AttributeError: list object has no attribute startswith
```
