### PR TITLE
Add the ability to gather the status of pods & containers from Kubernetes objects

### DIFF
--- a/clustering/kubernetes.py
+++ b/clustering/kubernetes.py
@@ -200,6 +200,7 @@ import base64
 KIND_URL = {
     "binding": "/api/v1/namespaces/{namespace}/bindings",
     "endpoints": "/api/v1/namespaces/{namespace}/endpoints",
+    "job": "/apis/batch/v1/namespaces/{namespace}/jobs",
     "limitrange": "/api/v1/namespaces/{namespace}/limitranges",
     "namespace": "/api/v1/namespaces",
     "node": "/api/v1/nodes",


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

kubernetes
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

In order to do more advanced orchestration with the Ansible Kubernetes module, I need to be able to get the status of existing Kubernetes objects.  I'm going to use the outputs to orchestrate the deployment of OpenStack using Ansible managed by Kubernetes.
