### PR TITLE
Added a module for installing certificates in the certificate store

### DIFF
--- a/windows/win_certificate_store.ps1
+++ b/windows/win_certificate_store.ps1
@@ -1,0 +1,107 @@
+#!powershell
+
+# Copyright 2016, Stuart Cullinan <stuart.cullinan@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+$store_location = Get-Attr -obj $params -name store_location -failifempty $true -emptyattributefailmessage "missing required argument: store_location"
+$thumbprint  = Get-Attr -obj $params -name thumbprint -failifempty $true -emptyattributefailmessage "missing required argument: thumbprint"
+$src = Get-Attr -obj $params -name src -default $null
+$password = Get-Attr -obj $params -name password -deafult $true 
+$private_key = Get-Attr -obj $params -name private_key -default "false" | ConvertTo-Bool
+$state = Get-Attr -obj $params -name state -default "present" -ValidateSet "present","absent"
+
+function Import-Cert()
+{
+    if(Is-Installed){
+        return
+    }
+
+    if($src -eq $null -or $src -eq ""){
+        throw "'src' argument is required when importing a certificate"
+    }
+    if($private_key -and ($password -eq $null -or $password -eq "")){
+        throw "'password' argument is required when importing a private key (pfx)"
+    }    
+              
+    $certificate = ( Get-ChildItem -Path $src )
+   
+    if($private_key){
+        $securepassword = ConvertTo-SecureString -String $password -Force -AsPlainText	
+        $res = $certificate | Import-PfxCertificate -CertStoreLocation $store_location -Password $securepassword
+        $result.changed = $true
+    }
+    else {
+        $res = $certificate | Import-Certificate -CertStoreLocation $store_location 
+        $result.changed = $true
+    }
+    $result = new-object psobject @{
+        changed = $result.changed
+        thumb_print = $res.Thumbprint
+        serial_number = $res.SerialNumber
+        subject = $res.Subject
+    }        
+}
+
+function Is-Installed()
+{
+    $item = Get-ChildItem -Path $store_location | where {$_.Thumbprint -eq $thumbprint } 
+    return ($item -ne $null)
+}
+
+function Remove-Cert()
+{
+    if(-not (Is-Installed)){
+        return
+    }
+    
+    [string]$path = $store_location 
+    if(-not $path.EndsWith('\')){ $path += '\' }
+    $path += $thumbprint
+
+    if($private_key){        
+        Remove-Item -Path $path -DeleteKey -Confirm:$false -Force
+    }
+    else{
+        Remove-Item -Path $path -Confirm:$false -Force
+    }
+    $result.changed = $true
+}
+
+Try
+{   
+
+    if ($state -eq "present"){
+        Import-Cert
+    }
+    else{
+        Remove-Cert        
+    }
+
+    Exit-Json $result;
+}
+Catch
+{
+    Fail-Json $result $_.Exception.Message
+}

--- a/windows/win_certificate_store.py
+++ b/windows/win_certificate_store.py
@@ -24,7 +24,7 @@
 DOCUMENTATION = '''
 ---
 module: win_certificate_store
-version_added: "2.1"
+version_added: "2.2"
 short_description: Imports and removes certificates from the local certificate store
 description:
     - Imports and removes certificates from the local certificate store.
@@ -93,4 +93,18 @@ EXAMPLES = '''
     private_key: yes
     state: absent
 
+'''
+
+RETURN = '''
+  # retruns the following json if the certificate was imported
+  {
+    changed: true,
+    thumb_print = '-thumprint-'
+    serial_number: '-serial numer-
+    subject: '-the subject-'
+  }
+  #otherwise just the changed flag
+  {
+    changed: true|false
+  }
 '''

--- a/windows/win_certificate_store.py
+++ b/windows/win_certificate_store.py
@@ -96,15 +96,14 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-  # retruns the following json if the certificate was imported
-  {
-    changed: true,
-    thumb_print = '-thumprint-'
-    serial_number: '-serial numer-
-    subject: '-the subject-'
-  }
-  #otherwise just the changed flag
-  {
-    changed: true|false
-  }
+state:
+  description: The certificate details after import.
+  returned: only on successful import
+  type: dict
+  sample: {
+      "changed": true,
+      "thumb_print": "",
+      "serial_number": "",
+      "subject": ""
+    }
 '''

--- a/windows/win_certificate_store.py
+++ b/windows/win_certificate_store.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Stuart Cullinan <stuart.cullinan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_certificate_store
+version_added: "2.1"
+short_description: Imports and removes certificates from the local certificate store
+description:
+    - Imports and removes certificates from the local certificate store.
+options:
+  store_location:
+    description:
+      - The certificate store location path where the certificate will be installed or that identifies the certificate to be removed.
+    required: true
+  thumbprint:
+    description:
+      - The certificate thumbprint. This will uniquely identify the certificate to import/remove and is required to make this module idempotent.
+    required: true
+  src:
+    description:
+      - Specify the folder location where the certificate file to be imported exists. Required if state is 'present'
+    require: false     
+  private_key:
+    description:
+      - When state is 'present' will imprt the file specified by src as a Pfx. If state is 'absent' will remove the private key along with the certificate specified.
+    require: false
+    choices:
+      - yes
+      - no
+    default: no  
+  password:
+    description:
+      - The password to import the Pfx. Required if state is 'present' and private_key is 'yes'
+    require: false    
+  state:
+    description:
+      - State of the package on the system
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  	
+author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
+'''
+
+EXAMPLES = '''
+  # Install certificate to my localmachine
+  win_certificate_store: 
+    store_location: 'cert:\\localMachine\\my' 
+    thumprint: D2D38EBA60CAA1C12055A2E1C83B15AD450110C2
+    src: 'c:\\certs\mycertificate.cer'
+
+  # Install private key Pfx to localmachine trustedpeople
+  win_certificate_store: 
+    store_location: 'cert:\\localMachine\\trustedpeople' 
+    thumprint: D2D38EBA60CAA1C12055A2E1C83B15AD450110C2
+    src: 'c:\\certs\mycertificate.pfx'
+    private_key: yes
+    password: 'secret'
+
+  # Remove certificate from my localmachine
+  win_certificate_store: 
+    store_location: 'cert:\\localMachine\\my' 
+    thumprint: D2D38EBA60CAA1C12055A2E1C83B15AD450110C2
+    state: absent
+
+  # Remove certificate and private key 
+  win_certificate_store: 
+    store_location: 'cert:\\localMachine\\my'
+    thumprint: D2D38EBA60CAA1C12055A2E1C83B15AD450110C2 
+    private_key: yes
+    state: absent
+
+'''

--- a/windows/win_certificate_store.py
+++ b/windows/win_certificate_store.py
@@ -61,7 +61,7 @@ options:
       - present
       - absent
     default: present
-  	
+
 author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_certificate_store
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The module supports the installation and removal of certificates, both public `.cer` and private `.pfk` certificate files fro mthe windows certifact store. The module is idempotent and uses the thumbprint and storelocation for identification. 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
