### PR TITLE
Fix svr4pkg being non-idempotent

### DIFF
--- a/packaging/os/svr4pkg.py
+++ b/packaging/os/svr4pkg.py
@@ -193,7 +193,9 @@ def main():
         if src is None:
             module.fail_json(name=name,
                              msg="src is required when state=present")
-        if not package_installed(module, name, category):
+        if package_installed(module, name, category):
+            module.exit_json(changed=False)
+        else:
             if module.check_mode:
                 module.exit_json(changed=True)
             (rc, out, err) = package_install(module, name, src, proxy, response_file, zone, category)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

svr4pkg
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
$ ./bin/ansible --version
ansible 2.2.0 (devel 7d53fd2ef2) last updated 2016/07/06 17:06:23 (GMT +700)
  lib/ansible/modules/core: (detached HEAD 4a0a9cd1fc) last updated 2016/07/06 17:06:52 (GMT +700)
  lib/ansible/modules/extras: (detached HEAD e0b3e2f790) last updated 2016/07/06 17:07:11 (GMT +700)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Right now module 'svr4pkg' is not idempotent: it fails if state=present is requested and the package is already installed. I decided to return SUCCESS and '"changed": false' instead.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before:

```
$ ./bin/ansible -i ~/git/ansible-playbooks/test_inventory -u root testz -m svr4pkg -a "name=CSWcommon state=present src=/var/tmp/common.pkg"
testz | SUCCESS => {
    "changed": true,
    "failed": false,
    "name": "CSWcommon",
    "state": "present",
    "stderr": "\nInstallation of <CSWcommon> was successful.\n"
}
$ ./bin/ansible -i ~/git/ansible-playbooks/test_inventory -u root testz -m svr4pkg -a "name=CSWcommon state=present src=/var/tmp/common.pkg"
testz | FAILED! => {
    "changed": false,
    "failed": true,
    "name": "CSWcommon",
    "state": "present"
}
```

After:

```
$ ./bin/ansible -i ~/git/ansible-playbooks/test_inventory -u root testz -m svr4pkg -a "name=CSWcommon state=present src=/var/tmp/common.pkg"
testz | SUCCESS => {
    "changed": true,
    "failed": false,
    "name": "CSWcommon",
    "state": "present",
    "stderr": "\nInstallation of <CSWcommon> was successful.\n"
}
$ ./bin/ansible -i ~/git/ansible-playbooks/test_inventory -u root testz -m svr4pkg -a "name=CSWcommon state=present src=/var/tmp/common.pkg"
testz | SUCCESS => {
    "changed": false
}
```
