### PR TITLE
Make elasticsearch_plugin module's existence check case-insensitive.

### DIFF
--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -113,7 +113,7 @@ def parse_plugin_repo(string):
 
 
 def is_plugin_present(plugin_dir, working_dir):
-    return os.path.isdir(os.path.join(working_dir, plugin_dir))
+    return os.path.isdir(os.path.join(working_dir, plugin_dir.lower()))
 
 
 def parse_error(string):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`elasticsearch_plugin`
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The `elasticsearch_plugin` fails to check whether the given plugin is installed if 
- plugin name includes capital letter (e.g.; `royrusso/elasticsearch-HQ`)
- and that plugin is already installed

This PR fixes this.
##### DETAIL

Elasticsearch's plugin manager installs plugins into `${ES_HOME}/plugins/${plugin_name,,}` (i.e.; plugin name is converted to **lower case**).
This modules judges if a given plugin is already installed, based on existance of the plugin directory .

For instance, if you specify `royrusso/elasticsearch-HQ`, the plugin will be installed into `${ES_HOME}/plugins/hq` while the module checks `${ES_HOME}/plugins/HQ`. Thus, you will get following error on the next execution of provision.

```
-> Installing royrusso/elasticsearch-HQ...
Trying https://github.com/royrusso/elasticsearch-HQ/archive/master.zip ...
Downloading ...(snip)...DONE
Verifying https://github.com/royrusso/elasticsearch-HQ/archive/master.zip checksums if available ...
NOTE: Unable to verify checksum for downloaded plugin (unable to find .sha1 or .md5 file to verify)
ERROR: plugin directory /usr/share/elasticsearch/plugins/hq already exists. To update the plugin, uninstall it first using 'remove hq' command
```

**NOTE:** You cannot see the error unless you modify the `parse_error()` as written in #2517.
##### ES version

``` shell
curl -X GET 'http://localhost:9200' | jq '.version'
```

``` json
{
  "lucene_version": "5.5.0",
  "build_snapshot": false,
  "build_timestamp": "2016-05-17T15:40:04Z",
  "build_hash": "218bdf10790eef486ff2c41a3df5cfa32dadcfde",
  "number": "2.3.3"
}
```
