### PR TITLE
Netscaler: Expire sessions gracefully instead of terminating immediately

### DIFF
--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -150,7 +150,6 @@ class netscaler(object):
           self._type_params = {"name": self._name, "delay": self._delay, "graceful": self._graceful}
         else:
           self._type_params = {"name": self._name}
-
         resp = self.http_request(
             'config',
             {

--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -211,7 +211,6 @@ def main():
         result['changed'] = True
         module.exit_json(**result)
 
-
 # import module snippets
 from ansible.module_utils.basic import *
 from ansible.module_utils.urls import *

--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -87,6 +87,7 @@ options:
     default: YES
     choices: ["YES", "NO"]
     aliases: []
+    version_added: "2.2"
   delay:
     description:
       - delay (in seconds) before disabling server or service
@@ -94,20 +95,21 @@ options:
     default: 1800
     choices: Any posative integer number
     aliases: []
+    version_added: "2.2"
 
 requirements: []
 author: "Nandor Sivok (@dominis)"
 '''
 
 EXAMPLES = '''
-# Disable the server
+# Disable the server (gracefully with up to 30 mins delay)
 ansible host -m netscaler -a "nsc_host=nsc.example.com user=apiuser password=apipass"
 
 # Enable the server
 ansible host -m netscaler -a "nsc_host=nsc.example.com user=apiuser password=apipass action=enable"
 
-# Disable the service local:8080
-ansible host -m netscaler -a "nsc_host=nsc.example.com user=apiuser password=apipass name=local:8080 type=service action=disable"
+# Disable the service local:8080 immediately
+ansible host -m netscaler -a "nsc_host=nsc.example.com user=apiuser password=apipass name=local:8080 type=service action=disable delay=0 graceful=NO"
 '''
 
 

--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -85,15 +85,13 @@ options:
       - gracefully expire sessions before disabling server or service
     required: false
     default: YES
-    choices: ["YES", "NO"]
-    aliases: []
+    choices: ['YES', 'yes', 'NO', 'no']
     version_added: "2.2"
   delay:
     description:
       - delay (in seconds) before disabling server or service
     required: false
     default: 1800
-    aliases: []
     version_added: "2.2"
 
 requirements: []
@@ -190,7 +188,7 @@ def main():
             type = dict(default='server', choices=['service', 'server']),
             validate_certs=dict(default='yes', type='bool'),
             delay = dict(default='1800', type='int'),
-            graceful = dict(default='YES', choices=['YES', 'NO']),
+            graceful = dict(default='YES', choices=['YES', 'yes', 'NO', 'no']),
         )
     )
 

--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -122,6 +122,7 @@ class netscaler(object):
         self.module = module
 
     def http_request(self, api_endpoint, data_json={}):
+        _return_content = {}
         request_url = self._nsc_protocol + '://' + self._nsc_host + self._nitro_base_url + api_endpoint
 
         data_json = urllib.urlencode(data_json)
@@ -136,7 +137,13 @@ class netscaler(object):
 
         response, info = fetch_url(self.module, request_url, data=data_json, headers=headers)
 
-        return json.load(response)
+        if response is None:
+          _return_content = info
+          _return_content['errorcode'] = "No response from Netscaler, see msg for detail"
+        else:
+          _return_content = json.load(response)
+
+        return _return_content
 
     def prepare_request(self, action):
         if action == 'disable':

--- a/network/citrix/netscaler.py
+++ b/network/citrix/netscaler.py
@@ -93,7 +93,6 @@ options:
       - delay (in seconds) before disabling server or service
     required: false
     default: 1800
-    choices: Any posative integer number
     aliases: []
     version_added: "2.2"
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

netscaler
##### ANSIBLE VERSION

```
ansible 2.0.0.2
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

For the netscaler module, allow custom settings for gracefully expiring sessions before removing from service, and allow a custom delay before nodes are removed from service. 
Details of options are at [docs.citrix.com - graceful shutdown](http://docs.citrix.com/en-us/netscaler/10-5/ns-tmg-wrapper-10-con/ns-lb-wrapper-con-10/ns-lb-clienttraffic-con/ns-lb-clienttraffic-gracefulshutdown-tsk.html)

This makes the module better suited for production environments where long stateful sessions exist. 
In the disabling service example below, this will wait up to 30 minutes before taking the service out of service. If there are still active sessions after 30 mins they will be terminated

```
ansible host -m netscaler -a "nsc_host=nsc.example.com user=apiuser password=apipass name=local:8080 type=service action=disable graceful=YES delay=1800"
```
