### PR TITLE
Monit fix

### DIFF
--- a/monitoring/monit.py
+++ b/monitoring/monit.py
@@ -73,7 +73,11 @@ def main():
 
     def get_status():
         """Return the status of the process in monit, or the empty string if not present."""
-        rc, out, err = module.run_command('%s summary' % MONIT, check_rc=True)
+        rc, out, err = module.run_command('%s summary' % MONIT)
+        if err:  # There is a race condition with newer versions of monit that causes a conn refused. Lets allow 1 retry
+            time.sleep(1) # one second should be enough time for monit to startup
+            rc, out, err = module.run_command('%s summary' % MONIT, check_rc=True)
+
         for line in out.split('\n'):
             # Sample output lines:
             # Process 'name'    Running


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

extras/monit
##### ANSIBLE VERSION

1) Scoping error causing name collision with function `status`:
The function names status and the local variable status in line 97 collide causing the following error:

```
TASK [nginx : NGinx Monit Config Load] *****************************************
fatal: [local]: FAILED! => {"changed": false, "failed": true, "module_stderr": "", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_3HEkD9/ansible_module_monit.py\", line 185, in <module>\r\n    main()\r\n  File \"/tmp/ansible_3HEkD9/ansible_module_monit.py\", line 130, in main\r\n    wait_for_monit_to_stop_pending()\r\n  File \"/tmp/ansible_3HEkD9/ansible_module_monit.py\", line 97, in wait_for_monit_to_stop_pending\r\n    running_status = status()\r\nTypeError: 'str' object is not callable\r\n", "msg": "MODULE FAILURE", "parsed": false}
```

2) A race condition is create on reload with newer monit versions (observed with monit version 5.17 on ubuntu 14.04). Addressed by adding a retry once to to the `get_status` function.

```
TASK [nginx : NGinx Monit Config Load] *****************************************
fatal: [local]: FAILED! => {"changed": false, "cmd": "/usr/bin/monit summary", "failed": true, "msg": "Cannot create socket to [localhost]:2819 -- Connection refused", "rc": 1, "stderr": "Cannot create socket to [localhost]:2819 -- Connection refused\n", "stdout": "", "stdout_lines": []}
```
