### PR TITLE
Remove the subsystem lock loop

### DIFF
--- a/cloud/lxc/lxc_container.py
+++ b/cloud/lxc/lxc_container.py
@@ -682,45 +682,23 @@ class LxcContainerManagement(object):
         else:
             return return_dict
 
-    def _run_command(self, build_command, unsafe_shell=False, timeout=600):
+    def _run_command(self, build_command, unsafe_shell=False):
         """Return information from running an Ansible Command.
 
         This will squash the build command list into a string and then
         execute the command via Ansible. The output is returned to the method.
         This output is returned as `return_code`, `stdout`, `stderr`.
 
-        Prior to running the command the method will look to see if the LXC
-        lockfile is present. If the lockfile "/var/lock/subsys/lxc" the method
-        will wait upto 10 minutes for it to be gone; polling every 5 seconds.
-
         :param build_command: Used for the command and all options.
         :type build_command: ``list``
         :param unsafe_shell: Enable or Disable unsafe sell commands.
         :type unsafe_shell: ``bol``
-        :param timeout: Time before the container create process quites.
-        :type timeout: ``int``
         """
 
-        lockfile = '/var/lock/subsys/lxc'
-
-        for _ in xrange(timeout):
-            if os.path.exists(lockfile):
-                time.sleep(1)
-            else:
-                return self.module.run_command(
-                    ' '.join(build_command),
-                    use_unsafe_shell=unsafe_shell
-                )
-        else:
-            message = (
-                'The LXC subsystem is locked and after 5 minutes it never'
-                ' became unlocked. Lockfile [ %s ]' % lockfile
-            )
-            self.failure(
-                error='LXC subsystem locked',
-                rc=0,
-                msg=message
-            )
+        return self.module.run_command(
+            ' '.join(build_command),
+            use_unsafe_shell=unsafe_shell
+        )
 
     def _config(self):
         """Configure an LXC container.


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

lxc_container
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This change removes the loop watching for "/var/lock/subsys/lxc" from
the lxc-container module. This change simply runs the command within
a container using the lxc CLI tools which should be responcible for
locking and unlocking on their own.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Fixes: https://github.com/ansible/ansible-modules-extras/issues/690

Signed-off-by: Kevin Carter kevin.carter@rackspace.com
