### PR TITLE
mongodb_user: properly guard user adding with try...except

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -320,16 +320,16 @@ def main():
         if password is None and update_password == 'always':
             module.fail_json(msg='password parameter required when adding a user unless update_password is set to on_create')
 
-        uinfo = user_find(client, user, db_name)
-        if update_password != 'always' and uinfo:
-            password = None
-            if not check_if_roles_changed(uinfo, roles, db_name):
-                module.exit_json(changed=False, user=user)
-
-        if module.check_mode:
-            module.exit_json(changed=True, user=user)
-
         try:
+            uinfo = user_find(client, user, db_name)
+            if update_password != 'always' and uinfo:
+                password = None
+                if not check_if_roles_changed(uinfo, roles, db_name):
+                    module.exit_json(changed=False, user=user)
+
+            if module.check_mode:
+                module.exit_json(changed=True, user=user)
+
             user_add(module, client, db_name, user, password, roles)
         except OperationFailure, e:
             module.fail_json(msg='Unable to add or update user: %s' % str(e))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

mongodb_user
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0 (stable-2.1 ed959d72f1)
```
##### SUMMARY

When mongodb_user was fixed to not being "changed" in all user adding/editing cases, the new
code was missed the exception handling, so pymongo exceptions can escape from the module.
This is a backport of the fix from -devel.

Fixes: #2575 
