### PR TITLE
List pacman options aliases documentation

### DIFF
--- a/packaging/os/pacman.py
+++ b/packaging/os/pacman.py
@@ -40,6 +40,7 @@ options:
             - Name of the package to install, upgrade, or remove.
         required: false
         default: null
+        aliases: [ 'pkg', 'package' ]
 
     state:
         description:
@@ -75,6 +76,7 @@ options:
         required: false
         default: no
         choices: ["yes", "no"]
+        aliases: [ 'update-cache' ]
 
     upgrade:
         description:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

pacman
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel bced8715cd) last updated 2016/08/04 17:44:21 (GMT -500)
  lib/ansible/modules/core: (devel 95a7ee271a) last updated 2016/08/04 17:44:21 (GMT -500)
  lib/ansible/modules/extras: (stable-2.2 fc76455326) last updated 2016/08/04 17:44:21 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Small documentation update to show aliases in pacman module options.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
