### PR TITLE
Add zypper refresh support in zypper module

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -350,11 +350,6 @@ def repo_refresh(m):
 
     retvals['cmd'] = cmd
     result, retvals['rc'], retvals['stdout'], retvals['stderr'] = parse_zypper_xml(m, cmd)
-    if retvals['rc'] == 0:
-        # refresh was successed
-        retvals['changed'] = True
-    else:
-        retvals['failed'] = True
 
     return retvals
 
@@ -384,9 +379,7 @@ def main():
     if refresh:
         retvals = repo_refresh(module)
 
-        failed = retvals['failed']
-        del retvals['failed']
-        if failed:
+        if retvals['rc'] != 0:
             module.fail_json(msg="Zypper refresh run failed.", **retvals)
 
         if not name:

--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -91,6 +91,7 @@ options:
         required: false
         default: "no"
         choices: [ "yes", "no" ]
+        aliases: [ "update_cache" ]
 
 
 # informational: requirements for nodes
@@ -365,7 +366,7 @@ def main():
             disable_gpg_check = dict(required=False, default='no', type='bool'),
             disable_recommends = dict(required=False, default='yes', type='bool'),
             force = dict(required=False, default='no', type='bool'),
-            refresh = dict(required=False, default='no', type='bool'),
+            refresh = dict(required=False, aliases=['update_cache'], default='no', type='bool'),
         ),
         required_one_of = [['name', 'refresh']],
         supports_check_mode = True


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

packaging/os/zypper
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This PR adds the manual refresh repositories before operation. Can be run as part of the package installation or as a separate step.
Also there is a clean-up of  trialling symbols.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
ok: [host] => {"changed": false, "cmd": ["/usr/bin/zypper", "--quiet", "--non-interactive", "--xmlout", "install", "--type", "package", "--auto-agree-with-licenses", "--no-recommends", "--", "openssh"], "invocation": {"module_args": {"disable_gpg_check": false, "disable_recommends": true, "force": false, "name": ["openssh"], "refresh": true, "state": "latest", "type": "package"}, "module_name": "zypper"}, "name": ["openssh"], "rc": 0, "refresh": true, "state": "latest"}
```
