### PR TITLE
Update comment for ttl parameter to indicate 2-119 seconds is invalid

### DIFF
--- a/network/cloudflare_dns.py
+++ b/network/cloudflare_dns.py
@@ -87,7 +87,7 @@ options:
     default: 30
   ttl:
     description:
-      - The TTL to give the new record. Min 1 (automatic), max 2147483647
+      - The TTL to give the new record. Must be between 120 and 2,147,483,647 seconds, or 1 for automatic.
     required: false
     default: 1 (automatic)
   type:


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME
- network/cloudflare_dns.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 626e6aee7d) last updated 2016/07/07 14:51:41 (GMT +1300)
  lib/ansible/modules/core: (detached HEAD 37b7708c5d) last updated 2016/07/07 14:51:51 (GMT +1300)
  lib/ansible/modules/extras: (detached HEAD 0f01acd6c4) last updated 2016/07/07 14:51:58 (GMT +1300)
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Update docs to indicate that ttl values of 2-119 seconds are invalid as per error message returned by the cloudflare API.

Playbook example of how to trigger the issue (note ttl of 60, will fail with a  400 error):

```
    - name: Create the foobaz B record
      cloudflare_dns:
# FAIL
        ttl: 60
#        ttl: 160
        zone: "{{ cf_zone }}"
        record: b
        type: A
        value: 127.0.0.1
        account_email: "{{ cf_account_email }}"
        account_api_token: "{{ cf_account_api_token }}"
```

Playbook output when ttl is 60:

```
TASK [Create the foobaz B record] **********************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "API bad request; Status: 400; Method: POST: Call: /zones/$CF_ZONE_ID/dns_records; The API response was empty"}
```

Output with https://github.com/ansible/ansible-modules-extras/pull/2470 merged

```
TASK [Create the foobaz B record] **********************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "API bad request; Status: 400; Method: POST: Call: /zones/3d3d7a35621fe967627a83efe928924a/dns_records; Error details: code: 1004, error: DNS Validation Error; code: 9021, error: Invalid TTL. Must be between 120 and 2,147,483,647 seconds, or 1 for automatic; "}
```

Curl equivalent of the failing API request, note the returned error message.

```
$ curl -s -X POST "https://api.cloudflare.com/client/v4/zones/$CF_ZONE_ID/dns_records" -H "Content-Type:application/json" -H "X-Auth-Key:$CF_ACCOUNT_API_TOKEN" -H "X-Auth-Email:$CF_ACCOUNT_EMAIL" --data '{"type":"A","name":"buzbuz","content":"127.0.0.1","ttl":60}' | jq '.'
{
  "success": false,
  "errors": [
    {
      "code": 1004,
      "message": "DNS Validation Error",
      "error_chain": [
        {
          "code": 9021,
          "message": "Invalid TTL. Must be between 120 and 2,147,483,647 seconds, or 1 for automatic"
        }
      ]
    }
  ],
  "messages": [],
  "result": null
}
```

Note that the Cloudflare API docs do not document this properly either at https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record

This was acknowledged in `#cloudflare` on freenode by `terinjokes`, I believe they are looking at updating their docs as well.
