### PR TITLE
Improve documentation for win_firewall_rule module

### DIFF
--- a/windows/win_firewall_rule.py
+++ b/windows/win_firewall_rule.py
@@ -97,7 +97,7 @@ options:
         required: false
     profile:
         description:
-            - the profile this rule applies to
+            - the profile this rule applies to, e.g. Domain,Private,Public
         default: null
         required: false
     force:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task  -->
##### ANSIBLE VERSION

```
<!--- Paste verbatim output from “ansible --version” between quotes -->
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

```
<!--- Paste verbatim command output here, e.g. before and after your change -->
```

added profile examples as my firewall task would pass yet no firewall rule was created until I added

profile: Domain,Private,Public

When setting a Firewall rule on Windows Server 2008 R2 manually, these three are selected as default, useful to have in the documentation maybe?
