### PR TITLE
Use py2.4 compat string formatting in github_key

### DIFF
--- a/source_control/github_key.py
+++ b/source_control/github_key.py
@@ -99,7 +99,7 @@ class GitHubSession(object):
 
     def request(self, method, url, data=None):
         headers = {
-            'Authorization': 'token {}'.format(self.token),
+            'Authorization': 'token %s' % self.token,
             'Content-Type': 'application/json',
             'Accept': 'application/vnd.github.v3+json',
         }
@@ -147,7 +147,7 @@ def delete_keys(session, to_delete, check_mode):
         return
 
     for key in to_delete:
-        session.request('DELETE', API_BASE + '/user/keys/{[id]}'.format(key))
+        session.request('DELETE', API_BASE + '/user/keys/%s' % key[id])
 
 
 def ensure_key_absent(session, name, check_mode):


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

source_control/github_key.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 409d95d67e) last updated 2016/07/28 12:58:29 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 24db4de245) last updated 2016/07/27 15:10:26 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD db979dde74) last updated 2016/07/27 15:10:26 (GMT -400)
  config file = /home/adrian/.ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Replace the use of python 2.6+ string .format() method
use with the python 2.4 compatible '%s' formatting to
make the github_key module py2.4 compatible.
