### PR TITLE
Fix the eni creation/modification logic thus making it idempotent

### DIFF
--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -71,6 +71,7 @@ options:
         instance_id is given, attachment status won't change
     required: false
     default: yes
+    version_added: 2.2
   force_detach:
     description:
       - Force detachment of the interface. This applies either when explicitly detaching the interface by setting instance_id to None or when deleting an interface with state=absent.

--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -18,9 +18,8 @@ DOCUMENTATION = '''
 module: ec2_eni
 short_description: Create and optionally attach an Elastic Network Interface (ENI) to an instance
 description:
-    - Create and optionally attach an Elastic Network Interface (ENI) to an
-      instance. If an ENI ID is provided, an attempt is made to update the
-      existing ENI. By passing state=detached, an ENI can be detached from its instance.
+    - Create and optionally attach an Elastic Network Interface (ENI) to an instance. If an ENI ID is provided, \
+    an attempt is made to update the existing ENI. By passing state=detached, an ENI can be detached from its instance.
 version_added: "2.0"
 author: "Rob White (@wimnat)"
 options:
@@ -31,8 +30,8 @@ options:
     default: null
   instance_id:
     description:
-      - Instance ID that you wish to attach ENI to, if None the new ENI will be
-        created in detached state, existing ENI will keep current attachment state.
+      - Instance ID that you wish to attach ENI to, if None the new ENI will be created in detached state, existing \
+      ENI will keep current attachment state.
     required: false
     default: null
   private_ip_address:

--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -168,6 +168,60 @@ EXAMPLES = '''
 
 '''
 
+
+RETURN = '''
+interface:
+  description: Network interface attributes
+  returned: when state != absent
+  type: dictionary
+  contains:
+    description:
+      description: interface description
+      type: string
+      sample: Firewall network interface
+    groups:
+      description: list of security groups
+      type: list of dictionaries
+      sample: [ { "sg-f8a8a9da": "default" } ]
+    id:
+      description: network interface id
+      type: string
+      sample: "eni-1d889198"
+    mac_address:
+      description: interface's physical address
+      type: string
+      sample: "06:9a:27:6a:6f:99"
+    owner_id:
+      description: aws account id
+      type: string
+      sample: 812381371
+    private_ip_address:
+      description: primary ip address of this interface
+      type: string
+      sample: 10.20.30.40
+    private_ip_addresses:
+      description: list of all private ip addresses associated to this interface
+      type: list of dictionaries
+      sample: [ { "primary_address": true, "private_ip_address": "10.20.30.40" } ]
+    source_dest_check:
+      description: value of source/dest check flag
+      type: boolean
+      sample: True
+    status:
+      description: network interface status
+      type: string
+      sample: "pending"
+    subnet_id:
+      description: which vpc subnet the interface is bound
+      type: string
+      sample: subnet-b0a0393c
+    vpc_id:
+      description: which vpc this network interface is bound
+      type: string
+      sample: vpc-9a9a9da
+
+'''
+
 import time
 import re
 

--- a/cloud/amazon/ec2_eni.py
+++ b/cloud/amazon/ec2_eni.py
@@ -241,7 +241,6 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-
 def get_eni_info(interface):
 
     # Private addresses
@@ -390,7 +389,10 @@ def modify_eni(connection, vpc_id, module, eni):
                 secondary_addresses_to_remove_count = current_secondary_address_count - secondary_private_ip_address_count
                 connection.unassign_private_ip_addresses(network_interface_id=eni.id, private_ip_addresses=current_secondary_addresses[:secondary_addresses_to_remove_count], dry_run=False)
 
-        if attached == True and instance_id is not None:
+        if attached == True:
+            if eni.attachment and eni.attachment.instance_id != instance_id:
+                detach_eni(eni, module)
+            if eni.attachment is None:
                 eni.attach(instance_id, device_index)
                 wait_for_eni(eni, "attached")
                 changed = True
@@ -451,13 +453,20 @@ def find_eni(connection, module):
     eni_id = module.params.get("eni_id")
     subnet_id = module.params.get('subnet_id')
     private_ip_address = module.params.get('private_ip_address')
+    instance_id = module.params.get('instance_id')
+    device_index = module.params.get('device_index')
 
     try:
         filters = {}
-        if private_ip_address:
-            filters['private-ip-address'] = private_ip_address
         if subnet_id:
             filters['subnet-id'] = subnet_id
+        if private_ip_address:
+            filters['private-ip-address'] = private_ip_address
+        else:
+            if instance_id:
+                filters['attachment.instance-id'] = instance_id
+            if device_index:
+                filters['attachment.device-index'] = device_index
 
         eni_result = connection.get_all_network_interfaces(eni_id, filters=filters)
         if len(eni_result) > 0:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_eni
##### ANSIBLE VERSION

```
➜  ansible --version
ansible 2.2.0 (devel f0023610e8) last updated 2016/06/02 16:41:50 (GMT -200)
  lib/ansible/modules/core: (detached HEAD ca4365b644) last updated 2016/06/02 16:42:04 (GMT -200)
  lib/ansible/modules/extras: (fix-ec2_eni 9d0ca87482) last updated 2016/06/02 16:39:24 (GMT -200)
  config file = ...
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes https://github.com/ansible/ansible-modules-extras/issues/2084 
##### Commands tested:
- ENI Creation:
  `ansible -i localhost, -c local -m ec2_eni -a 'private_ip_address=10.137.8.7 subnet_id=subnet-??? state=present region=eu-west-1 ' localhost`
- Modifying description: 
  `ansible -i localhost, -c local -m ec2_eni -a 'private_ip_address=10.137.8.7 subnet_id=subnet-??? description=bla state=present region=eu-west-1 ' localhost`
- Modifying security groups: `ansible -i localhost, -c local -m ec2_eni -a 'private_ip_address=10.137.8.7 subnet_id=subnet-??? state=present region=eu-west-1 security_groups=sg-8708dde0 ' localhost`
- Modifying delete_on_termination: `ansible -i localhost, -c local -m ec2_eni -a 'private_ip_address=10.137.8.7 subnet_id=subnet-??? state=present region=eu-west-1 delete_on_termination=yes ' localhost 
- Detaching: `ansible -i localhost, -c local -m ec2_eni -a 'eni_id=eni-1c216256 state=detached region=eu-west-1`
- Deleting: `ansible -i localhost, -c local -m ec2_eni -a 'eni_id=eni-1c216256 state=absent region=eu-west-1' localhost`
