### PR TITLE
Added consul module for windows

### DIFF
--- a/windows/win_consul.ps1
+++ b/windows/win_consul.ps1
@@ -1,0 +1,667 @@
+#!powershell
+
+# Copyright 2016, Stuart Cullinan <stuart.cullinan@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+$module = New-Object psobject -Property @{
+    service_name = Get-Attr -obj $params -name service_name -default $null
+    service_id = Get-Attr -obj $params -name service_id -default (Get-Attr -obj $params -name service_name)
+    host = Get-Attr -obj $params -name host -default "localhost"
+    port = Get-Attr -obj $params -name port -default "8500"
+    scheme = Get-Attr -obj $params -name scheme -default "http"
+    validate_certs = Get-Attr -obj $params -name validate_certs -default "true" | ConvertTo-Bool
+    notes = Get-Attr -obj $params -name notes -default $null
+    service_port = Get-Attr -obj $params -name service_port -default $null
+    service_address = Get-Attr -obj $params -name service_address -default $null
+    tags = Get-Attr -obj $params -name tags -default $null
+    script = Get-Attr -obj $params -name script -default $null
+    interval = Get-Attr -obj $params -name interval -default $null
+    check_id = Get-Attr -obj $params -name check_id -default $null
+    check_name = Get-Attr -obj $params -name check_name -default $null
+    ttl = Get-Attr -obj $params -name ttl -default $null
+    http = Get-Attr -obj $params -name http -default $null
+    tcp = Get-Attr -obj $params -name tcp -default $null
+    timeout = Get-Attr -obj $params -name timeout -default $null
+    token = Get-Attr -obj $params -name token -default $null
+    status = Get-Attr -obj $params -name status -default $null -ValidateSet "critical","passing"
+    state = Get-Attr -obj $params -name state -default "present" -ValidateSet "present","absent"
+}
+
+add-type @"
+    using System.Net;
+    using System.Security.Cryptography.X509Certificates;
+    public class TrustAllCertsPolicy : ICertificatePolicy {
+        public bool CheckValidationResult(
+            ServicePoint srvPoint, X509Certificate certificate,
+            WebRequest request, int certificateProblem) {
+            return true;
+        }
+    }
+"@
+
+function Add
+{
+    $check = Parse-Check $module
+    $service = Parse-Service $module
+
+    if(($null -eq $service) -and ($null -eq $check)){
+        Fail-Json $result "a name and port are required to register a service"
+    }
+    if($null -ne $service){
+        if($null -ne $check){
+            $service.add_check($check)
+        }    
+        Add-Service $module $service
+    }
+    elseif ($null -ne $check){
+        Add-Check $module $check
+    }
+}
+
+function Remove
+{    
+    $service_id = ($module.service_id, $module.service_name -ne $null)[0]
+    $check_id = ($module.check_id, $module.check_name -ne $null)[0]
+
+    if(($null -eq $service_id) -and ($null -eq $check_id)){
+        Fail-Json $result "services and checks are removed by id or name. please supply a service id/name or a check id/name"
+    } 
+
+    if($null -ne $service_id){
+        Remove-Service -module $module -service_id $service_id
+        Remove-Check -module $module -check_id $service_id
+    }
+
+    if($null -ne $check_id){
+        Remove-Check -module $module -check_id $check_id
+    }   
+}
+
+function Add-Service()
+{
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module,
+        [Parameter(Mandatory=$true,Position=1)]
+        [object]$service
+    )
+    $res = $service
+    $result.changed = $false  
+    
+    $consul_api = Get-ConsulApi $module
+
+    $existing = Get-ServiceById $module $service.id
+
+    if($service.has_checks() -or ($null -eq $existing) -or (-not $service.Equals($existing))){
+        $consul_api.agent.check.de_register("service:"+$service.id) 
+        $service.register($consul_api)        
+        $result.changed = $true
+        $res = Get-ServiceById -module $module -id $service.id             
+        if($service.has_checks()){
+            $res.checks = $service.checks 
+        }        
+    }
+
+    Exit-Json @{
+        changed=$result.changed
+        service_id=$res.id
+        service_name=$res.name
+        service_port=$res.port
+        checks=$res.checks | %{ return $_.check }
+        tags=$res.tags
+    }
+}
+
+function Remove-Service()
+{
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$service_id
+    )          
+    
+    $consul_api = Get-ConsulApi $module
+    $consul_api.agent.service.de_register($service_id)
+    $result.changed = $true
+
+    Exit-Json @{
+        changed=$result.changed
+        id=$service_id
+    }
+}
+
+function Add-Check()
+{    
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module,
+        [Parameter(Mandatory=$true,Position=1)]
+        [object]$check
+    )   
+
+    if($null -eq $check.name){
+        Fail-Json $result "a check name is required for a node level check, one not attached to a service"
+    }
+
+    $consul_api = Get-ConsulApi $module
+    $check.register($consul_api)
+    $result.changed = $true
+
+    Exit-Json @{
+        changed=$result.changed
+        check_id=$check.id
+        check_name=$check.name
+        script=$check.script
+        interval=$check.interval
+        ttl=$check.ttl
+        tcp=$check.tcp
+        http=$check.http
+        timeout=$check.timeout
+    }
+}
+
+function Remove-Check()
+{
+   param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$check_id
+    )   
+    $consul_api = Get-ConsulApi $module    
+    
+    $consul_api.agent.check.de_register($check_id) 
+    $result.changed = $true
+
+    Exit-Json @{
+        changed=$result.changed
+        id=$check_id
+    }
+}
+
+function Get-ServiceById()
+{
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module,
+        [Parameter(Mandatory=$true,Position=1)]
+        [string]$id
+    )
+    $api = Get-ConsulApi $module
+    
+    $services = $api.agent.services()
+    $existing = $services.psobject.properties `
+      | where { $_.Name -eq $id } `
+      | %{ return $services.psobject.members[$_.Name].Value }
+      
+    if($null -ne $existing){
+      return New-ConsulService -loaded $existing
+    }
+
+    return $null
+}
+
+function Parse-Check()
+{ 
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module
+    )
+
+    if(($module.script, $module.ttl, $module.http, $module.tcp -ne $null).Length -gt 1){
+        Fail-Json $result "checks are either script, http, tcp or ttl driven, supplying more than one does not make sense"
+    }
+
+    if(($null -eq $module.check_id) -and `
+        ($null -eq $module.script) -and `
+        ($null -eq $module.ttl) -and `
+        ($null -eq $module.http) -and `
+        ($null -eq $module.tcp)){
+        return $null
+    }
+
+    return New-ConsulCheck -check_id $module.check_id `
+                            -name $module.check_name `
+                            -script $module.script `
+                            -interval $module.interval `
+                            -ttl $module.ttl `
+                            -notes $module.notes `
+                            -http $module.http `
+                            -tcp $module.tcp `
+                            -timeout $module.timeout `
+                            -status $module.status 
+}
+
+function New-ConsulCheck()
+{
+    param(
+        [Parameter(Mandatory=$false,Position=0)]
+        [string]$check_id,
+        [Parameter(Mandatory=$false,Position=1)]
+        [string]$name,
+        [Parameter(Mandatory=$false,Position=2)]
+        [string]$script=$null,
+        [Parameter(Mandatory=$false,Position=3)]
+        [string]$interval=$null,
+        [Parameter(Mandatory=$false,Position=4)]
+        [string]$ttl=$null,
+        [Parameter(Mandatory=$false,Position=5)]
+        [string]$notes=$null,
+        [Parameter(Mandatory=$false,Position=6)]
+        [string]$http=$null,
+        [Parameter(Mandatory=$false,Position=7)]
+        [string]$tcp=$null,
+        [Parameter(Mandatory=$false,Position=8)]
+        [string]$timeout=$null,
+        [Parameter(Mandatory=$false,Position=9)]
+        [string]$status=$null
+    )
+
+    $check = New-Object psobject -Property @{
+        id=($check_id, $name -ne $null)[0]
+        name=$name
+        script=$script            
+        notes=$notes
+        http=$http
+        tcp=$tcp 
+        ttl=$null
+        interval=$null
+        timeout=$null
+        check=$null  
+        status=$status
+    }
+
+    $check | Add-Member ScriptMethod validate_duration {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [string]$name,
+            [Parameter(Mandatory=$true, Position=1)]
+            [string]$duration
+        )
+        if(($null -eq $duration) -or ($duration -eq "")){
+            return $null
+        }           
+        $duration_units = @('ns', 'us', 'ms', 's', 'm', 'h')
+          
+        $suffix_ok=$false
+        $duration_units | %{
+            if($duration.EndsWith($_)){ $suffix_ok=$true }
+        }
+        if(-not $suffix_ok){
+            throw ('Invalid {0} {1} you must specify units ({2})' -f `
+                $name, $duration, ($duration_units -join ', '))
+        }        
+        return $duration
+    }
+
+    if(($script, $http, $tcp -ne $null).Length -gt 0){
+        $check.interval = $check.validate_duration("interval",$interval)
+    }
+    $check.timeout = $check.validate_duration("timeout",$timeout)
+    $check.ttl = $check.validate_duration("ttl",$ttl)
+
+    if(-not (null_or_empty $script)) { 
+        $check.check = @{
+            Script = $script
+            Interval = $interval 
+        }            
+    }
+    if(-not (null_or_empty $http)) {
+        $check.check = @{ 
+            HTTP = $http
+            Interval = $interval             
+        }
+    }
+    if(-not (null_or_empty $tcp)) { 
+        $check.check = @{ 
+            TCP = $tcp
+            Interval = $interval             
+        }
+    }
+    if(-not (null_or_empty $ttl)) { 
+        $check.check = @{ 
+            TTL = $ttl 
+        }
+    } 
+
+    $check | Add-Member ScriptMethod register {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [object]$consul_api
+        )
+
+        $consul_api.agent.check.register($check.name, $check.id, $check.notes, `
+                                        $check.script, $check.http, $check.tcp, `
+                                        $check.ttl, $check.interval, $check.status)
+    }        
+    return $check  
+}
+
+function Parse-Service()
+{  
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module,    
+        [Parameter(Mandatory=$false, Position=1)]
+        [object]$loaded=$null
+    ) 
+    
+    if(($module.service_name -ne $null) -and ($module.service_port -ne $null)){
+        return New-ConsulService $module.service_id $module.service_name $module.service_address $module.service_port $module.tags 
+    }
+    elseif(($module.service_name -ne $null) -and ($module.service_port -eq $null)) {
+        Fail-Json $result ("service_name supplied but no service_port, a port is required to configure a service." + `
+                          " Did you configure the 'port' argument meaning 'service_port'?")
+    }
+    return $null
+}
+
+function New-ConsulService()
+{
+    param(
+        [Parameter(Mandatory=$false,Position=0)]
+        [string]$service_id=$null,
+        [Parameter(Mandatory=$false,Position=1)]
+        [string]$service_name=$null,  
+        [Parameter(Mandatory=$false,Position=2)]
+        [string]$service_address=$null,
+        [Parameter(Mandatory=$false,Position=3)]
+        [string]$service_port=$null,
+        [Parameter(Mandatory=$false,Position=4)]
+        [array]$tags=$null,        
+        [Parameter(Mandatory=$false, Position=5)]
+        [object]$loaded=$null
+    )
+
+    $service = New-Object psobject -Property @{            
+        name=$service_name
+        id=($service_id, $service_name -ne $null)[0]
+        address=$service_address
+        port=$service_port
+        tags=($tags,@() -ne $null)[0]
+        checks=@()
+    }
+
+    if($loaded -ne $loaded){
+        $service.id = $loaded.ServiceID
+        $service.name = $loaded.ServiceName
+        $service.port = $loaded.ServicePort         
+        $service.address = $loaded.ServiceAddress
+        if($loaded.PSobject.Properties.name -match "ServiceTags"){
+            $service.tags = $loaded.ServiceTags
+        }
+    }
+
+    $service | Add-Member ScriptMethod register { 
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [object]$consul_api
+        )
+                     
+        if($this.checks.Length -gt 0){
+            $check = $this.checks[0]               
+
+            $consul_api.agent.service.register($service.name, `
+                                    $service.id, `
+                                    $service.address, `
+                                    $service.port, `
+                                    $service.tags, `
+                                    $check)             
+        } 
+        else {
+            $consul_api.agent.service.register($service.name, `
+                                    $service.id, `
+                                    $service.address, `
+                                    $service.port, `
+                                    $service.tags)     
+
+        }
+    }
+
+    $service | Add-Member ScriptMethod add_check {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [object]$check
+        )
+        $this.checks += $check
+    }
+	
+    $service | Add-Member ScriptMethod has_checks {
+        return ($this.checks.Length -gt 0) 
+    }
+
+    $service | Add-Member ScriptMethod Equals -Force {
+        param(
+            [Parameter(Mandatory=$true,Position=0)]
+            [object]$obj
+        )
+        if($null -eq $obj){ return $false }
+        return (($obj.GetType() -eq $this.GetType()) -and `
+                ($this.id -eq $obj.id) -and `
+                ($this.name -eq $obj.name) -and `
+                ($this.port -eq $obj.port) -and `
+                (@(Compare-Object $this.tags $obj.tags -SyncWindow 0).Length -eq 0))
+    }
+    return $service
+}
+
+function Get-ConsulApi()
+{
+    param(
+        [Parameter(Mandatory=$true,Position=0)]
+        [object]$module
+    )
+
+    if(-not $module.validate_certs){        
+        [System.Net.ServicePointManager]::CertificatePolicy = New-Object TrustAllCertsPolicy
+    }
+
+    $consul_api = New-Object psobject -Property @{
+        agent = New-Object psobject -Property @{
+            service=New-Object psobject @{}
+            check=New-Object psobject @{}
+        }       
+        host=$module.host
+        port=$module.port
+        scheme=$module.scheme
+        validate_certs=$module.validate_certs
+        token=$module.token
+    }
+
+    $consul_api | Add-Member ScriptMethod tokenise_url {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [string]$uri            
+        )
+
+        if($this.token -ne $null){ 
+            $uri += "?token="+$this.token 
+        }
+        return $uri
+    }
+   
+    $consul_api.agent | Add-Member ScriptMethod services {
+        $uri = "{0}://{1}:{2}/v1/agent/services" `
+                -f $consul_api.scheme, $consul_api.host, $consul_api.port
+
+        $uri = $consul_api.tokenise_url($uri)
+
+        return Invoke-RestMethod -Method Get -Uri $uri         
+    }
+
+    $consul_api.agent.service | Add-Member ScriptMethod register {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [string]$name,
+            [Parameter(Mandatory=$false, Position=1)]
+            [string]$id,
+            [Parameter(Mandatory=$false, Position=2)]
+            [string]$address=$null,
+            [Parameter(Mandatory=$false, Position=3)]
+            [int]$port=$null,
+            [Parameter(Mandatory=$false, Position=4)]
+            [array]$tags=$null,
+            [Parameter(Mandatory=$false, Position=5)]
+            [object]$check=$null
+        )
+        $uri = "{0}://{1}:{2}/v1/agent/service/register" `
+                -f $consul_api.scheme, $consul_api.host, $consul_api.port
+
+        $uri = $consul_api.tokenise_url($uri)
+
+        $body = @{ 
+            Name=$name 
+            ID = ($id, $name -ne $null)[0] 
+        }
+        if(-not (null_or_empty $address)) { $body.Address = $address }
+        if(-not (null_or_empty $port)) { $body.Port = $port }
+        if($null -ne $tags) { $body.Tags = $tags }
+        if($null -ne $check) { $body.Check = $check }
+
+        return Invoke-RestMethod -Method Put -Uri $uri `
+                -Body ($body | ConvertTo-Json) -ContentType "application/json"                
+    }
+
+    $consul_api.agent.service | Add-Member ScriptMethod de_register {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [string]$id
+        )
+        $uri = "{0}://{1}:{2}/v1/agent/service/deregister/{3}" `
+                -f $consul_api.scheme, $consul_api.host, $consul_api.port, $id
+
+        $uri = $consul_api.tokenise_url($uri)
+        
+        return Invoke-RestMethod -Method Put -Uri $uri              
+    }
+
+    $consul_api.agent | Add-Member ScriptMethod checks {
+        $uri = "{0}://{1}:{2}/v1/agent/checks" `
+                -f $consul_api.scheme, $consul_api.host, $consul_api.port
+
+        $uri = $consul_api.tokenise_url($uri)
+
+        return Invoke-RestMethod -Method Get -Uri $uri 
+    }
+
+    $consul_api.agent.check | Add-Member ScriptMethod register {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [string]$name,
+            [Parameter(Mandatory=$false, Position=1)]
+            [string]$id=$null,
+            [Parameter(Mandatory=$false, Position=2)]
+            [string]$notes=$null,
+            [Parameter(Mandatory=$false, Position=3)]
+            [string]$script=$null,
+            [Parameter(Mandatory=$false, Position=4)]
+            [string]$http=$null,
+            [Parameter(Mandatory=$false, Position=5)]
+            [string]$tcp=$null,
+            [Parameter(Mandatory=$false, Position=6)]
+            [string]$ttl=$null,
+            [Parameter(Mandatory=$false, Position=7)]
+            [string]$interval=$null,
+            [Parameter(Mandatory=$false, Position=8)]
+            [string]$status=$null
+        )
+        $uri = "{0}://{1}:{2}/v1/agent/check/register" `
+                -f $consul_api.scheme, $consul_api.host, $consul_api.port
+
+        $uri = $consul_api.tokenise_url($uri)
+
+        $body = @{            
+            Name=$name
+            ID=($id, $name -ne $null)[0]
+        }        
+        if(-not (null_or_empty $notes)) { 
+            $body.Notes = $notes 
+        }
+        if(-not (null_or_empty $script)) { 
+            $body.Script = $script
+            $body.Interval = $interval
+        }
+        if(-not (null_or_empty $http)) {  
+            $body.HTTP = $http
+            $body.Interval = $interval           
+        }
+        if(-not (null_or_empty $tcp)) { 
+            $body.TCP = $tcp
+            $body.Interval = $interval                   
+        }
+        if(-not (null_or_empty $ttl)) { 
+            $body.TTL = $ttl           
+        } 
+        if(-not (null_or_empty $status)) { 
+            $body.Status = $status           
+        } 
+        
+        return Invoke-RestMethod -Method Put -Uri $uri `
+                -Body ($body | ConvertTo-Json) -ContentType "application/json"             
+    }
+
+    $consul_api.agent.check | Add-Member ScriptMethod de_register {
+        param(
+            [Parameter(Mandatory=$true, Position=0)]
+            [string]$id
+        )
+        $uri = "{0}://{1}:{2}/v1/agent/check/deregister/{3}" `
+                -f $consul_api.scheme, $consul_api.host, $consul_api.port, $id
+        
+        $uri = $consul_api.tokenise_url($uri)
+        
+        return Invoke-RestMethod -Method Put -Uri $uri          
+    }
+
+    return $consul_api    
+}
+
+function null_or_empty()
+{
+    param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [AllowNull()]
+        [AllowEmptyString()]
+        [string]$string
+    )
+    return (($string -eq $null) -or ($string -eq "") -or ($string -eq [String]::Empty))
+}
+
+try
+{
+    if ($module.state -eq "present"){
+        Add
+    }
+    else {
+        Remove
+    }
+
+    Exit-Json $result;
+}
+catch
+{
+    Fail-Json $result $_.Exception.Message
+}

--- a/windows/win_consul.py
+++ b/windows/win_consul.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Stuart Cullinan <stuart.cullinan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: consul
+short_description: "Add, modify & delete services within a consul cluster."
+description:
+ - Registers services and checks for an agent with a consul cluster.
+   A service is some process running on the agent node that should be advertised by
+   consul's discovery mechanism. It may optionally supply a check definition,
+   a periodic service test to notify the consul cluster of service's health.
+ - "Checks may also be registered per node e.g. disk usage, or cpu usage and
+   notify the health of the entire node to the cluster.
+   Service level checks do not require a check name or id as these are derived
+   by Consul from the Service name and id respectively by appending 'service:'
+   Node level checks require a check_name and optionally a check_id."
+ - Currently, there is no complete way to retrieve the script, interval or ttl
+   metadata for a registered check. Without this metadata it is  not possible to
+   tell if the data supplied with ansible represents a change to a check. As a
+   result this does not attempt to determine changes and will always report a
+   changed occurred. An api method is planned to supply this metadata so at that
+   stage change management will be added.
+ - "See http://consul.io for more details."
+
+version_added: "2.1"
+author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
+options:
+    state:
+        description:
+          - register or deregister the consul service, defaults to present
+        required: true
+        choices: ['present', 'absent']
+    service_name:
+        description:
+          - Unique name for the service on a node, must be unique per node,
+            required if registering a service. May be ommitted if registering
+            a node level check
+        required: false
+    service_id:
+        description:
+          - the ID for the service, must be unique per node, defaults to the
+            service name if the service name is supplied
+        required: false
+        default: service_name if supplied
+    host:
+        description:
+          - host of the consul agent defaults to localhost
+        required: false
+        default: localhost
+    port:
+        description:
+          - the port on which the consul agent is running
+        required: false
+        default: 8500
+    scheme:
+        description:
+          - the protocol scheme on which the consul agent is running
+        required: false
+        default: http
+    validate_certs:
+        description:
+          - whether to verify the tls certificate of the consul agent
+        required: false
+        default: True
+    notes:
+        description:
+          - Notes to attach to check when registering it.
+        required: false
+        default: None
+    service_port:
+        description:
+          - the port on which the service is listening required for
+            registration of a service, i.e. if service_name or service_id is set
+        required: false
+    service_address:
+        description:
+          - the address on which the service is serving required for
+            registration of a service
+        required: false
+        default: localhost
+    tags:
+        description:
+          - a list of tags that will be attached to the service registration.
+        required: false
+        default: None
+    script:
+        description:
+          - the script/command that will be run periodically to check the health
+            of the service. Scripts require an interval and vise versa
+        required: false
+        default: None
+    interval:
+        description:
+          - the interval at which the service check will be run. This is a number
+            with a s or m suffix to signify the units of seconds or minutes e.g
+            15s or 1m. If no suffix is supplied, m will be used by default e.g.
+            1 will be 1m. Required if the script param is specified.
+        required: false
+        default: None
+    check_id:
+        description:
+          - an ID for the service check, defaults to the check name, ignored if
+            part of a service definition.
+        required: false
+        default: None
+    check_name:
+        description:
+          - a name for the service check, defaults to the check id. required if
+            standalone, ignored if part of service definition.
+        required: false
+        default: None
+    ttl:
+        description:
+          - checks can be registered with a ttl instead of a script and interval
+            this means that the service will check in with the agent before the
+            ttl expires. If it doesn't the check will be considered failed.
+            Required if registering a check and the script an interval are missing
+            Similar to the interval this is a number with a s or m suffix to
+            signify the units of seconds or minutes e.g 15s or 1m. If no suffix
+            is supplied, m will be used by default e.g. 1 will be 1m
+        required: false
+        default: None
+    http:
+        description:
+          - checks can be registered with an http endpoint. This means that consul
+            will check that the http endpoint returns a successful http status.
+            Interval must also be provided with this option.
+        required: false
+        default: None 
+    tcp:
+        description:
+          - checks can be registered with a tcp endpoint. An TCP check will perform an TCP connection attempt against the value of TCP (expected to be an IP/hostname and port combination) every Interval. If the connection attempt is successful, the check is passing. If the connection attempt is unsuccessful, the check is critical. In the case of a hostname that resolves to both IPv4 and IPv6 addresses, an attempt will be made to both addresses, and the first successful connection attempt will result in a successful check
+        required: false
+        default: None 
+    timeout:
+        description:
+          - A custom HTTP check timeout. The consul default is 10 seconds.
+            Similar to the interval this is a number with a s or m suffix to
+            signify the units of seconds or minutes, e.g. 15s or 1m.
+        required: false
+        default: None        
+    token:
+        description:
+          - the token key indentifying an ACL rule set. May be required to register services.
+        required: false
+        default: None
+    status:
+        description:
+          - The Status field can be provided to specify the initial state of the health check. Valid values are "critical","passing".
+        required: false
+        default: critical
+"""
+
+EXAMPLES = '''
+  - name: register foo service with the local consul agent
+    win_consul:
+      service_name: foo
+      service_port: 80
+  - name: register foo service with curl check
+    win_consul:
+      service_name: foo
+      service_port: 80
+      script: "curl http://localhost"
+      interval: 60s
+  - name: register foo with an http check
+    win_consul:
+      name: foo
+      service_port: 80
+      interval: 60s
+      http: /status
+  - name: register foo with address
+    win_consul:
+      service_name: foo
+      service_port: 80
+      service_address: 127.0.0.1
+  - name: register foo with some service tags
+    win_consul:
+      service_name: foo
+      service_port: 80
+      tags:
+        - prod
+        - webservers
+  - name: remove foo service
+    win_consul:
+      service_name: foo
+      state: absent
+  - name: create a node level check to test disk usage
+    win_consul:
+      check_name: Disk usage
+      check_id: disk_usage
+      script: "c:\temp\disk_usage.ps1"
+      interval: 5m
+'''

--- a/windows/win_consul.py
+++ b/windows/win_consul.py
@@ -21,7 +21,7 @@
 # this is a windows documentation stub.  actual code lives in the .ps1
 # file of the same name
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: consul
 short_description: "Add, modify & delete services within a consul cluster."
@@ -43,7 +43,7 @@ description:
    stage change management will be added.
  - "See http://consul.io for more details."
 
-version_added: "2.1"
+version_added: "2.2"
 author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
 options:
     state:
@@ -173,42 +173,94 @@ options:
 """
 
 EXAMPLES = '''
-  - name: register foo service with the local consul agent
-    win_consul:
-      service_name: foo
-      service_port: 80
-  - name: register foo service with curl check
-    win_consul:
-      service_name: foo
-      service_port: 80
-      script: "curl http://localhost"
-      interval: 60s
-  - name: register foo with an http check
-    win_consul:
-      name: foo
-      service_port: 80
-      interval: 60s
-      http: /status
-  - name: register foo with address
-    win_consul:
-      service_name: foo
-      service_port: 80
-      service_address: 127.0.0.1
-  - name: register foo with some service tags
-    win_consul:
-      service_name: foo
-      service_port: 80
-      tags:
-        - prod
-        - webservers
-  - name: remove foo service
-    win_consul:
-      service_name: foo
-      state: absent
-  - name: create a node level check to test disk usage
-    win_consul:
-      check_name: Disk usage
-      check_id: disk_usage
-      script: "c:\temp\disk_usage.ps1"
-      interval: 5m
+    - name: register foo service with the local consul agent
+      win_consul:
+        service_name: foo
+        service_port: 80
+
+    - name: register foo service with curl check
+      win_consul:
+        service_name: foo
+        service_port: 80
+        script: "curl http://localhost"
+        interval: 60s
+
+    - name: register foo with an http check
+      win_consul:
+        name: foo
+        service_port: 80
+        interval: 60s
+        http: /status
+
+    - name: register foo with address
+      win_consul:
+        service_name: foo
+        service_port: 80
+        service_address: 127.0.0.1
+
+    - name: register foo with some service tags
+      win_consul:
+        service_name: foo
+        service_port: 80
+        tags:
+          - prod
+          - webservers
+
+    - name: remove foo service
+      win_consul:
+        service_name: foo
+        state: absent
+
+    - name: create a node level check to test disk usage
+      win_consul:
+        check_name: Disk usage
+        check_id: disk_usage
+        script: "c:/temp/disk_usage.ps1"
+        interval: 5m
+'''
+
+RETURN = '''
+state:
+  description: The service details after a successful service registration.
+  returned: only on successful registration
+  type: dict
+  sample: {
+      "changed": true,
+      "service_id": "foo",
+      "service_name": "foo",
+      "service_port": 80,
+      "checks": [],
+      "tags": "webservers"
+    }
+state:
+  description: The service details after a successful service removal (unregister).
+  returned: only on successful service removal
+  type: dict
+  sample: {
+      "changed": true,
+      "id": "foo"
+    }
+state:
+  description: The check details after a successful check registration.
+  returned: only on successful check registration
+  type: dict
+  sample: {
+      "changed": true,
+      "check_id": "foo-health",
+      "check_name": "foo-health",
+      "script": null,
+      "interval": 5,
+      "ttl": null,
+      "tcp": null,
+      "http": "http://localhost:80/health",
+      "timeout": 25,
+    }
+state:
+  description: The check details after a successful check removal.
+  returned: only on successful check removal
+  type: dict
+  sample: {
+      "changed": true,
+      "id": "foo-health"
+    }
 '''

--- a/windows/win_consul.py
+++ b/windows/win_consul.py
@@ -43,7 +43,7 @@ description:
    stage change management will be added.
  - "See http://consul.io for more details."
 
-version_added: "2.2"
+version_added: "2.3"
 author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
 options:
     state:


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

win_consul
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0.0
```
##### SUMMARY

This is a module for managing consul service registrations on windows. It is a port of the existing consul.py module so that it can work on windows. The only difference in usage is the module name i.e. "win" prefix otherwise this works in the same way.
Adidtional features that go beyond the consul.py impementation are:
- Implemented TCP checks which was missing from consul.py
- Implemented Status property to specify the initial state of the health check as supported by consul api.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
