### PR TITLE
Bugfix influxdb/retention_policy: infinite retention is returned as 0

### DIFF
--- a/database/influxdb/influxdb_retention_policy.py
+++ b/database/influxdb/influxdb_retention_policy.py
@@ -195,7 +195,7 @@ def alter_retention_policy(module, client, retention_policy):
     elif duration_lookup.group(2) == 'w':
         influxdb_duration_format = '%sh0m0s' % (int(duration_lookup.group(1)) * 24 * 7)
     elif duration == 'INF':
-        influxdb_duration_format = 'INF'
+        influxdb_duration_format = '0'
 
     if not retention_policy['duration'] == influxdb_duration_format or not retention_policy['replicaN'] == int(replication) or not retention_policy['default'] == default:
         if not module.check_mode:

--- a/database/influxdb/influxdb_retention_policy.py
+++ b/database/influxdb/influxdb_retention_policy.py
@@ -125,7 +125,7 @@ def influxdb_argument_spec():
         port=dict(default=8086, type='int'),
         username=dict(default='root', type='str'),
         password=dict(default='root', type='str', no_log=True),
-        database_name=dict(default=None, type='str')
+        database_name=dict(required=True, type='str')
     )
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

influxdb/retention_policy
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

A retention policy with infinite duration is created with duration `INF` but is displayed with duration `0`.
