### PR TITLE
disable ssl check, validate_certs does not work on ubuntu 16.04

### DIFF
--- a/cloud/vmware/vmware_vm_shell.py
+++ b/cloud/vmware/vmware_vm_shell.py
@@ -111,6 +111,9 @@ EXAMPLES = '''
 
 '''
 
+import ssl
+ssl._create_default_https_context = ssl._create_unverified_context
+
 try:
     from pyVmomi import vim, vmodl
     HAS_PYVMOMI = True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

vmware_vm_shell
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

validate_certs has no effect on and i get:

```
"msg": "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)"}
```

If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
--> it disables ssl

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
"msg": "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:590)"}
```

```
changed: [localhost -> localhost] => (item={'value': {u'disk_size_gb': 27, u'notes': u'This is a test VM', u'vmtemplate': u'ansible_template', u'num_cores': 2, u'state': u'powered_on', u'memory': 4048, u'osid': u'rhel7_64Guest', u'network_name': u'LAN', u'ip_add': u'192.168.20.41'}, 'key': u'vanilla-master'})
```
