### PR TITLE
Added a nuget module

### DIFF
--- a/windows/win_nuget.ps1
+++ b/windows/win_nuget.ps1
@@ -1,0 +1,238 @@
+#!powershell
+
+# Copyright 2016, Stuart Cullinan <stuart.cullinan@gmail.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+
+# WANT_JSON
+# POWERSHELL_COMMON
+
+$params = Parse-Args $args;
+$result = New-Object PSObject;
+Set-Attr $result "changed" $false;
+
+$package = Get-Attr -obj $params -name name -failifempty $true -emptyattributefailmessage "missing required argument: name"
+$output_directory = Get-Attr -obj $params -name location -failifempty $true -emptyattributefailmessage "missing required argument: location"
+$exclude_version = Get-Attr -obj $params -name exclude_version -default "false" | ConvertTo-Bool
+$prerelease = Get-Attr -obj $params -name prerelease -default "false" | ConvertTo-Bool
+$nocache = Get-Attr -obj $params -name nocache -default "false" | ConvertTo-Bool
+$force = Get-Attr -obj $params -name force -default "false" | ConvertTo-Bool
+$version = Get-Attr -obj $params -name version -default $null
+
+$source = Get-Attr -obj $params -name source -default $null
+if ($source) {$source = $source.Tolower()}
+
+$state = Get-Attr -obj $params -name state -default "present"
+
+
+if ("present","absent" -notcontains $state)
+{
+    Fail-Json $result "state is $state; must be present or absent"
+}
+
+Function Check-NugetIsInstalled
+{
+    [CmdletBinding()]
+
+    param()
+
+    $installed = get-command nuget -ErrorAction 0
+    if ($installed -eq $null)
+    {
+        Fail-Json $result "nuget is not installed or not in PATH. Install 'Nuget.Commandline' using win_chocolatey module first"
+    }
+    else
+    {
+        $script:nuget = "nuget.exe"       
+    }
+}
+
+function Get-LatestPackageVersion([string]$packageId, [string]$source)
+{
+    #get the latest version from list command
+    $cmd = "$nuget list '$packageId'"
+
+    if(($source -ne $null) -and ($source -ne "")){ $cmd += " -Source $source" }
+
+    $results = invoke-expression $cmd
+
+    if (($LastExitCode -ne 0) -or ($results.Contains('No packages found')))
+    {
+        Set-Attr $result "nuget_error_cmd" $cmd
+        Set-Attr $result "nuget_error_log" "$results"
+    
+        Throw "Error checking installation status for $package" 
+    } 
+
+    $pkg = $results.Split([System.Environment]::NewLine, [System.StringSplitOptions]::RemoveEmptyEntries) `
+                             | %{ $kv = $_.Split(' '); return @{ Name=$kv[0]; Version=$kv[1] } } `
+                             | where { $_.Name -eq $packageId } `
+                             | Select -index 0 
+                             
+    return $pkg.Version 
+}
+
+Function Install-Package
+{
+    [CmdletBinding()]
+    
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]$package,
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]$output_directory,
+        [Parameter(Mandatory=$false, Position=3)]
+        [string]$version,
+        [Parameter(Mandatory=$false, Position=4)]
+        [string]$source,
+        [Parameter(Mandatory=$false, Position=5)]
+        [bool]$exclude_version,
+        [Parameter(Mandatory=$false, Position=6)]
+        [bool]$prerelease,                
+        [Parameter(Mandatory=$false, Position=7)]
+        [bool]$nocache,
+        [Parameter(Mandatory=$false, Position=7)]
+        [bool]$force = $false
+    ) 
+
+    Add-Facts
+    
+    if(-not $force)
+    {
+        if($result.IsInstalled()){ return }
+    }    
+
+    $cmd = "$nuget install $package"
+
+    if (-not $version)
+    {
+        $version = $result.package_version        
+    }
+    $cmd += " -Version $version"
+        
+    if ($source)
+    {
+        $cmd += " -Source $source"
+    }
+
+    if ($exclude_version)
+    {
+        $cmd += " -ExcludeVersion"
+    }
+
+    if ($output_directory)
+    {
+        $cmd += " -OutputDirectory '$output_directory'"
+    }
+
+    if ($prerelease)
+    {
+        $cmd += " -Prerelease"
+    }
+
+    if ($nocache)
+    {
+        $cmd += " -NoCache"
+    }
+
+    $cmd += " -NonInteractive"
+
+    $results = invoke-expression $cmd
+
+    if ($LastExitCode -ne 0)
+    {
+        Set-Attr $result "nuget_error_cmd" $cmd
+        Set-Attr $result "nuget_error_log" "$results"
+        Throw "Error installing $package" 
+    }
+    
+    $result | Add-Member -MemberType NoteProperty -Name "command" -Value $cmd
+            
+    $result.changed = $true
+}
+
+function Add-Facts()
+{
+    if(-not $version)
+    {
+        $version = Get-LatestPackageVersion $package $source
+    }
+            
+    if($exclude_version)
+    {
+        $dir = (Join-Path $output_directory $package)
+    }
+    else
+    {
+        $pdir = "{0}.{1}" -f $package, $version
+        $dir = (Join-Path $output_directory $pdir)
+    }
+          
+    $result | Add-Member -MemberType NoteProperty -Name "package_path" -Value $dir
+    $result | Add-Member -MemberType NoteProperty -Name "package_id" -Value $package
+    $result | Add-Member -MemberType NoteProperty -Name "package_version" -Value $version
+    $result | Add-Member -MemberType ScriptMethod -Name "IsInstalled" -Value { return Test-Path $this.package_path }    
+    
+}
+
+Function Uninstall-Package 
+{
+    [CmdletBinding()]
+    
+    param(
+        [Parameter(Mandatory=$true, Position=1)]
+        [string]$package,
+        [Parameter(Mandatory=$true, Position=2)]
+        [string]$output_directory,
+        [Parameter(Mandatory=$false, Position=3)]
+        [string]$version = $null,
+        [Parameter(Mandatory=$false, Position=4)]
+        [bool]$exclude_version = $false
+    )
+    
+    Add-Facts
+
+    if (-not ($result.IsInstalled()))
+    {
+        return
+    }   
+
+    Remove-Item -Recurse -Force $result.package_path
+      
+    $result.changed = $true
+}
+
+Try
+{
+    Check-NugetIsInstalled
+
+    if ($state -eq "present")
+    {
+        Install-Package -package $package -output_directory $output_directory -version $version `
+            -source $source -exclude_version $exclude_version -prerelease $prerelease -nocache $nocache -force $force
+    }
+    else
+    {
+        Uninstall-Package -package $package -output_directory $output_directory -version $version -exclude_version $exclude_version
+    }
+
+    Exit-Json $result;
+}
+Catch
+{
+    Fail-Json $result $_.Exception.Message
+}

--- a/windows/win_nuget.py
+++ b/windows/win_nuget.py
@@ -1,0 +1,113 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Stuart Cullinan <stuart.cullinan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+# this is a windows documentation stub.  actual code lives in the .ps1
+# file of the same name
+
+DOCUMENTATION = '''
+---
+module: win_nuget
+version_added: "2.1"
+short_description: Installs packages using nuget
+description:
+    - Installs packages using Nuget (https://www.nuget.org/). If Nuget is missing from the system, this module will NOT install it. To install
+	nuget, use the win_chocolatey module and install 'Nuget.Commandline' first.
+options:
+  name:
+    description:
+      - Name (packageId) of the package to be installed
+    required: true
+  output_directory:
+    description:
+      - Specify the folder location to install the package
+    require: true   
+  state:
+    description:
+      - State of the package on the system
+    required: false
+    choices:
+      - present
+      - absent
+    default: present
+  force:
+    description:
+      - Forces install of the package (even if it already exists). Using Force will cause ansible to always report that a change was made
+    required: false
+    choices:
+      - yes
+      - no
+    default: no  
+  version:
+    description:
+      - Specific version of the package to be installed
+      - Ignored when state == 'absent'
+    required: false
+    default: null
+  source:
+    description:
+      - Specify source rather than using default nuget.org gallery
+    require: false
+    default: null   
+  exclude_version:
+    description:
+      - Exlcude the version in the name of the installation folder. If a package is installed with this option set then it must be uninstalled with this option set too.
+    require: false
+    choices:
+      - yes
+      - no
+    default: no    
+  prerelease:
+    description:
+      - Allows prerelease packages to be installed.
+    choices:
+      - yes
+      - no
+    default: no
+  nocache:
+    description:
+      - Disable looking up packages from local machine cache.
+    choices:
+      - yes
+      - no
+    default: no	
+author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
+'''
+
+EXAMPLES = '''
+  # Install EntityFramework
+  win_nuget:
+    name: EntityFramework
+	location: c:/lib
+  # Install EntityFramework 6.1.2
+  win_nuget:
+    name: EntityFramework
+    version: 6.1.2
+	location: c:/lib
+  # Uninstall EntityFramework
+  win_nuget:
+    name: EntityFramework
+    state: absent
+	location: c:/lib
+  # Install EntityFramework from specified repository
+  win_nuget:
+    name: EntityFramework
+	location: c:/lib
+    source: https://someserver/api/v2/
+'''

--- a/windows/win_nuget.py
+++ b/windows/win_nuget.py
@@ -119,7 +119,7 @@ state:
   type: dict
   sample: {
       "changed": true,
-      "package_path": "c:\\root\\packages\\somepackage-1.2.3",
+      "package_path": "c:/packages/somepackage-1.2.3",
       "package_id": "somepackage",
       "package_version": "1.2.3"
     }

--- a/windows/win_nuget.py
+++ b/windows/win_nuget.py
@@ -24,11 +24,11 @@
 DOCUMENTATION = '''
 ---
 module: win_nuget
-version_added: "2.1"
+version_added: "2.2"
 short_description: Installs packages using nuget
 description:
     - Installs packages using Nuget (https://www.nuget.org/). If Nuget is missing from the system, this module will NOT install it. To install
-	nuget, use the win_chocolatey module and install 'Nuget.Commandline' first.
+      nuget, use the win_chocolatey module and install 'Nuget.Commandline' first.
 options:
   name:
     description:
@@ -94,20 +94,33 @@ EXAMPLES = '''
   # Install EntityFramework
   win_nuget:
     name: EntityFramework
-	location: c:/lib
+    location: c:/lib
   # Install EntityFramework 6.1.2
   win_nuget:
     name: EntityFramework
     version: 6.1.2
-	location: c:/lib
+    location: c:/lib
   # Uninstall EntityFramework
   win_nuget:
     name: EntityFramework
     state: absent
-	location: c:/lib
+    location: c:/lib
   # Install EntityFramework from specified repository
   win_nuget:
     name: EntityFramework
-	location: c:/lib
+    location: c:/lib
     source: https://someserver/api/v2/
+'''
+
+RETURN = '''
+state:
+  description: The package installation details after successful install.
+  returned: only on successful installation
+  type: dict
+  sample: {
+      "changed": true,
+      "package_path": "c:\\root\\packages\\somepackage-1.2.3",
+      "package_id": "somepackage",
+      "package_version": "1.2.3"
+    }
 '''

--- a/windows/win_nuget.py
+++ b/windows/win_nuget.py
@@ -37,7 +37,7 @@ options:
   output_directory:
     description:
       - Specify the folder location to install the package
-    require: true   
+    require: true
   state:
     description:
       - State of the package on the system
@@ -53,7 +53,7 @@ options:
     choices:
       - yes
       - no
-    default: no  
+    default: no
   version:
     description:
       - Specific version of the package to be installed
@@ -72,7 +72,7 @@ options:
     choices:
       - yes
       - no
-    default: no    
+    default: no
   prerelease:
     description:
       - Allows prerelease packages to be installed.
@@ -86,7 +86,7 @@ options:
     choices:
       - yes
       - no
-    default: no	
+    default: no
 author: "Stuart Cullinan (stuart.cullinan@gmail.com)"
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_nuget
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Installs packages using Nuget (https://www.nuget.org/). If Nuget is missing from the system, this module will NOT install it. To install nuget, this module requires you have chocolatey installed first (i.e. use the win_chocolatey module and install 'Nuget.Commandline' first).

The rationale for creating this package is to support nuget package installs using the nuget protocol instead of a more basic unzip. We deploy all our windows .Net applications using nuget packages as it is the natural and most common application package managment choice on windows for .Net.

Nuget does not inherently support idempotency nor does it support package installation discovery outside of development tools like Visual Studio. So to support idempotency I have leveraged the install location folder name given that nuget does support adding the pacakgeId and version to the folder name by default. Using this idempotency is achievable at a package or package+version level depending on how the `exclude_version` option is set.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
