### PR TITLE
Add a 'requirements:' field to homebrew doc

### DIFF
--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -27,6 +27,8 @@ author:
     - "Indrajit Raychaudhuri (@indrajitr)"
     - "Daniel Jaouen (@danieljaouen)"
     - "Andrew Dunham (@andrew-d)"
+requirements:
+   - "python >= 2.6"
 short_description: Package manager for Homebrew
 description:
     - Manages Homebrew packages

--- a/packaging/os/homebrew_cask.py
+++ b/packaging/os/homebrew_cask.py
@@ -24,6 +24,8 @@ author:
     - "Indrajit Raychaudhuri (@indrajitr)"
     - "Daniel Jaouen (@danieljaouen)"
     - "Enric Lluelles (@enriclluelles)"
+requirements:
+   - "python >= 2.6"
 short_description: Install/uninstall homebrew casks.
 description:
     - Manages Homebrew casks.


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

packaging/os/homebrew.py
package/os/homebrew_cask.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 409d95d67e) last updated 2016/07/28 12:58:29 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/27 15:10:26 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/27 15:10:26 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides


```
##### SUMMARY

The homebrew and homebrew_cask modules need python 2.6, but there was no documented
'requirements' field for that. So add one.

homebrew.py and homebrew_cask.py make use of python
2.5 and 2.6 features like string .format() method.
