### PR TITLE
If rc is null, assume that a timeout happened. Fixes #2484

### DIFF
--- a/commands/expect.py
+++ b/commands/expect.py
@@ -214,7 +214,7 @@ def main():
     if out is None:
         out = ''
 
-    module.exit_json(
+    ret = dict(
         cmd=args,
         stdout=out.rstrip('\r\n'),
         rc=rc,
@@ -223,6 +223,12 @@ def main():
         delta=str(delta),
         changed=True,
     )
+
+    if rc:
+        module.exit_json(**ret)
+    else:
+        ret['msg'] = 'command exceeded timeout'
+        module.fail_json(**ret)
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`expect`
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
v2.2
```
##### SUMMARY

It appears as though `run` and `runu` don't raise a timeout exception in pexpect.  This change will assume a timeout occurred if `rc` is `None` and add a msg that the command exceeded the timeout.

Fixes #2484 
