### PR TITLE
Exclude mssql_db.py from py24 syntax checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,7 @@ install:
   - pip install git+https://github.com/ansible/ansible.git@devel#egg=ansible
   - pip install git+https://github.com/sivel/ansible-testing.git#egg=ansible_testing
 script:
-  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py|database/influxdb/influxdb.*\.py' .
+  - python2.4 -m compileall -fq -x 'cloud/|monitoring/zabbix.*\.py|/dnf\.py|/layman\.py|/maven_artifact\.py|clustering/(consul.*|znode)\.py|notification/pushbullet\.py|database/influxdb/influxdb.*\.py|database/mssql/mssql_db\.py' .
   - python2.6 -m compileall -fq .
   - python2.7 -m compileall -fq .
   - python3.4 -m compileall -fq . -x $(echo "$PY3_EXCLUDE_LIST"| tr ' ' '|')


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

mssql_db
##### ANSIBLE VERSION

```
v2.2
```
##### SUMMARY

Builds failing due to py24 syntax checks on travis for mssql_db.py.  Per recent commits changes, mssql_db requires at least py27.
