### PR TITLE
mongodb_user: fix ssl_cert_reqs exception

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -306,7 +306,9 @@ def main():
     user = module.params['name']
     password = module.params['password']
     ssl = module.params['ssl']
-    ssl_cert_reqs = getattr(ssl_lib, module.params['ssl_cert_reqs'])
+    ssl_cert_reqs = None
+    if ssl:
+        ssl_cert_reqs = getattr(ssl_lib, module.params['ssl_cert_reqs'])
     roles = module.params['roles']
     state = module.params['state']
     update_password = module.params['update_password']


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

mongodb_user
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 7ecc75b555)
```
##### SUMMARY

Pass None as ssl_cert_reqs to pymongo, if ssl is False, otherwise an exception will thrown.

If ssl is not enabled, but ssl_cert_reqs is passed to pymongo, an
exception occures.

Fixes: #2571
