### PR TITLE
openbsd_pkg: Add support for "pkgname%branch" syntax. Fixes #97

### DIFF
--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -114,7 +114,7 @@ def get_package_state(name, pkg_spec, module):
     if stdout:
         # If the requested package name is just a stem, like "python", we may
         # find multiple packages with that name.
-        pkg_spec['installed_names'] = [line.rstrip() for line in stdout.splitlines()]
+        pkg_spec['installed_names'] = [name for name in stdout.splitlines()]
         module.debug("get_package_state(): installed_names = %s" % pkg_spec['installed_names'])
         return True
     else:

--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -229,10 +229,12 @@ def package_latest(name, installed_state, pkg_spec, module):
             module.debug("package_latest(): checking for pre-upgrade package name: %s" % installed_name)
             match = re.search("\W%s->.+: ok\W" % installed_name, stdout)
             if match:
+                module.debug("package_latest(): package name match: %s" % installed_name)
                 if module.check_mode:
                     module.exit_json(changed=True)
 
                 changed = True
+                break
 
         # FIXME: This part is problematic. Based on the issues mentioned (and
         # handled) in package_present() it is not safe to blindly trust stderr

--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -299,7 +299,7 @@ def parse_package_name(name, pkg_spec, module):
     # Stop if someone is giving us a name that both has a version and is
     # version-less at the same time.
     if version_match and versionless_match:
-        module.fail_json(msg="Package name both has a version and is version-less: " + name)
+        module.fail_json(msg="package name both has a version and is version-less: " + name)
 
     # If name includes a version.
     if version_match:
@@ -312,7 +312,7 @@ def parse_package_name(name, pkg_spec, module):
             pkg_spec['flavor']            = match.group('flavor')
             pkg_spec['style']             = 'version'
         else:
-            module.fail_json(msg="Unable to parse package name at version_match: " + name)
+            module.fail_json(msg="unable to parse package name at version_match: " + name)
 
     # If name includes no version but is version-less ("--").
     elif versionless_match:
@@ -325,7 +325,7 @@ def parse_package_name(name, pkg_spec, module):
             pkg_spec['flavor']            = match.group('flavor')
             pkg_spec['style']             = 'versionless'
         else:
-            module.fail_json(msg="Unable to parse package name at versionless_match: " + name)
+            module.fail_json(msg="unable to parse package name at versionless_match: " + name)
 
     # If name includes no version, and is not version-less, it is all a stem.
     else:
@@ -338,7 +338,7 @@ def parse_package_name(name, pkg_spec, module):
             pkg_spec['flavor']            = None
             pkg_spec['style']             = 'stem'
         else:
-            module.fail_json(msg="Unable to parse package name at else: " + name)
+            module.fail_json(msg="unable to parse package name at else: " + name)
 
     # If the stem contains an "%" then it needs special treatment.
     branch_match = re.search("%", pkg_spec['stem'])
@@ -347,9 +347,9 @@ def parse_package_name(name, pkg_spec, module):
         branch_release = "6.0"
 
         if version_match or versionless_match:
-            module.fail_json(msg="Package name using 'branch' syntax also has a version or is version-less: " + name)
+            module.fail_json(msg="package name using 'branch' syntax also has a version or is version-less: " + name)
         if StrictVersion(platform.release()) < StrictVersion(branch_release):
-            module.fail_json(msg="Package name using 'branch' syntax requires at least OpenBSD %s: %s" % (branch_release, name))
+            module.fail_json(msg="package name using 'branch' syntax requires at least OpenBSD %s: %s" % (branch_release, name))
 
         pkg_spec['style'] = 'branch'
 
@@ -358,7 +358,7 @@ def parse_package_name(name, pkg_spec, module):
     if pkg_spec['flavor']:
         match = re.search("-$", pkg_spec['flavor'])
         if match:
-            module.fail_json(msg="Trailing dash in flavor: " + pkg_spec['flavor'])
+            module.fail_json(msg="trailing dash in flavor: " + pkg_spec['flavor'])
 
 # Function used for figuring out the port path.
 def get_package_source_path(name, pkg_spec, module):

--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -491,6 +491,11 @@ def main():
         pkg_spec = {}
         parse_package_name(name, pkg_spec, module)
 
+        # Not sure how the branch syntax is supposed to play together
+        # with build mode. Disable it for now.
+        if pkg_spec['style'] == 'branch' and module.params['build'] is True:
+            module.fail_json(msg="the combination of 'branch' syntax and build=%s is not supported: %s" % (module.params['build'], name))
+
         # Get package state.
         installed_state = get_package_state(name, pkg_spec, module)
 

--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -477,7 +477,7 @@ def main():
         parse_package_name('sqlports', pkg_spec, module)
         installed_state = get_package_state('sqlports', pkg_spec, module)
         if not installed_state:
-            module.debug("main(): installing sqlports")
+            module.debug("main(): installing 'sqlports' because build=%s" % module.params['build'])
             package_present('sqlports', installed_state, pkg_spec, module)
 
     if name == '*':

--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -229,7 +229,7 @@ def package_latest(name, installed_state, pkg_spec, module):
             module.debug("package_latest(): checking for pre-upgrade package name: %s" % installed_name)
             match = re.search("\W%s->.+: ok\W" % installed_name, stdout)
             if match:
-                module.debug("package_latest(): package name match: %s" % installed_name)
+                module.debug("package_latest(): pre-upgrade package name match: %s" % installed_name)
                 if module.check_mode:
                     module.exit_json(changed=True)
 

--- a/packaging/os/openbsd_pkg.py
+++ b/packaging/os/openbsd_pkg.py
@@ -374,7 +374,7 @@ def get_package_source_path(name, pkg_spec, module):
         conn = sqlite3.connect(sqlports_db_file)
         first_part_of_query = 'SELECT fullpkgpath, fullpkgname FROM ports WHERE fullpkgname'
         query = first_part_of_query + ' = ?'
-        module.debug("package_package_source_path(): query: %s" % query)
+        module.debug("package_package_source_path(): exact query: %s" % query)
         cursor = conn.execute(query, (name,))
         results = cursor.fetchall()
 
@@ -384,14 +384,14 @@ def get_package_source_path(name, pkg_spec, module):
             query = first_part_of_query + ' LIKE ?'
             if pkg_spec['flavor']:
                 looking_for += pkg_spec['flavor_separator'] + pkg_spec['flavor']
-                module.debug("package_package_source_path(): flavor query: %s" % query)
+                module.debug("package_package_source_path(): fuzzy flavor query: %s" % query)
                 cursor = conn.execute(query, (looking_for,))
             elif pkg_spec['style'] == 'versionless':
                 query += ' AND fullpkgname NOT LIKE ?'
-                module.debug("package_package_source_path(): versionless query: %s" % query)
+                module.debug("package_package_source_path(): fuzzy versionless query: %s" % query)
                 cursor = conn.execute(query, (looking_for, "%s-%%" % looking_for,))
             else:
-                module.debug("package_package_source_path(): query: %s" % query)
+                module.debug("package_package_source_path(): fuzzy query: %s" % query)
                 cursor = conn.execute(query, (looking_for,))
             results = cursor.fetchall()
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

openbsd_pkg
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7ba71fc2d2) last updated 2016/06/27 18:58:32 (GMT +200)
  lib/ansible/modules/core: (devel 3c6f2c2db1) last updated 2016/06/27 18:59:31 (GMT +200)
  lib/ansible/modules/extras: (openbsd_pkg_branch d55f22a2c6) last updated 2016/06/30 18:56:13 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add support for the new "pkgname%branch" syntax coming to pkg_add in OpenBSD 6.0.

Fixes #97. While not implementing what was initially requested there (use of pkg_add -z) this does provide a way to install packages using less specific names in playbooks while still being able to remove the packages using those same names etc.

This change required me to modify the use if pkg_info as well, which improved the code overall because I could remove some custom parsing etc.

While working on this I did some cosmetic cleanup along the way.
