### PR TITLE
zabbix_hostmacro: Fixed basic auth (#2330)

### DIFF
--- a/monitoring/zabbix_hostmacro.py
+++ b/monitoring/zabbix_hostmacro.py
@@ -111,8 +111,8 @@ except ImportError:
 # Extend the ZabbixAPI
 # Since the zabbix-api python module too old (version 1.0, no higher version so far).
 class ZabbixAPIExtends(ZabbixAPI):
-    def __init__(self, server, timeout, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=timeout)
+    def __init__(self, server, timeout, user, passwd, **kwargs):
+        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
 
 
 class HostMacro(object):


### PR DESCRIPTION
##### ISSUE TYPE
- Bug Report
##### COMPONENT NAME

zabbix_hostmacro
##### ANSIBLE VERSION

```
2.1
```
##### CONFIGURATION

Default
##### OS / ENVIRONMENT

Ubuntu 14.04
##### SUMMARY

`zabbix_hostmacro` not work correctly with basic auth because `ZabbixAPI` is calling without _user_ and _password_ arguments. 
