### PR TITLE
Add win_msg module

### DIFF
--- a/windows/win_msg.ps1
+++ b/windows/win_msg.ps1
@@ -1,0 +1,52 @@
+#!powershell
+# This file is part of Ansible
+#
+# Copyright 2015, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args
+$result = New-Object PSObject
+Set-Attr $result "changed" $False
+$to = Get-Attr -obj $params -name to -default "*" -failifempty $False -resultobj $result
+$display_seconds = Get-Attr -obj $params -name display_seconds -default "10" -failifempty $False -resultobj $result
+$wait = Get-Attr -obj $params -name wait -default $False -failifempty $False -resultobj $result
+$msg = Get-Attr -obj $params -name msg -failifempty $True -resultobj $result
+
+$msg_args = @($to, "/TIME:$display_seconds")
+
+If ($wait) 
+{
+  $msg_args += "/W"
+}
+
+$msg_args += $msg
+$ret = & msg.exe $msg_args 2>&1
+If ($LASTEXITCODE -eq 0) 
+{
+    $sent_at = Get-Date| Out-String
+    Set-Attr $result "changed" $True
+    Set-Attr $result "msg_time" $sent_at
+    Set-Attr $result "msg" $msg
+} 
+Else 
+{
+    Set-Attr $result "rc" $LASTEXITCODE
+    Fail-Json $result "$ret"
+}
+  
+Exit-Json $result

--- a/windows/win_msg.py
+++ b/windows/win_msg.py
@@ -1,0 +1,78 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Jon Hawkesworth (@jhawkesworth) <figs@unity.demon.co.uk>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_msg
+version_added: "2.2"
+short_description: Sends a message to logged in users on Windows hosts.
+description:
+    - Wraps the msg.exe command in order to send messages to Windows hosts.
+options:
+  to:
+    description:
+      - Who to send the message to. can be a username, sessionname or sessionid
+    required: false
+    default: * (which means all logged in users on the windows target)
+  display_seconds:
+    description:
+      - How long to wait for receiver to acknowledge message
+    required: false
+    default: 10
+  wait:
+    description:
+      - Whether to wait for a user to respond.  Module will only wait for the number of seconds specified in display_seconds.
+    required: false
+    default: false
+  msg:
+    description:
+      - The message to send
+    required: true
+    default: no default
+author: "Jon Hawkesworth (@jhawkesworth)"
+notes: 
+   - This module must run on a windows host, so ensure your play targets windows
+     hosts, or delegates to a windows host.
+     Messages are only sent to the local host where the module is run.
+     The module does not support sending to users listed in a file
+'''
+
+EXAMPLES = '''
+  # Warn logged in users of impending upgrade
+  win_msg:
+    display_seconds: 60
+    msg: "Automated upgrade about to start.  Please save your work and log off before {{ deployment_start_time  }}"
+'''
+
+RETURN = '''
+msg_time:
+    description: local time from windows host when the message was sent.
+    returned: success
+    type: string
+    sample: 22 July 2016 17:45:51
+msg:
+    description: message text
+    returned: changed
+    type: string
+    sample: : "Automated upgrade about to start.  Please save your work and log off before 22 July 2016 18:00:00"
+'''


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_msg
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel a8aea3c6d4) last updated 2016/07/26 18:26:4 (GMT +100)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Adds a simple module that wraps the msg.exe program which you can use to send pop up dialog boxes to logged in windows users.
Useful for warning of impending upgrades, downtime etc, and essential for annoying your co-workers.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
ansible win-10 -m win_msg -a 'msg="Upgrade will start in 10 seconds or earlier if you press Ok" wait=True'

win-10 | SUCCESS => {
    "changed": true,
    "msg": "Upgrade will start in 10 seconds or earlier if you press Ok"
    "msg_time": "\r\n26 July 2016 18:25:35\r\n\r\n"
}
```
