### PR TITLE
Allow value to be bool where 'yes'/'no' are in choices

### DIFF
--- a/cloud/amazon/ecs_service_facts.py
+++ b/cloud/amazon/ecs_service_facts.py
@@ -55,7 +55,7 @@ EXAMPLES = '''
 - ecs_service_facts:
     cluster: test-cluster
     service: console-test-service
-    details: "true"
+    details: true
 
 # Basic listing example
 - ecs_service_facts:
@@ -201,7 +201,7 @@ def main():
 
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        details=dict(required=False, choices=['true', 'false'] ),
+        details=dict(required=False, type='bool', default=False ),
         cluster=dict(required=False, type='str' ),
         service=dict(required=False, type='str' )
     ))
@@ -214,9 +214,7 @@ def main():
     if not HAS_BOTO3:
       module.fail_json(msg='boto3 is required.')
 
-    show_details = False
-    if 'details' in module.params and module.params['details'] == 'true':
-        show_details = True
+    show_details = module.params.get('details', False)
 
     task_mgr = EcsServiceManager(module)
     if show_details:

--- a/cloud/misc/virt_net.py
+++ b/cloud/misc/virt_net.py
@@ -534,16 +534,16 @@ def core(module):
         else:
             module.fail_json(msg="Command %s not recognized" % basecmd)
 
-    if autostart:
+    if autostart is not None:
         if not name:
             module.fail_json(msg = "state change requires a specified name")
 
         res['changed'] = False
-        if autostart == 'yes':
+        if autostart:
             if not v.get_autostart(name):
                 res['changed'] = True
                 res['msg'] = v.set_autostart(name, True)
-        elif autostart == 'no':
+        else:
             if v.get_autostart(name):
                 res['changed'] = True
                 res['msg'] = v.set_autostart(name, False)
@@ -562,7 +562,7 @@ def main():
             command = dict(choices=ALL_COMMANDS),
             uri = dict(default='qemu:///system'),
             xml = dict(),
-            autostart = dict(choices=['yes', 'no'])
+            autostart = dict(type='bool')
         ),
         supports_check_mode = True
     )

--- a/cloud/misc/virt_pool.py
+++ b/cloud/misc/virt_pool.py
@@ -629,16 +629,16 @@ def core(module):
         else:
             module.fail_json(msg="Command %s not recognized" % basecmd)
 
-    if autostart:
+    if autostart is not None:
         if not name:
             module.fail_json(msg = "state change requires a specified name")
 
         res['changed'] = False
-        if autostart == 'yes':
+        if autostart:
             if not v.get_autostart(name):
                 res['changed'] = True
                 res['msg'] = v.set_autostart(name, True)
-        elif autostart == 'no':
+        else:
             if v.get_autostart(name):
                 res['changed'] = True
                 res['msg'] = v.set_autostart(name, False)
@@ -657,7 +657,7 @@ def main():
             command = dict(choices=ALL_COMMANDS),
             uri = dict(default='qemu:///system'),
             xml = dict(),
-            autostart = dict(choices=['yes', 'no']),
+            autostart = dict(type='bool'),
             mode = dict(choices=ALL_MODES),
         ),
         supports_check_mode = True

--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -514,6 +514,12 @@ class Nmcli(object):
         return setting_list
         # print ""
 
+    def bool_to_string(self, boolean):
+        if boolean:
+            return "yes"
+        else:
+            return "no"
+
     def list_connection_info(self):
         # Ask the settings service for the list of connections it provides
         bus=dbus.SystemBus()
@@ -602,7 +608,7 @@ class Nmcli(object):
             cmd.append(self.gw6)
         if self.autoconnect is not None:
             cmd.append('autoconnect')
-            cmd.append(self.autoconnect)
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def modify_connection_team(self):
@@ -631,7 +637,7 @@ class Nmcli(object):
             cmd.append(self.dns6)
         if self.autoconnect is not None:
             cmd.append('autoconnect')
-            cmd.append(self.autoconnect)
+            cmd.append(self.bool_to_string(self.autoconnect))
             # Can't use MTU with team
         return cmd
 
@@ -704,7 +710,7 @@ class Nmcli(object):
             cmd.append(self.gw6)
         if self.autoconnect is not None:
             cmd.append('autoconnect')
-            cmd.append(self.autoconnect)
+            cmd.append(self.bool_to_string(self.autoconnect))
         if self.mode is not None:
             cmd.append('mode')
             cmd.append(self.mode)
@@ -751,7 +757,7 @@ class Nmcli(object):
             cmd.append(self.dns6)
         if self.autoconnect is not None:
             cmd.append('autoconnect')
-            cmd.append(self.autoconnect)
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def create_connection_bond_slave(self):
@@ -820,7 +826,7 @@ class Nmcli(object):
             cmd.append(self.gw6)
         if self.autoconnect is not None:
             cmd.append('autoconnect')
-            cmd.append(self.autoconnect)
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def modify_connection_ethernet(self):
@@ -855,7 +861,7 @@ class Nmcli(object):
             cmd.append(self.mtu)
         if self.autoconnect is not None:
             cmd.append('autoconnect')
-            cmd.append(self.autoconnect)
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def create_connection_bridge(self):
@@ -964,7 +970,7 @@ def main():
     # Parsing argument file
     module=AnsibleModule(
         argument_spec=dict(
-            autoconnect=dict(required=False, default=None, choices=['yes', 'no'], type='str'),
+            autoconnect=dict(required=False, default=None, type='bool'),
             state=dict(required=True, choices=['present', 'absent'], type='str'),
             conn_name=dict(required=True, type='str'),
             master=dict(required=False, default=None, type='str'),
@@ -987,7 +993,7 @@ def main():
             mtu=dict(required=False, default=None, type='str'),
             mac=dict(required=False, default=None, type='str'),
             # bridge specific vars
-            stp=dict(required=False, default='yes', choices=['yes', 'no'], type='str'),
+            stp=dict(required=False, default=True, type='bool'),
             priority=dict(required=False, default="128", type='str'),
             slavepriority=dict(required=False, default="32", type='str'),
             forwarddelay=dict(required=False, default="15", type='str'),

--- a/system/debconf.py
+++ b/system/debconf.py
@@ -108,6 +108,11 @@ def set_selection(module, pkg, question, vtype, value, unseen):
     if unseen:
         cmd.append('-u')
 
+    if vtype == 'boolean':
+        if value == 'True':
+            value = 'true'
+        elif value == 'False':
+            value = 'false'
     data = ' '.join([pkg, question, vtype, value])
 
     return module.run_command(cmd, data=data)


### PR DESCRIPTION
**NOTE** This pull request work on same issue as [#4220 on ansible-modules-core](https://github.com/ansible/ansible-modules-core/pull/4220). Therefore, below comment is almost copy-and-paste.
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAMES
- `ecs_service_facts`
- `virt_net`
- `virt_pool`
- `portage`
- `nmcli`
- `debconf`
##### ANSIBLE VERSION

```
ansible 2.1.0.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Many arguments from many modules has limited choices including `'yes'` and/or `'no'` as a option. However, in some case, these are treated as string type; boolean values cause error.

This pull request fix this problem, in the following two way:
##### 1. Change type to bool

If choices are only `'yes'` and `'no'`, this argument can be easily modified to bool type. Even parameter is passed as string, it will be [converted to boolean](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L1439-L1446), so it is 100% backward compatible.

**Modules:**
- `ecs_service_facts`
- `virt_net`
- `virt_pool`
- `nmcli`

**Example:** `ecs_service_facts` module's case

``` yaml

---
# This still works,
- name: Basic listing example
  ecs_service_facts: details=true # snip...

---
# and this still works too,
- name: Basic listing example
  ecs_service_facts:
    details: "true"
    # snip...

---
# AND! this will work now.
- name: Basic listing example
  ecs_service_facts:
    details: true
    # snip...
```
##### 2. Add options to catch boolean

_UPDATED_ Thanks to ansible/ansible#16961, this case doesn't need to be considered any more.

~~If choices contains other values than `'yes'` or `'no'`, this argument should be kept to be treated as string. In this case, if you pass boolean argument here, it will be [converted to `'True'` or `'False'` respectively](https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L1376-L1381). Therefore, adding them to the choices will solve the problem.~~

~~**Modules:**~~
- ~~`portage`~~

~~**Example**: `portage` module's case~~

~~The choices of `sync` argument of `portage` modules contain `"web"`, so it cannot be treated as boolean.~~

``` yaml

---
# This still works,
- name: sync repositories
  portage: sync=yes

---
# and this still works too,
- name: sync repositories
  portage:
    sync: "yes"

---
# AND! this will work now.
- name: sync repositories
  portage:
    sync: yes

---
# Of course, this
- name: sync repositories via web
  portage: sync=web

---
# or this still works.
- name: sync repositories via web
  portage:
    sync: web
```

**Another example**: `debconf` module's case
The `value` argument of `debconf` modules does not have any explicit choices in the modules source code, but actually its choices are limited when `vtype` is `'boolean'`. So I added conversion process here.
