### PR TITLE
return a proper result set for getmaster/getslave

### DIFF
--- a/database/mysql/mysql_replication.py
+++ b/database/mysql/mysql_replication.py
@@ -260,13 +260,17 @@ def main():
     if mode in "getmaster":
         status = get_master_status(cursor)
         if not isinstance(status, dict):
-            status = dict(master=False, msg="Server is not configured as mysql master")
+            status = dict(Is_Master=False, msg="Server is not configured as mysql master")
+        else:
+            status['Is_Master'] = True
         module.exit_json(**status)
 
     elif mode in "getslave":
         status = get_slave_status(cursor)
         if not isinstance(status, dict):
-            status = dict(slave=False, msg="Server is not configured as mysql slave")
+            status = dict(Is_Slave=False, msg="Server is not configured as mysql slave")
+        else:
+            status['Is_Slave'] = True
         module.exit_json(**status)
 
     elif mode in "changemaster":

--- a/database/mysql/mysql_replication.py
+++ b/database/mysql/mysql_replication.py
@@ -258,18 +258,16 @@ def main():
             module.fail_json(msg="unable to find %s. Exception message: %s" % (config_file, e))
 
     if mode in "getmaster":
-        masterstatus = get_master_status(cursor)
-        try:
-            module.exit_json( **masterstatus )
-        except TypeError:
-            module.fail_json(msg="Server is not configured as mysql master")
+        status = get_master_status(cursor)
+        if not isinstance(status, dict):
+            status = dict(master=False, msg="Server is not configured as mysql master")
+        module.exit_json(**status)
 
     elif mode in "getslave":
-        slavestatus = get_slave_status(cursor)
-        try:
-            module.exit_json( **slavestatus )
-        except TypeError, e:
-            module.fail_json(msg="Server is not configured as mysql slave. ERROR: %s" % e)
+        status = get_slave_status(cursor)
+        if not isinstance(status, dict):
+            status = dict(slave=False, msg="Server is not configured as mysql slave")
+        module.exit_json(**status)
 
     elif mode in "changemaster":
         chm=[]


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

database/mysql/mysql_replication.py
##### ANSIBLE VERSION

2.1.0.0
##### SUMMARY

When doing a getslave on a master or getmaster on a slave, the module fails, and doesn't return a clean error message.

```
tns1270 | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "Server is not configured as mysql slave. ERROR: exit_json() argument after ** must be a mapping, not NoneType"
}
```

This patch makes the module return a proper result set, which can more cleanly be handled in a playbook.

```
tns1270 | SUCCESS => {
    "changed": false, 
    "msg": "Server is not configured as mysql slave", 
    "slave": false
}
```
