### PR TITLE
added s3 download support to maven module

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -28,7 +28,6 @@ import sys
 import posixpath
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
-from urlparse import urlparse
 try:
     import boto3
     HAS_BOTO = True

--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -28,6 +28,12 @@ import sys
 import posixpath
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *
+from urlparse import urlparse
+try:
+    import boto3
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
 
 DOCUMENTATION = '''
 ---
@@ -42,6 +48,7 @@ author: "Chris Schmidt (@chrisisbeef)"
 requirements:
     - "python >= 2.6"
     - lxml
+    - boto if using a S3 repository (s3://...)
 options:
     group_id:
         description:
@@ -68,19 +75,21 @@ options:
         default: jar
     repository_url:
         description:
-            - The URL of the Maven Repository to download from
+            - The URL of the Maven Repository to download from. Use s3://... if the repository is hosted on Amazon S3
         required: false
         default: http://repo1.maven.org/maven2
     username:
         description:
-            - The username to authenticate as to the Maven Repository
+            - The username to authenticate as to the Maven Repository. Use AWS secret key of the repository is hosted on S3
         required: false
         default: null
+        aliases: [ "aws_secret_key" ]
     password:
         description:
-            - The password to authenticate with to the Maven Repository
+            - The password to authenticate with to the Maven Repository. Use AWS secret access key of the repository is hosted on S3
         required: false
         default: null
+        aliases: [ "aws_secret_access_key" ]
     dest:
         description:
             - The path where the artifact should be written to
@@ -185,7 +194,8 @@ class Artifact(object):
 class MavenDownloader:
     def __init__(self, module, base="http://repo1.maven.org/maven2"):
         self.module = module
-        base = base.rstrip("/")
+        if base.endswith("/"):
+            base = base.rstrip("/")
         self.base = base
         self.user_agent = "Maven Artifact Downloader/1.0"
 
@@ -220,14 +230,23 @@ class MavenDownloader:
         return posixpath.join(self.base, artifact.path(), artifact.artifact_id + "-" + version + "." + artifact.extension)
 
     def _request(self, url, failmsg, f):
+        url_to_use = url
+        parsed_url = urlparse.urlparse(url)
+        if parsed_url.scheme=='s3':
+                parsed_url = urlparse.urlparse(url)
+                bucket_name = parsed_url.netloc[:parsed_url.netloc.find('.')]
+                key_name = parsed_url.path[1:]
+                client = boto3.client('s3',aws_access_key_id=self.module.params.get('username', ''), aws_secret_access_key=self.module.params.get('password', ''))
+                url_to_use = client.generate_presigned_url('get_object',Params={'Bucket':bucket_name,'Key':key_name},ExpiresIn=10)
+
         # Hack to add parameters in the way that fetch_url expects
         self.module.params['url_username'] = self.module.params.get('username', '')
         self.module.params['url_password'] = self.module.params.get('password', '')
         self.module.params['http_agent'] = self.module.params.get('user_agent', None)
 
-        response, info = fetch_url(self.module, url)
+        response, info = fetch_url(self.module, url_to_use)
         if info['status'] != 200:
-            raise ValueError(failmsg + " because of " + info['msg'] + "for URL " + url)
+            raise ValueError(failmsg + " because of " + info['msg'] + "for URL " + url_to_use)
         else:
             return f(response)
 
@@ -305,13 +324,19 @@ def main():
             classifier = dict(default=None),
             extension = dict(default='jar'),
             repository_url = dict(default=None),
-            username = dict(default=None),
-            password = dict(default=None, no_log=True),
+            username = dict(default=None,aliases=['aws_secret_key']),
+            password = dict(default=None, no_log=True,aliases=['aws_secret_access_key']),
             state = dict(default="present", choices=["present","absent"]), # TODO - Implement a "latest" state
             dest = dict(type="path", default=None),
             validate_certs = dict(required=False, default=True, type='bool'),
         )
     )
+
+
+    parsed_url = urlparse.urlparse(module.params["repository_url"])
+
+    if parsed_url.scheme=='s3' and not HAS_BOTO:
+        module.fail_json(msg='boto3 required for this module, when using s3:// repository URLs')
 
     group_id = module.params["group_id"]
     artifact_id = module.params["artifact_id"]


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->
##### ANSIBLE VERSION

```
ansible 2.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Added S3 support for maven_artifact 
Re-used all http fetch logic. The S3 supported was added through means of generating a temporary HTTP download, that is passed to the pre-existing HTTP get flow
No changes in the command output or existing behaviour. The new S3 download behaviour is exactly the same as the pre-existing one.

(I messed up with the previous pull request)
- Example configuration:

```
- hosts: localhost
  tasks:
    - name: download artifact if absent
      maven_artifact:
        group_id: com.something.somethingelse
        artifact_id: myartifact
        version: "latest"
        dest: "/tmp"
        repository_url: "s3://<redacted>.s3.amazonaws.com/dev"
        aws_secret_key: <redacted>
        aws_secret_access_key: <redacted>
        extension: war
      register: artifact
    - debug: var=artifact
```
- Result (artifact already existed locally)

```
ok: [localhost] => {
    "artifact": {
        "changed": false, 
        "dest": "/tmp/myartifact-latest.war", 
        "gid": 0, 
        "group": "wheel", 
        "mode": "0600", 
        "owner": "gluiz", 
        "size": 98637847, 
        "state": "file", 
        "uid": 502
    }
}
```
- Result (artifact did not exist locally)

```
ok: [localhost] => {
    "artifact": {
        "artifact_id": "myartifact", 
        "changed": true, 
        "classifier": null, 
        "dest": "/tmp/myartifact-latest.war", 
        "extension": "war", 
        "gid": 0, 
        "group": "wheel", 
        "group_id":  com.something.somethingelse", 
        "mode": "0600", 
        "owner": "gluiz", 
        "repository_url":  "s3://<redacted>.s3.amazonaws.com/dev", 
        "size": 98637847, 
        "state": "file", 
        "uid": 502, 
        "version": "latest"
    }
}
```
