### PR TITLE
Fix default service_address in consul module

### DIFF
--- a/clustering/consul.py
+++ b/clustering/consul.py
@@ -95,10 +95,12 @@ options:
         required: false
     service_address:
         description:
-          - the address on which the service is serving required for
-            registration of a service
+          - the address to advertise that the service will be listening on.
+            This value will be passed as the I(Address) parameter to Consul's
+            U(/v1/agent/service/register) API method, so refer to the Consul API
+            documentation for further details.
         required: false
-        default: localhost
+        default: None
         version_added: "2.1"
     tags:
         description:
@@ -185,11 +187,11 @@ EXAMPLES = '''
       interval: 60s
       http: /status
 
-  - name: register nginx with address
+  - name: register external service nginx available at 10.1.5.23
     consul:
       service_name: nginx
       service_port: 80
-      service_address: 127.0.0.1
+      service_address: 10.1.5.23
 
   - name: register nginx with some service tags
     consul:
@@ -542,7 +544,7 @@ def main():
             script=dict(required=False),
             service_id=dict(required=False),
             service_name=dict(required=False),
-            service_address=dict(required=False, type='str', default='localhost'),
+            service_address=dict(required=False, type='str', default=None),
             service_port=dict(required=False, type='int'),
             state=dict(default='present', choices=['present', 'absent']),
             interval=dict(required=False, type='str'),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

consul module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel af150ea43a) last updated 2016/06/17 23:58:12 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 002028748f) last updated 2015/12/27 17:03:18 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD f6a7b6dd1f) last updated 2015/12/27 17:03:21 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

See my comment at the end of #1299 for more details -- I believe that #1299 introduced a regression with the service_address parameter's default value of localhost, and this fixes the default value so the module behaves in the way it did prior to #1299 and also a in a way that I believe makes sense.
