### PR TITLE
taskDefinition may be prefixed causing false positives

### DIFF
--- a/cloud/amazon/ecs_service.py
+++ b/cloud/amazon/ecs_service.py
@@ -238,7 +238,12 @@ class EcsServiceManager:
         raise StandardError("Unknown problem describing service %s." % service_name)
 
     def is_matching_service(self, expected, existing):
-        if expected['task_definition'] != existing['taskDefinition']:
+        # existing will be prefixed, like arn:aws:ecs:us-east-1:000000000000:task-definition/
+        try:
+            _, existing_task_definition = existing['taskDefinition'].split('/', 1)
+        except (AttributeError, ValueError):
+            existing_task_definition = existing['taskDefinition']
+        if expected['task_definition'] != existing_task_definition:
             return False
 
         if (expected['load_balancers'] or []) != existing['loadBalancers']:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/amazon/ecs_service
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In ecs_service, `is_matching_service` member of `EcsServiceManager` compares the documented task name (like task:revision) against the response from amazon, which contains a prefix about the region and policy related to the task name.  This change splits off the prefix and only compares the task name)

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

before:

```
TASK [ecs_service aws_secret_key={{aws_secret_access_key}}, aws_access_key={{aws_access_key_id}}, name=elasticsearch-ecs-serv, desired_count=4, region=us-east-1, state=present, cluster=default, task_definition=elasticsearch-ecs-taskdef:16, role=ecsServiceRole, load_balancers=[{u'containerName': u'elasticsearch-ecs', u'containerPort': 9200, u'loadBalancerName': u'f...'}], client_token=...] ***
changed: [localhost -> localhost]
```

after:

```
TASK [ecs_service aws_secret_key={{aws_secret_access_key}}, aws_access_key={{aws_access_key_id}}, name=elasticsearch-ecs-serv, desired_count=4, region=us-east-1, state=present, cluster=default, task_definition=elasticsearch-ecs-taskdef:16, role=ecsServiceRole, load_balancers=[{u'containerName': u'elasticsearch-ecs', u'containerPort': 9200, u'loadBalancerName': u'f...'}], client_token=...] ***
ok: [localhost -> localhost]

```
