### PR TITLE
List homebrew options aliases in documentation

### DIFF
--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -39,6 +39,7 @@ options:
             - name of package to install/remove
         required: false
         default: None
+        aliases: ['pkg', 'package', 'formula']
     path:
         description:
             - "':' separated list of paths to search for 'brew' executable. Since A package (I(formula) in homebrew parlance) location is prefixed relative to the actual path of I(brew) command, providing an alternative I(brew) path enables managing different set of packages in an alternative location in the system."
@@ -56,17 +57,20 @@ options:
         required: false
         default: no
         choices: [ "yes", "no" ]
+        aliases: ['update-brew']
     upgrade_all:
         description:
             - upgrade all homebrew packages
         required: false
         default: no
         choices: [ "yes", "no" ]
+        aliases: ['upgrade']
     install_options:
         description:
             - options flags to install a package
         required: false
         default: null
+        aliases: ['options']
         version_added: "1.4"
 notes:  []
 '''


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

homebrew
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel bced8715cd) last updated 2016/08/04 17:44:21 (GMT -500)
  lib/ansible/modules/core: (devel 95a7ee271a) last updated 2016/08/04 17:44:21 (GMT -500)
  lib/ansible/modules/extras: (stable-2.2 fc76455326) last updated 2016/08/04 17:44:21 (GMT -500)
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Small documentation update to show aliases in pacman module options.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
