### PR TITLE
Add datadog_monitor param for datadog tags

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -34,7 +34,7 @@ description:
 - "Manages monitors within Datadog"
 - "Options like described on http://docs.datadoghq.com/api/"
 version_added: "2.0"
-author: "Sebastian Kornehl (@skornehl)" 
+author: "Sebastian Kornehl (@skornehl)"
 notes: []
 requirements: [datadog]
 options:
@@ -44,6 +44,10 @@ options:
     app_key:
         description: ["Your DataDog app key."]
         required: true
+    dd_tags:
+        description: ["A list of tags to associate with your monitor when creating or updating. This can help you categorize and filter monitors."]
+        required: false
+        default: None
     state:
         description: ["The designated state of the monitor."]
         required: true
@@ -153,6 +157,7 @@ def main():
             escalation_message=dict(required=False, default=None),
             notify_audit=dict(required=False, default=False, type='bool'),
             thresholds=dict(required=False, type='dict', default=None),
+            dd_tags=dict(required=False, type='list', default=None)
         )
     )
 
@@ -189,9 +194,12 @@ def _get_monitor(module):
 
 def _post_monitor(module, options):
     try:
-        msg = api.Monitor.create(type=module.params['type'], query=module.params['query'],
-                                 name=module.params['name'], message=_fix_template_vars(module.params['message']),
-                                 options=options)
+        kwargs = dict(type=module.params['type'], query=module.params['query'],
+                      name=module.params['name'], message=_fix_template_vars(module.params['message']),
+                      options=options)
+        if module.params['dd_tags'] is not None:
+            kwargs['tags'] = module.params['dd_tags']
+        msg = api.Monitor.create(**kwargs)
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
         else:
@@ -206,9 +214,13 @@ def _equal_dicts(a, b, ignore_keys):
 
 def _update_monitor(module, monitor, options):
     try:
-        msg = api.Monitor.update(id=monitor['id'], query=module.params['query'],
-                                 name=module.params['name'], message=_fix_template_vars(module.params['message']),
-                                 options=options)
+        kwargs = dict(id=monitor['id'], query=module.params['query'],
+                      name=module.params['name'], message=_fix_template_vars(module.params['message']),
+                      options=options)
+        if module.params['dd_tags'] is not None:
+            kwargs['tags'] = module.params['dd_tags']
+        msg = api.Monitor.update(**kwargs)
+
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
         elif _equal_dicts(msg, monitor, ['creator', 'overall_state', 'modified']):

--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -44,14 +44,15 @@ options:
     app_key:
         description: ["Your DataDog app key."]
         required: true
-    dd_tags:
-        description: ["A list of tags to associate with your monitor when creating or updating. This can help you categorize and filter monitors."]
-        required: false
-        default: None
     state:
         description: ["The designated state of the monitor."]
         required: true
         choices: ['present', 'absent', 'muted', 'unmuted']
+    tags:
+        description: ["A list of tags to associate with your monitor when creating or updating. This can help you categorize and filter monitors."]
+        required: false
+        default: None
+        version_added: 2.2
     type:
         description:
             - "The type of the monitor."
@@ -157,7 +158,7 @@ def main():
             escalation_message=dict(required=False, default=None),
             notify_audit=dict(required=False, default=False, type='bool'),
             thresholds=dict(required=False, type='dict', default=None),
-            dd_tags=dict(required=False, type='list', default=None)
+            tags=dict(required=False, type='list', default=None)
         )
     )
 
@@ -197,8 +198,8 @@ def _post_monitor(module, options):
         kwargs = dict(type=module.params['type'], query=module.params['query'],
                       name=module.params['name'], message=_fix_template_vars(module.params['message']),
                       options=options)
-        if module.params['dd_tags'] is not None:
-            kwargs['tags'] = module.params['dd_tags']
+        if module.params['tags'] is not None:
+            kwargs['tags'] = module.params['tags']
         msg = api.Monitor.create(**kwargs)
         if 'errors' in msg:
             module.fail_json(msg=str(msg['errors']))
@@ -217,8 +218,8 @@ def _update_monitor(module, monitor, options):
         kwargs = dict(id=monitor['id'], query=module.params['query'],
                       name=module.params['name'], message=_fix_template_vars(module.params['message']),
                       options=options)
-        if module.params['dd_tags'] is not None:
-            kwargs['tags'] = module.params['dd_tags']
+        if module.params['tags'] is not None:
+            kwargs['tags'] = module.params['tags']
         msg = api.Monitor.update(**kwargs)
 
         if 'errors' in msg:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

datadog_monitor
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 0ada7eae5e) last updated 2016/07/08 18:02:43 (GMT -700)
  lib/ansible/modules/core: (detached HEAD db8af4c5af) last updated 2016/07/08 18:02:48 (GMT -700)
  lib/ansible/modules/extras: (datadog_monitor_tags f35df9e2de) last updated 2016/07/08 18:40:13 (GMT -700)
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The datadog API allows you to tag monitors, and this allows ansible to edit those tags as well as the other monitor attributes.

An example of the new option working:

```
~/src/ansible/hacking/test-module -m ./monitoring/datadog_monitor.py -a "api_key=[redacted]
app_key=[redacted]
message=\"There are passes with tasks! Check {antenna_site.name}


      This is a meta-alert for our multi-antenna rollup.



      #meta_task_alert\"
name=\"[fake] There are passes with tasks on {antenna_site.name}\"
no_data_timeframe=240
notify_audit=false
notify_no_data=false
query=\"events('priority:all tags:environment:prod,pass_with_task').by('antenna_site').rollup('count').last('2h') > 0\"
renotify_interval=0
state=present
tags=\"app:mission_control, apaul-test\"
type=\"event alert\""
* including generated source, if any, saving to: /Users/alexpaul/.ansible_module_generated
* ziploader module detected; extracted module source to: /Users/alexpaul/debug_dir
***********************************
RAW OUTPUT

{"msg": {"multi": true, "name": "[fake] There are passes with tasks on {antenna_site.name}", "created": "2016-07-08T20:37:59.247901+00:00", "deleted": null, "created_at": 1468010279000, "tags": ["app:mission_control", "apaul-test"], "org_id": 18729, "modified": "2016-07-09T01:47:03.595084+00:00", "id": 714719, "overall_state": "No Data", "query": "events('priority:all tags:environment:prod,pass_with_task').by('antenna_site').rollup('count').last('2h') > 0", "message": "There are passes with tasks! Check {antenna_site.name}\n\n\nThis is a meta-alert for our multi-antenna rollup.\n\n\n\n#meta_task_alert", "type": "event alert", "options": {"notify_audit": false, "locked": false, "timeout_h": null, "silenced": {}, "no_data_timeframe": 240, "notify_no_data": false, "renotify_interval": 0, "escalation_message": null}}, "invocation": {"module_args": {"notify_audit": false, "name": "[fake] There are passes with tasks on {antenna_site.name}", "silenced": null, "no_data_timeframe": "240", "app_key": "[redacted]", "notify_no_data": false, "renotify_interval": "0", "state": "present", "escalation_message": null, "tags": ["app:mission_control", " apaul-test"], "query": "events('priority:all tags:environment:prod,pass_with_task').by('antenna_site').rollup('count').last('2h') > 0", "message": "There are passes with tasks! Check {antenna_site.name}\n\n\nThis is a meta-alert for our multi-antenna rollup.\n\n\n\n#meta_task_alert", "api_key": "[redacted]", "type": "event alert", "thresholds": null, "timeout_h": null}}, "changed": true}


***********************************
PARSED OUTPUT
{
    "changed": true,
    "invocation": {
        "module_args": {
            "api_key": "[redacted]",
            "app_key": "[redacted]",
            "tags": [
                "app:mission_control",
                " apaul-test"
            ],
            "escalation_message": null,
            "message": "There are passes with tasks! Check {antenna_site.name}\n\n\nThis is a meta-alert for our multi-antenna rollup.\n\n\n\n#meta_task_alert",
            "name": "[fake] There are passes with tasks on {antenna_site.name}",
            "no_data_timeframe": "240",
            "notify_audit": false,
            "notify_no_data": false,
            "query": "events('priority:all tags:environment:prod,pass_with_task').by('antenna_site').rollup('count').last('2h') > 0",
            "renotify_interval": "0",
            "silenced": null,
            "state": "present",
            "thresholds": null,
            "timeout_h": null,
            "type": "event alert"
        }
    },
    "msg": {
        "created": "2016-07-08T20:37:59.247901+00:00",
        "created_at": 1468010279000,
        "deleted": null,
        "id": 714719,
        "message": "There are passes with tasks! Check {antenna_site.name}\n\n\nThis is a meta-alert for our multi-antenna rollup.\n\n\n\n#meta_task_alert",
        "modified": "2016-07-09T01:47:03.595084+00:00",
        "multi": true,
        "name": "[fake] There are passes with tasks on {antenna_site.name}",
        "options": {
            "escalation_message": null,
            "locked": false,
            "no_data_timeframe": 240,
            "notify_audit": false,
            "notify_no_data": false,
            "renotify_interval": 0,
            "silenced": {},
            "timeout_h": null
        },
        "org_id": 18729,
        "overall_state": "No Data",
        "query": "events('priority:all tags:environment:prod,pass_with_task').by('antenna_site').rollup('count').last('2h') > 0",
        "tags": [
            "app:mission_control",
            "apaul-test"
        ],
        "type": "event alert"
    }
}
```
