### PR TITLE
Fix #16708 - Ansible module win_unzip to support windows server core.

### DIFF
--- a/windows/win_unzip.ps1
+++ b/windows/win_unzip.ps1
@@ -60,9 +60,6 @@ If ($ext -eq ".zip" -And $recurse -eq $false) {
     If (-Not (Get-WindowsFeature -Name 'Server-Gui-Shell')) {
         # unzip for windows server core.
         Try {
-            If ($(Get-WindowsFeature -Name Net-Framework-45-Core).installed -eq $False) {
-                Install-WindowsFeature Net-Framework-45-Core
-            }
             #Load the assembly
             [System.Reflection.Assembly]::LoadWithPartialName("System.IO.Compression.FileSystem") | Out-Null
             #Unzip the file


### PR DESCRIPTION
**ISSUE TYPE**
- Bugfix Pull Request
  
  **COMPONENT NAME**
  win_unzip.ps1

**SUMMARY**
Fixes #2576 

Fix for Ansible module win_unzip donot work on windows server core. #16708.
Get-WindowsFeature -Name 'Server-Gui-Shell' is False for all server core, so we unzip using dotnet feature of windows on server core.
