### PR TITLE
Adds server port argument to legacy BIG-IP modules

### DIFF
--- a/network/f5/bigip_facts.py
+++ b/network/f5/bigip_facts.py
@@ -25,7 +25,9 @@ short_description: "Collect facts from F5 BIG-IP devices"
 description:
     - "Collect facts from F5 BIG-IP devices via iControl SOAP API"
 version_added: "1.6"
-author: "Matt Hite (@mhite)" 
+author:
+    - Matt Hite (@mhite)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11.4"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -42,6 +44,12 @@ options:
         default: null
         choices: []
         aliases: []
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -137,8 +145,8 @@ class F5(object):
         api: iControl API instance.
     """
 
-    def __init__(self, host, user, password, session=False, validate_certs=True):
-        self.api = bigip_api(host, user, password, validate_certs)
+    def __init__(self, host, user, password, session=False, validate_certs=True, port=443):
+        self.api = bigip_api(host, user, password, validate_certs, port)
         if session:
             self.start_session()
 
@@ -1593,6 +1601,7 @@ def main():
         module.fail_json(msg="the python suds and bigsuds modules are required")
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     validate_certs = module.params['validate_certs']
@@ -1622,7 +1631,7 @@ def main():
         facts = {}
 
         if len(include) > 0:
-            f5 = F5(server, user, password, session, validate_certs)
+            f5 = F5(server, user, password, session, validate_certs, server_port)
             saved_active_folder = f5.get_active_folder()
             saved_recursive_query_state = f5.get_recursive_query_state()
             if saved_active_folder != "/":

--- a/network/f5/bigip_monitor_http.py
+++ b/network/f5/bigip_monitor_http.py
@@ -27,7 +27,9 @@ short_description: "Manages F5 BIG-IP LTM http monitors"
 description:
     - "Manages F5 BIG-IP LTM monitors via iControl SOAP API"
 version_added: "1.4"
-author: "Serge van Ginderachter (@srvg)"
+author:
+    - Serge van Ginderachter (@srvg)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -41,6 +43,12 @@ options:
             - BIG-IP host
         required: true
         default: null
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -326,6 +334,7 @@ def main():
             module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
@@ -347,7 +356,7 @@ def main():
 
     # end monitor specific stuff
 
-    api = bigip_api(server, user, password, validate_certs)
+    api = bigip_api(server, user, password, validate_certs, port=server_port)
     monitor_exists = check_monitor_exists(module, api, monitor, parent)
 
 

--- a/network/f5/bigip_monitor_tcp.py
+++ b/network/f5/bigip_monitor_tcp.py
@@ -25,7 +25,9 @@ short_description: "Manages F5 BIG-IP LTM tcp monitors"
 description:
     - "Manages F5 BIG-IP LTM tcp monitors via iControl SOAP API"
 version_added: "1.4"
-author: "Serge van Ginderachter (@srvg)"
+author:
+    - Serge van Ginderachter (@srvg)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -39,6 +41,12 @@ options:
             - BIG-IP host
         required: true
         default: null
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -345,6 +353,7 @@ def main():
             module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
@@ -370,7 +379,7 @@ def main():
 
     # end monitor specific stuff
 
-    api = bigip_api(server, user, password, validate_certs)
+    api = bigip_api(server, user, password, validate_certs, port=server_port)
     monitor_exists = check_monitor_exists(module, api, monitor, parent)
 
 

--- a/network/f5/bigip_node.py
+++ b/network/f5/bigip_node.py
@@ -25,7 +25,9 @@ short_description: "Manages F5 BIG-IP LTM nodes"
 description:
     - "Manages F5 BIG-IP LTM nodes via iControl SOAP API"
 version_added: "1.4"
-author: "Matt Hite (@mhite)"
+author:
+    - Matt Hite (@mhite)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -40,6 +42,12 @@ options:
         default: null
         choices: []
         aliases: []
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -313,7 +321,8 @@ def set_monitors(api, name, monitor_type, quorum, monitor_templates):
 def main():
     monitor_type_choices = ['and_list', 'm_of_n']
 
-    argument_spec=f5_argument_spec()
+    argument_spec = f5_argument_spec()
+
     argument_spec.update(dict(
             session_state = dict(type='str', choices=['enabled', 'disabled']),
             monitor_state = dict(type='str', choices=['enabled', 'disabled']),
@@ -340,6 +349,7 @@ def main():
             module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
@@ -387,7 +397,7 @@ def main():
         module.fail_json(msg="quorum requires monitors parameter")
 
     try:
-        api = bigip_api(server, user, password, validate_certs)
+        api = bigip_api(server, user, password, validate_certs, port=server_port)
         result = {'changed': False}  # default
 
         if state == 'absent':

--- a/network/f5/bigip_pool.py
+++ b/network/f5/bigip_pool.py
@@ -25,7 +25,9 @@ short_description: "Manages F5 BIG-IP LTM pools"
 description:
     - "Manages F5 BIG-IP LTM pools via iControl SOAP API"
 version_added: "1.2"
-author: "Matt Hite (@mhite)"
+author:
+    - Matt Hite (@mhite)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -40,6 +42,12 @@ options:
         default: null
         choices: []
         aliases: []
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -95,7 +103,7 @@ options:
                   'least_connection_node_address', 'fastest_node_address',
                   'observed_node_address', 'predictive_node_address',
                   'dynamic_ratio', 'fastest_app_response', 'least_sessions',
-                  'dynamic_ratio_member', 'l3_addr', 'unknown',
+                  'dynamic_ratio_member', 'l3_addr',
                   'weighted_least_connection_member',
                   'weighted_least_connection_node_address',
                   'ratio_session', 'ratio_least_connection_member',
@@ -353,7 +361,7 @@ def main():
                          'fastest_node_address', 'observed_node_address',
                          'predictive_node_address', 'dynamic_ratio',
                          'fastest_app_response', 'least_sessions',
-                         'dynamic_ratio_member', 'l3_addr', 'unknown',
+                         'dynamic_ratio_member', 'l3_addr',
                          'weighted_least_connection_member',
                          'weighted_least_connection_node_address',
                          'ratio_session', 'ratio_least_connection_member',
@@ -392,6 +400,7 @@ def main():
             module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
@@ -449,7 +458,7 @@ def main():
         module.fail_json(msg="quorum requires monitors parameter")
 
     try:
-        api = bigip_api(server, user, password, validate_certs)
+        api = bigip_api(server, user, password, validate_certs, port=server_port)
         result = {'changed': False}  # default
 
         if state == 'absent':

--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -25,7 +25,9 @@ short_description: "Manages F5 BIG-IP LTM pool members"
 description:
     - "Manages F5 BIG-IP LTM pool members via iControl SOAP API"
 version_added: "1.4"
-author: "Matt Hite (@mhite)"
+author:
+    - Matt Hite (@mhite)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -39,6 +41,12 @@ options:
         description:
             - BIG-IP host
         required: true
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -343,6 +351,7 @@ def main():
             module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
@@ -371,7 +380,7 @@ def main():
         module.fail_json(msg="valid ports must be in range 0 - 65535")
 
     try:
-        api = bigip_api(server, user, password, validate_certs)
+        api = bigip_api(server, user, password, validate_certs, port=server_port)
         if not pool_exists(api, pool):
             module.fail_json(msg="pool %s does not exist" % pool)
         result = {'changed': False}  # default

--- a/network/f5/bigip_virtual_server.py
+++ b/network/f5/bigip_virtual_server.py
@@ -25,7 +25,9 @@ short_description: "Manages F5 BIG-IP LTM virtual servers"
 description:
     - "Manages F5 BIG-IP LTM virtual servers via iControl SOAP API"
 version_added: "2.1"
-author: Etienne Carriere (@Etienne-Carriere)
+author:
+    - Etienne Carriere (@Etienne-Carriere)
+    - Tim Rupp (@caphrim007)
 notes:
     - "Requires BIG-IP software version >= 11"
     - "F5 developed module 'bigsuds' required (see http://devcentral.f5.com)"
@@ -37,6 +39,12 @@ options:
         description:
             - BIG-IP host
         required: true
+    server_port:
+        description:
+            - BIG-IP server port
+        required: false
+        default: 443
+        version_added: "2.2"
     user:
         description:
             - BIG-IP username
@@ -151,7 +159,7 @@ EXAMPLES = '''
         name: myvirtualserver
         port: 8080
 
-  - name: Delete pool
+  - name: Delete virtual server
     local_action:
         module: bigip_virtual_server
         server: lb.mydomain.net
@@ -423,6 +431,7 @@ def main():
             module.fail_json(msg='bigsuds does not support verifying certificates with python < 2.7.9.  Either update python or set validate_certs=False on the task')
 
     server = module.params['server']
+    server_port = module.params['server_port']
     user = module.params['user']
     password = module.params['password']
     state = module.params['state']
@@ -443,7 +452,7 @@ def main():
         module.fail_json(msg="valid ports must be in range 1 - 65535")
   
     try:
-        api = bigip_api(server, user, password, validate_certs)
+        api = bigip_api(server, user, password, validate_certs, port=server_port)
         result = {'changed': False}  # default
 
         if state == 'absent':


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

all of the network/f5/ modules
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

This patch adds support for the server_port module. It
additionally updates the documentation in the module for
it.

The changes were tested in the f5-ansible repository to
ensure no breaking changes were made. This argument allows
modules to be used on BIG-IPs that are listening on
non-standard ports.
