### PR TITLE
fix ovirt UnboundLocalError during vm_start

### DIFF
--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -339,7 +339,6 @@ def vm_start(conn, vmname, hostname=None, ip=None, netmask=None, gateway=None,
         ipinfo = params.IP(address=ip, netmask=netmask, gateway=gateway)
         nic = params.GuestNicConfiguration(name='eth0', boot_protocol='STATIC', ip=ipinfo, on_boot=True)
         nics = params.Nics()
-    nics = params.GuestNicsConfiguration(nic_configuration=[nic])
     initialization=params.Initialization(regenerate_ssh_keys=True, host_name=hostname, domain=domain, user_name='root',
                                          root_password=rootpw, nic_configurations=nics, dns_servers=dns,
                                          authorized_ssh_keys=key)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ovirt module
##### ANSIBLE VERSION

ansible 2.1.1.0
##### SUMMARY

I get following exception when trying to start vm with (`state: present`):

```
Traceback (most recent call last):
  File \"/tmp/ansible_0Noa5w/ansible_module_ovirt.py\", line 520, in <module>
    main()
  File \"/tmp/ansible_0Noa5w/ansible_module_ovirt.py\", line 491, in main
    vm_start(c, vmname, hostname, ip, netmask, gateway, domain, dns, rootpw, key)
  File \"/tmp/ansible_0Noa5w/ansible_module_ovirt.py\", line 342, in vm_start
    nics = params.GuestNicsConfiguration(nic_configuration=[nic])
UnboundLocalError: local variable 'nic' referenced before assignment
```

Looking at a code, that variable shouldn't be used at all so I removed extra line.
