### PR TITLE
Add timeout feature to ecs_task module

### DIFF
--- a/cloud/amazon/ecs_task.py
+++ b/cloud/amazon/ecs_task.py
@@ -61,6 +61,7 @@ options:
             - A value showing who or what started the task (for informational purposes)
         required: False
     timeout:
+        version_added: 2.2
         description: 
             - The time to wait for the task to complete
             - A value of 0 (default) will not wait for the task to complete


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ecs_task
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Enhances existing `ecs_task` module as follows:
- Adds ability to specify a `timeout` variable, which causes the module to wait and poll the invoked task until task completion
- If a timeout is specified and the task completes with a zero (success) exit code, the module will return success
- If a timeout is specified and the task fails (i.e. ECS task failure), the module will return a failure
- If a timeout is specified and the task completes with a non-zero exit code, the module will return a failure
- The `task_definition` variable can now accept a task definition ARN as input

The default value of `timeout` is 0, which causes the module to complete immediately without waiting for the task to complete.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
# Simple example of run task and wait 300 seconds for task to complete
- name: Run task with timeout
  ecs_task:
      operation: run
      cluster: console-sample-app-static-cluster
      task_definition: console-sample-app-static-taskdef
      timeout: 300
```
