### PR TITLE
Added 'answer' as an alias of 'value' on debconf module

### DIFF
--- a/system/debconf.py
+++ b/system/debconf.py
@@ -119,7 +119,7 @@ def main():
            name = dict(required=True, aliases=['pkg'], type='str'),
            question = dict(required=False, aliases=['setting', 'selection'], type='str'),
            vtype = dict(required=False, type='str', choices=['string', 'password', 'boolean', 'select',  'multiselect', 'note', 'error', 'title', 'text', 'seen']),
-           value= dict(required=False, type='str'),
+           value = dict(required=False, type='str', aliases=['answer']),
            unseen = dict(required=False, type='bool'),
         ),
         required_together = ( ['question','vtype', 'value'],),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- debconf
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The [document](http://docs.ansible.com/ansible/debconf_module.html) says `answer` can be used as an alias of `value`, but it actually fails with following message.

```
unsupported parameter for module: answer
```

This PR modify this.
