### PR TITLE
Ensure os_project checks the right domain

### DIFF
--- a/cloud/openstack/os_project.py
+++ b/cloud/openstack/os_project.py
@@ -111,7 +111,7 @@ def _needs_update(module, project):
     keys = ('description', 'enabled')
     for key in keys:
         if module.params[key] is not None and module.params[key] != project.get(key):
-            return True       
+            return True
 
     return False
 
@@ -176,9 +176,13 @@ def main():
                 except:
                     # Ok, let's hope the user is non-admin and passing a sane id
                     pass
-        
+
         cloud = shade.openstack_cloud(**module.params)
-        project = cloud.get_project(name)
+
+        if domain:
+            project = cloud.get_project(name, domain_id=domain)
+        else:
+            project = cloud.get_project(name)
 
         if module.check_mode:
             module.exit_json(changed=_system_state_change(module, project))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

os_project
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

When os_project checks if a project already exists, it uses the default domain.
In case the project should be created in a different domain and a project of the same name
already exists in the default domain, the project doesn't  get created.

CC @agireud
