### PR TITLE
Fix error handling error for kube kind error.

### DIFF
--- a/clustering/kubernetes.py
+++ b/clustering/kubernetes.py
@@ -363,7 +363,7 @@ def main():
             try:
                 url = target_endpoint + KIND_URL[kind]
             except KeyError:
-                module.fail_json("invalid resource kind specified in the data: '%s'" % kind)
+                module.fail_json(msg="invalid resource kind specified in the data: '%s'" % kind)
             url = url.replace("{namespace}", namespace)
         else:
             url = target_endpoint


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
  -
##### COMPONENT NAME

clustering/kubernetes.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 60a8af95a5) last updated 2016/06/27 12:22:27 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 3c6f2c2db1) last updated 2016/06/27 12:22:27 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 1c36665545) last updated 2016/06/24 14:33:34 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```
##### SUMMARY

This is a fix for https://github.com/ansible/ansible-modules-extras/issues/2477

If the provided kubernetes resource file references
a 'kind' that is currently unsupported, the error handling
is supposed to return with fail_json(msg="message"), but
the msg keyword was missing causing the fail_json() method
to assert. Fix is to add the msg kwarg.

Fixes #2477
