### PR TITLE
Added fallback for parse_error(string) on elasticsearch_plugin module.

### DIFF
--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -118,7 +118,10 @@ def is_plugin_present(plugin_dir, working_dir):
 
 def parse_error(string):
     reason = "reason: "
-    return string[string.index(reason) + len(reason):].strip()
+    try:
+        return string[string.index(reason) + len(reason):].strip()
+    except ValueError:
+        return string
 
 
 def main():


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`elasticsearch_plugin`
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

This module passes **"""parsed"""** error message when failed, but sometimes error message parser itself fails.
This happens when error message does not include substring `"reason: "`.

```
Traceback (most recent call last):
  File \"/tmp/ansible_5KVQVo/ansible_module_elasticsearch_plugin.py\", line 187, in <module>
    main()
  File \"/tmp/ansible_5KVQVo/ansible_module_elasticsearch_plugin.py\", line 180, in main
    reason = parse_error(out)
  File \"/tmp/ansible_5KVQVo/ansible_module_elasticsearch_plugin.py\", line 121, in parse_error
    return string[string.index(reason) + len(reason):].strip()
    ValueError: substring not found
```

This PR fixes this keeping as much behavior as possible as is.
