### PR TITLE
By default shutdown_sessions is always true but it should'nt

### DIFF
--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -330,7 +330,7 @@ def main():
             backend=dict(required=False, default=None),
             weight=dict(required=False, default=None),
             socket = dict(required=False, default=DEFAULT_SOCKET_LOCATION),
-            shutdown_sessions=dict(required=False, default=False),
+            shutdown_sessions=dict(required=False, default=False, type='bool'),
             fail_on_not_found=dict(required=False, default=False, type='bool'),
             wait=dict(required=False, default=False, type='bool'),
             wait_retries=dict(required=False, default=WAIT_RETRIES, type='int'),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/haproxy.py
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

By default shutdown_sessions is always true but it should'nt.
I just fix the type to bool for the argument shutdown_sessions.
