### PR TITLE
New Module: archive

### DIFF
--- a/files/archive.py
+++ b/files/archive.py
@@ -229,11 +229,7 @@ def main():
                         if os.path.isdir(path) and not path.endswith(os.sep + '.'):
                             basename = os.path.basename(path) + os.sep
 
-                        filter_create = lambda f:
-                            if filecmp.cmp(f.name, creates):
-                                return f
-
-                        archive.add(path, path[len(arcroot):], filter=filter_create)
+                        archive.add(path, path[len(arcroot):], filter=lambda f: not filecmp.cmp(f.name, creates) and f)
                         successes.append(path)
 
                 # Slightly more difficult (and less efficient!) compression using zipfile module

--- a/files/archive.py
+++ b/files/archive.py
@@ -231,36 +231,35 @@ def main():
 
                 for path in archive_paths:
                     if os.path.isdir(path):
-                        basename = ''
-
-                        # Prefix trees in the archive with their basename, unless specifically prevented with '.'
-                        if not path.endswith(os.sep + '.'):
-                            basename = os.path.basename(path) + os.sep
-
                         # Recurse into directories
                         for dirpath, dirnames, filenames in os.walk(path, topdown=True):
+                            if not dirpath.endswith(os.sep):
+                                dirpath += os.sep
+
                             for dirname in dirnames:
-                                fullpath = dirpath + os.sep + dirname
+                                fullpath = dirpath + dirname
+                                arcname = fullpath[len(arcroot):]
 
                                 try:
                                     if compression == 'zip':
-                                        arcfile.write(fullpath, basename + dirname)
+                                        arcfile.write(fullpath, arcname)
                                     else:
-                                        arcfile.add(fullpath, basename + dirname, recursive=False)
+                                        arcfile.add(fullpath, arcname, recursive=False)
 
                                 except Exception:
                                     e = get_exception()
                                     errors.append('%s: %s' % (fullpath, str(e)))
 
                             for filename in filenames:
-                                fullpath = dirpath + os.sep + filename
+                                fullpath = dirpath + filename
+                                arcname = fullpath[len(arcroot):]
 
                                 if not filecmp.cmp(fullpath, dest):
                                     try:
                                         if compression == 'zip':
-                                            arcfile.write(fullpath, basename + filename)
+                                            arcfile.write(fullpath, arcname)
                                         else:
-                                            arcfile.add(fullpath, basename + filename, recursive=False)
+                                            arcfile.add(fullpath, arcname, recursive=False)
 
                                         successes.append(fullpath)
                                     except Exception:

--- a/files/archive.py
+++ b/files/archive.py
@@ -50,6 +50,27 @@ EXAMPLES = '''
     compression: bz2
 '''
 
+RETURN = '''
+state:
+    description: The current state of the archived file.
+    type: string
+    returned: always
+missing:
+    description: Any files that were missing from the source.
+    type: list
+    returned: success
+archived:
+    description: Any files that were compressed or added to the archive.
+    type: list
+    returned: success
+arcroot:
+    description: The archive root.
+    type: string
+expanded_paths:
+    description: The list of matching paths from paths argument.
+    type: list
+'''
+
 import stat
 import os
 import errno

--- a/files/archive.py
+++ b/files/archive.py
@@ -28,21 +28,20 @@ version_added: 2.2
 short_description: Creates a compressed archive of one or more files or trees.
 extends_documentation_fragment: files
 description:
-     - The M(archive) module packs an archive. It is the opposite of the unarchive module. By default, it assumes the compression source exists on the target. It will not copy the source file from the local system to the target before archiving. Source files can be deleted after archival by specifying remove=True.
+     - The M(archive) module packs an archive. It is the opposite of the unarchive module. By default, it assumes the compression source exists on the target. It will not copy the source file from the local system to the target before archiving. Source files can be deleted after archival by specifying C(remove)=I(True).
 options:
   path:
     description:
       - Remote absolute path, glob, or list of paths or globs for the file or files to archive or compress.
-    required: false
-    default: null
+    required: true
   compression:
     description:
       - The type of compression to use. Can be 'gz', 'bz2', or 'zip'.
     choices: [ 'gz', 'bz2', 'zip' ]
   creates:
     description:
-      - The file name of the destination archive. This is required when 'path' refers to multiple files by either specifying a glob, a directory or multiple paths in a list. 
-    required: false, unless multiple source paths or globs are specified
+      - The file name of the destination archive. This is required when C(path) refers to multiple files by either specifying a glob, a directory or multiple paths in a list.
+    required: false
     default: null
   remove:
     description:

--- a/files/archive.py
+++ b/files/archive.py
@@ -1,6 +1,26 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
+"""
+(c) 2016, Ben Doherty <bendohmv@gmail.com>
+Sponsored by Oomph, Inc. http://www.oomphinc.com
+
+This file is part of Ansible
+
+Ansible is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Ansible is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
 DOCUMENTATION = '''
 ---
 module: archive

--- a/files/archive.py
+++ b/files/archive.py
@@ -28,7 +28,7 @@ version_added: 2.2
 short_description: Creates a compressed archive of one or more files or trees.
 extends_documentation_fragment: files
 description:
-     - The M(archive) module packs an archive. It is the opposite of the unarchive module. By default, it assumes the compression source exists on the target. It will not copy the source file from the local system to the target before archiving - set copy=yes to pack an archive which does not already exist on the target. The source files are deleted after archiving.
+     - The M(archive) module packs an archive. It is the opposite of the unarchive module. By default, it assumes the compression source exists on the target. It will not copy the source file from the local system to the target before archiving. Source files can be deleted after archival by specifying remove=True.
 options:
   path:
     description:
@@ -41,22 +41,28 @@ options:
     choices: [ 'gz', 'bz2', 'zip' ]
   creates:
     description:
-      - The file name of the destination archive. When it already exists, this step will B(not) be run. This is required when 'path' refers to multiple files by either specifying a glob, a directory or multiple paths in a list.
-    required: false
+      - The file name of the destination archive. This is required when 'path' refers to multiple files by either specifying a glob, a directory or multiple paths in a list. 
+    required: false, unless multiple source paths or globs are specified
     default: null
+  remove:
+    description:
+      - Remove any added source files and trees after adding to archive.
+    type: bool
+    required: false
+    default: false
+
 author: "Ben Doherty (@bendoh)"
 notes:
     - requires tarfile, zipfile, gzip, and bzip2 packages on target host
-    - can product I(gzip), I(bzip2) and I(zip) compressed files or archives
-    - removes source files by default
+    - can produce I(gzip), I(bzip2) and I(zip) compressed files or archives
 '''
 
 EXAMPLES = '''
 # Compress directory /path/to/foo/ into /path/to/foo.tgz
 - archive: path=/path/to/foo creates=/path/to/foo.tgz
 
-# Compress regular file /path/to/foo into /path/to/foo.gz
-- archive: path=/path/to/foo
+# Compress regular file /path/to/foo into /path/to/foo.gz and remove it
+- archive: path=/path/to/foo remove=True
 
 # Create a zip archive of /path/to/foo
 - archive: path=/path/to/foo compression=zip
@@ -113,7 +119,7 @@ def main():
             path = dict(type='list', required=True),
             compression = dict(choices=['gz', 'bz2', 'zip'], default='gz', required=False),
             creates = dict(required=False),
-            remove = dict(required=False, default=True, type='bool'),
+            remove = dict(required=False, default=False, type='bool'),
         ),
         add_file_common_args=True,
         supports_check_mode=True,

--- a/files/archive.py
+++ b/files/archive.py
@@ -1,0 +1,285 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+DOCUMENTATION = '''
+---
+module: archive
+version_added: 2.2
+short_description: Creates a compressed archive of one or more files or trees.
+extends_documentation_fragment: files
+description:
+     - The M(archive) module packs an archive. It is the opposite of the unarchive module. By default, it assumes the compression source exists on the target. It will not copy the source file from the local system to the target before archiving - set copy=yes to pack an archive which does not already exist on the target. The source files are deleted after archiving.
+options:
+  path:
+    description:
+      - Remote absolute path, glob, or list of paths or globs for the file or files to archive or compress.
+    required: false
+    default: null
+  compression:
+    description:
+      - "The type of compression to use. Can be 'gz', 'bz2', or 'zip'.
+    choices: [ 'gz', 'bz2', 'zip' ]
+  creates:
+    description:
+      - The file name of the destination archive. When it already exists, this step will B(not) be run. This is required when 'path' refers to multiple files by either specifying a glob, a directory or multiple paths in a list.
+    required: false
+    default: null
+author: "Ben Doherty (@bendoh)"
+notes:
+    - requires tarfile, zipfile, gzip, and bzip2 packages on target host
+    - can product I(gzip), I(bzip2) and I(zip) compressed files or archives
+    - removes source files by default
+'''
+
+EXAMPLES = '''
+# Compress directory /path/to/foo/ into /path/to/foo.tgz
+- archive: path=/path/to/foo creates=/path/to/foo.tgz
+
+# Compress regular file /path/to/foo into /path/to/foo.gz
+- archive: path=/path/to/foo
+
+# Create a zip archive of /path/to/foo
+- archive: path=/path/to/foo compression=zip
+
+# Create a bz2 archive of multiple files, rooted at /path
+- archive:
+    path:
+        - /path/to/foo
+        - /path/wong/foo
+    creates: /path/file.tar.bz2
+    compression: bz2
+'''
+
+import stat
+import os
+import errno
+import glob
+import shutil
+import gzip
+import bz2
+import zipfile
+import tarfile
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            path = dict(required=True),
+            compression = dict(choices=['gz', 'bz2', 'zip'], default='gz', required=False),
+            creates = dict(required=False),
+            remove = dict(required=False, default=True, type='bool'),
+        ),
+        add_file_common_args=True,
+        supports_check_mode=True,
+    )
+
+    params = module.params
+    paths = params['path']
+    creates = params['creates']
+    remove = params['remove']
+    expanded_paths = []
+    compression = params['compression']
+    globby = False
+    changed = False
+    state = 'absent'
+
+    # Simple or archive file compression (inapplicable with 'zip')
+    archive = False
+    successes = []
+
+    if isinstance(paths, basestring):
+        paths = [paths]
+
+    for i, path in enumerate(paths):
+        path = os.path.expanduser(params['path'])
+
+        # Detect glob-like characters
+        if any((c in set('*?')) for c in path):
+            expanded_paths = expanded_paths + glob.glob(path)
+        else:
+            expanded_paths.append(path)
+
+    if len(expanded_paths) == 0:
+        module.fail_json(path, msg='Error, no source paths were found')
+
+    # If we actually matched multiple files or TRIED to, then
+    # treat this as a multi-file archive
+    archive = globby or len(expanded_paths) > 1 or any(os.path.isdir(path) for path in expanded_paths)
+
+    # Default created file name (for single-file archives) to
+    # <file>.<compression>
+    if not archive and not creates:
+        creates = '%s.%s' % (expanded_paths[0], compression)
+
+    # Force archives to specify 'creates'
+    if archive and not creates:
+        module.fail_json(creates=creates, path=', '.join(paths), msg='Error, must specify "creates" when archiving multiple files or trees')
+
+    archive_paths = []
+    missing = []
+    arcroot = ''
+
+    for path in expanded_paths:
+        # Use the longest common directory name among all the files
+        # as the archive root path
+        if arcroot == '':
+            arcroot = os.path.dirname(path)
+        else:
+            for i in xrange(len(arcroot)):
+                if path[i] != arcroot[i]:
+                    break
+
+            if i < len(arcroot):
+                arcroot = os.path.dirname(arcroot[0:i+1])
+
+        if path == creates:
+            # Don't allow the archive to specify itself! this is an error.
+            module.fail_json(path=', '.join(paths), msg='Error, created archive would be included in archive')
+
+        if os.path.lexists(path):
+            archive_paths.append(path)
+        else:
+            missing.append(path)
+
+    # No source files were found but the named archive exists: are we 'compress' or 'archive' now?
+    if len(missing) == len(expanded_paths) and creates and os.path.exists(creates):
+        # Just check the filename to know if it's an archive or simple compressed file
+        if re.search(r'(\.tar\.gz|\.tgz|.tbz2|\.tar\.bz2|\.zip)$', os.path.basename(creates), re.IGNORECASE):
+            state = 'archive'
+        else:
+            state = 'compress'
+
+    # Multiple files, or globbiness
+    elif archive:
+        if len(archive_paths) == 0:
+            # No source files were found, but the archive is there.
+            if os.path.lexists(creates):
+                state = 'archive'
+        elif len(missing) > 0:
+            # SOME source files were found, but not all of them
+            state = 'incomplete'
+
+        archive = None
+        size = 0
+        errors = []
+
+        if os.path.lexists(creates):
+            size = os.path.getsize(creates)
+
+        if state != 'archive':
+            try:
+                if compression == 'gz' or compression == 'bz2':
+                    archive = tarfile.open(creates, 'w|' + compression)
+
+                    for path in archive_paths:
+                        archive.add(path, path[len(arcroot):])
+                        successes.append(path)
+
+                elif compression == 'zip':
+                    archive = zipfile.ZipFile(creates, 'wb')
+
+                    for path in archive_paths:
+                        archive.write(path, path[len(arcroot):])
+                        successes.append(path)
+
+            except OSError:
+                e = get_exception()
+                module.fail_json(msg='Error when writing zip archive at %s: %s' % (creates, str(e)))
+
+            if archive:
+                archive.close()
+
+        if state != 'archive' and remove:
+            for path in successes:
+                try:
+                    if os.path.isdir(path):
+                        shutil.rmtree(path)
+                    else:
+                        os.remove(path)
+                except OSError:
+                    e = get_exception()
+                    errors.append(path)
+
+            if len(errors) > 0:
+                module.fail_json(creates=creates, msg='Error deleting some source files: ' + str(e), files=errors)
+
+        # Rudimentary check: If size changed then file changed. Not perfect, but easy.
+        if os.path.getsize(creates) != size:
+            changed = True
+
+        if len(successes) and state != 'incomplete':
+            state = 'archive'
+
+    # Simple, single-file compression
+    else:
+        path = expanded_paths[0]
+
+        # No source or compressed file
+        if not (os.path.exists(path) or os.path.lexists(creates)):
+            state = 'absent'
+
+        # if it already exists and the source file isn't there, consider this done
+        elif not os.path.lexists(path) and os.path.lexists(creates):
+            state = 'compress'
+
+        else:
+            if module.check_mode:
+                if not os.path.exists(creates):
+                    changed = True
+            else:
+                size = 0
+                f_in = f_out = archive = None
+
+                if os.path.lexists(creates):
+                    size = os.path.getsize(creates)
+
+                try:
+                    if compression == 'zip':
+                        archive = zipfile.ZipFile(creates, 'wb')
+                        archive.write(path, path[len(arcroot):])
+                        archive.close()
+                        state = 'archive' # because all zip files are archives
+
+                    else:
+                        f_in = open(path, 'rb')
+
+                        if compression == 'gz':
+                            f_out = gzip.open(creates, 'wb')
+                        elif compression == 'bz2':
+                            f_out = bz2.BZ2File(creates, 'wb')
+                        else:
+                            raise OSError("Invalid compression")
+
+                        shutil.copyfileobj(f_in, f_out)
+
+                except OSError:
+                    e = get_exception()
+
+                    module.fail_json(path=path, creates=creates, msg='Unable to write to compressed file: %s' % str(e))
+
+                if archive:
+                    archive.close()
+                if f_in:
+                    f_in.close()
+                if f_out:
+                    f_out.close()
+
+                # Rudimentary check: If size changed then file changed. Not perfect, but easy.
+                if os.path.getsize(creates) != size:
+                    changed = True
+
+            state = 'compress'
+
+        if remove:
+            try:
+                os.remove(path)
+
+            except OSError:
+                e = get_exception()
+                module.fail_json(path=path, msg='Unable to remove source file: %s' % str(e))
+
+    module.exit_json(archived=successes, creates=creates, changed=changed, state=state, arcroot=arcroot, missing=missing, expanded_paths=expanded_paths)
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/files/archive.py
+++ b/files/archive.py
@@ -157,7 +157,9 @@ def main():
 
     # Default created file name (for single-file archives) to
     # <file>.<compression>
-    if not archive and not dest:
+    if dest:
+        dest = os.path.expanduser(dest)
+    elif not archive:
         dest = '%s.%s' % (expanded_paths[0], compression)
 
     # Force archives to specify 'dest'

--- a/files/archive.py
+++ b/files/archive.py
@@ -17,7 +17,7 @@ options:
     default: null
   compression:
     description:
-      - "The type of compression to use. Can be 'gz', 'bz2', or 'zip'.
+      - The type of compression to use. Can be 'gz', 'bz2', or 'zip'.
     choices: [ 'gz', 'bz2', 'zip' ]
   creates:
     description:

--- a/files/archive.py
+++ b/files/archive.py
@@ -175,7 +175,7 @@ def main():
                         successes.append(path)
 
                 elif compression == 'zip':
-                    archive = zipfile.ZipFile(creates, 'wb')
+                    archive = zipfile.ZipFile(creates, 'w')
 
                     for path in archive_paths:
                         archive.write(path, path[len(arcroot):])

--- a/files/archive.py
+++ b/files/archive.py
@@ -223,7 +223,11 @@ def main():
                         if os.path.isdir(path) and not path.endswith(os.sep + '.'):
                             basename = os.path.basename(path) + os.sep
 
-                        archive.add(path, path[len(arcroot):], filter=lambda f: f if f.name != creates else None)
+                        filter_create = lambda f:
+                            if filecmp.cmp(f.name, creates):
+                                return f
+
+                        archive.add(path, path[len(arcroot):], filter=filter_create)
                         successes.append(path)
 
                 # Slightly more difficult (and less efficient!) compression using zipfile module

--- a/files/archive.py
+++ b/files/archive.py
@@ -32,7 +32,7 @@ description:
 options:
   path:
     description:
-      - Remote absolute path, glob, or list of paths or globs for the file or files to archive or compress.
+      - Remote absolute path, glob, or list of paths or globs for the file or files to compress or archive.
     required: true
   compression:
     description:
@@ -134,7 +134,7 @@ def main():
     changed = False
     state = 'absent'
 
-    # Simple or archive file compression (inapplicable with 'zip')
+    # Simple or archive file compression (inapplicable with 'zip' since it's always an archive)
     archive = False
     successes = []
 

--- a/files/archive.py
+++ b/files/archive.py
@@ -272,6 +272,8 @@ def main():
 
                         shutil.copyfileobj(f_in, f_out)
 
+                    successes.append(path)
+
                 except OSError:
                     e = get_exception()
 

--- a/files/archive.py
+++ b/files/archive.py
@@ -315,16 +315,16 @@ def main():
                     changed = True
             else:
                 size = 0
-                f_in = f_out = archive = None
+                f_in = f_out = arcfile = None
 
                 if os.path.lexists(dest):
                     size = os.path.getsize(dest)
 
                 try:
                     if compression == 'zip':
-                        archive = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED)
-                        archive.write(path, path[len(arcroot):])
-                        archive.close()
+                        arcfile = zipfile.ZipFile(dest, 'w', zipfile.ZIP_DEFLATED)
+                        arcfile.write(path, path[len(arcroot):])
+                        arcfile.close()
                         state = 'archive' # because all zip files are archives
 
                     else:
@@ -346,8 +346,8 @@ def main():
 
                     module.fail_json(path=path, dest=dest, msg='Unable to write to compressed file: %s' % str(e))
 
-                if archive:
-                    archive.close()
+                if arcfile:
+                    arcfile.close()
                 if f_in:
                     f_in.close()
                 if f_out:

--- a/files/archive.py
+++ b/files/archive.py
@@ -38,6 +38,7 @@ options:
     description:
       - The type of compression to use. Can be 'gz', 'bz2', or 'zip'.
     choices: [ 'gz', 'bz2', 'zip' ]
+    default: 'gz'
   creates:
     description:
       - The file name of the destination archive. This is required when C(path) refers to multiple files by either specifying a glob, a directory or multiple paths in a list.


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

archive
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This module serves two purposes:
- Allow management of compressed archives or single files using standard compression formats
- Act as an analog to the 'unarchive' module which does the opposite.

My particular use case was that I wanted to ensure a large SQL file stayed in a compressed state, and would update when the non-compressed version was restored. I initially opened a PR https://github.com/ansible/ansible-modules-core/pull/3735 against the file module to achieve this behavior, but it was clear that was not the right place for it.

This module offers the same functionality and more, by allowing multiple paths, trees, or patterns to be specified for archival. The common root for all of the files is computed and removed from the archived path names.

The simple use case is to compress a single file:

``` yaml
- name: Compress this file
  archive: path=/my/file
```

When `/my/file` exists, `/my/file.gz` is created with the gzip-compressed contents of `/my/file`. If the `/my/file.gz` already exists, it is over-written and the difference in the compressed file size is used to determine whether or not the state has changed. If `/my/file.gz` exists and the source file `/my/file` does not, the state is considered `compress` and unchanged. `/my/file` is removed once compressed, _unless_ `remove=False` is specified.

Another use:

``` yaml
- name: Compress this tree
  archive: path=/my/tree creates=/my/archive.tgz
```

Creates a tarball at /my/archive.tgz with the contents of `/my/tree`. Since all of the files in the specified path share a common base path in `/my/tree`, the files in the produced archive are relative to `/my/tree`. The path `/my/tree` is removed unless `remove=False` is specified. 
