### PR TITLE
cloudflare_dns: Improve error handling

### DIFF
--- a/network/cloudflare_dns.py
+++ b/network/cloudflare_dns.py
@@ -349,11 +349,17 @@ class CloudflareAPI(object):
         result = None
         try:
             content = resp.read()
-            result = json.loads(content)
         except AttributeError:
-            error_msg += "; The API response was empty"
-        except json.JSONDecodeError:
-            error_msg += "; Failed to parse API response: {0}".format(content)
+            if info['body']:
+                content = info['body']
+            else:
+                error_msg += "; The API response was empty"
+
+        if content:
+            try:
+                result = json.loads(content)
+            except json.JSONDecodeError:
+                error_msg += "; Failed to parse API response: {0}".format(content)
 
         # received an error status but no data with details on what failed
         if  (info['status'] not in [200,304]) and (result is None):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/cloudflare_dns
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel c117b9d79b) last updated 2016/06/23 18:10:23 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 4fe583e29b) last updated 2016/06/23 18:10:38 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 9dfbe04378) last updated 2016/06/23 18:53:36 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Thanks to ansible/ansible#14915 it is now possible to get the body of a HTTPError response. Add support for the new `info['body']` field returned by `fetch_url`.
