### PR TITLE
ec2_vpc_route_table fixes: #2377

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -319,7 +319,8 @@ def ensure_routes(vpc_conn, route_table, route_specs, propagating_vgw_ids,
     # VGWs in place.
     routes_to_delete = [r for r in routes_to_match
                         if r.gateway_id != 'local'
-                        and r.gateway_id not in propagating_vgw_ids]
+                        and (propagating_vgw_ids is not None
+                             and r.gateway_id not in propagating_vgw_ids)]
 
     changed = routes_to_delete or route_specs_to_create
     if changed:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
  Issue: https://github.com/ansible/ansible-modules-extras/issues/2377
##### COMPONENT NAME

ec2_vpc_route_table
##### ANSIBLE VERSION

ansible 2.0.2.0
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

propagating_vgw_ids are allowed to be none, but there is a block of code that incorrectly assumes propagating_vgw_ids will NOT be none.

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
Ran a 'create' and 'update' ec2_vpc_route_table task with and without propagating_vgw_ids.
```
