### PR TITLE
Set 'type' of 'external_ids' to 'dict' in argument_spec of openvswitch_port

### DIFF
--- a/network/openvswitch_port.py
+++ b/network/openvswitch_port.py
@@ -238,7 +238,7 @@ def main():
             'state': {'default': 'present', 'choices': ['present', 'absent']},
             'timeout': {'default': 5, 'type': 'int'},
             'set': {'required': False, 'default': None},
-            'external_ids': {'default': {}, 'required': False},
+            'external_ids': {'default': {}, 'required': False, 'type': 'dict'},
         },
         supports_check_mode=True,
     )


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

openvswitch_port module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 96495594cc) last updated 2016/06/01 20:40:41 (GMT +200)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/01 20:43:45 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD b0aec50b9a) last updated 2016/06/01 20:43:45 (GMT +200)
```
##### SUMMARY

Running the command `openvswitch_port: bridge=br-test port=eth0 state=present` would fail if the bridge existed and the port was already added.

The external_ids 'type' was not defined in the argument spec of openvswitch_port. This lead 'external_ids' to be converted to a string, when the default value was used. Further down the code this was leading to an exception. By defining the type all is right.

Test playbook: (tested under Ubuntu 12.04) (you need to run the playbook twice to get the error)

```

---
- name: Reproduce error
  hosts: localhost
  become: true
  tasks:
        - name: Install OpenVSwitch
          apt: name=openvswitch-switch state=present

        - name: Create test bridge
          openvswitch_bridge: bridge=br-test state=present

        - name: Add eth0 to test bridge
          openvswitch_port: bridge=br-test port=eth0 state=present
```

Before:

```
$ ansible-playbook -i dev.inventory ovsport.yml --ask-sudo
SUDO password: 

PLAY [Reproduce error] *********************************************************

TASK [setup] *******************************************************************
ok: [network]

TASK [Install OpenVSwitch] *****************************************************
ok: [network]

TASK [Create test bridge] ******************************************************
ok: [network]

TASK [Add eth0 to test bridge] *************************************************
fatal: [network]: FAILED! => {"changed": false, "failed": true, "msg": "'str' object has no attribute 'items'"}
```

After:

```
$ ansible-playbook -i dev.inventory ovsport.yml --ask-sudo
SUDO password: 

PLAY [Reproduce error] *********************************************************

TASK [setup] *******************************************************************
ok: [network]

TASK [Install OpenVSwitch] *****************************************************
ok: [network]

TASK [Create test bridge] ******************************************************
ok: [network]

TASK [Add eth0 to test bridge] *************************************************
ok: [network]

PLAY RECAP *********************************************************************
network                    : ok=4    changed=0    unreachable=0    failed=0
```
