### PR TITLE
win_firewall_rule: fix "property X doesn't exist"

### DIFF
--- a/windows/win_firewall_rule.ps1
+++ b/windows/win_firewall_rule.ps1
@@ -24,7 +24,7 @@ function getFirewallRule ($fwsettings) {
     try {
 
         #$output = Get-NetFirewallRule -name $($fwsettings.'Rule Name');
-        $rawoutput=@(netsh advfirewall firewall show rule name="$($fwsettings.'Rule Name')")
+        $rawoutput=@(netsh advfirewall firewall show rule name="$($fwsettings.'Rule Name')" verbose)
         if (!($rawoutput -eq 'No rules match the specified criteria.')){
             $rawoutput | Where {$_ -match '^([^:]+):\s*(\S.*)$'} | Foreach -Begin {
                     $FirstRun = $true;


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

win_firewall_rule
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /home/asc/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

After commit 9392943 more properties are always set with their defaults
values (e.g. service to 'any'). This causes no issue when the rule is created,
but causes an error message that says "The property 'X' cannot be found on this
object. Verify that the property exists." because the module checks for
any property value that has changed, but `netsh advfirewall firewall show rule`
does not list properties like service or program unless `verbose` is set. This patch solves this.

Fixes #2624
