### PR TITLE
add type declaration to the port parameter of the irc module. #AnsibleZH

### DIFF
--- a/notification/irc.py
+++ b/notification/irc.py
@@ -247,7 +247,7 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             server=dict(default='localhost'),
-            port=dict(default=6667),
+            port=dict(type='int', default=6667),
             nick=dict(default='ansible'),
             nick_to=dict(required=False, type='list'),
             msg=dict(required=True),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

notification/irc.py
##### ANSIBLE VERSION

```
ansible 2.0.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fix small issue brought up by @resmo at the 3rd Ansible Zurich meetup
The port parameter in the irc module did not have a type declaration.
