### PR TITLE
Fixes check mode error on Python 2.4 and wrong changed state

### DIFF
--- a/database/postgresql/postgresql_ext.py
+++ b/database/postgresql/postgresql_ext.py
@@ -164,9 +164,9 @@ def main():
 
     try:
         if module.check_mode:
-            if state == "absent":
+            if state == "present":
                 changed = not ext_exists(cursor, ext)
-            elif state == "present":
+            elif state == "absent":
                 changed = ext_exists(cursor, ext)
             module.exit_json(changed=changed,ext=ext)
 
@@ -175,6 +175,8 @@ def main():
 
         elif state == "present":
             changed = ext_create(cursor, ext)
+    except SystemExit, e:
+        raise
     except NotSupportedError, e:
         module.fail_json(msg=str(e))
     except Exception, e:

--- a/database/postgresql/postgresql_ext.py
+++ b/database/postgresql/postgresql_ext.py
@@ -168,21 +168,18 @@ def main():
                 changed = not ext_exists(cursor, ext)
             elif state == "absent":
                 changed = ext_exists(cursor, ext)
-            module.exit_json(changed=changed,ext=ext)
-
-        if state == "absent":
-            changed = ext_delete(cursor, ext)
-
-        elif state == "present":
-            changed = ext_create(cursor, ext)
-    except SystemExit, e:
-        raise
+        else:
+            if state == "absent":
+                changed = ext_delete(cursor, ext)
+    
+            elif state == "present":
+                changed = ext_create(cursor, ext)
     except NotSupportedError, e:
         module.fail_json(msg=str(e))
     except Exception, e:
         module.fail_json(msg="Database query failed: %s" % e)
 
-    module.exit_json(changed=changed, db=db)
+    module.exit_json(changed=changed, db=db, ext=ext)
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

postgresql_ext
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

`postgresql_ext` in check mode always returned an error when it was executed on Python 2.4. Also in check mode the `changed` return value was wrong. This simple pull request fixes both issues.
