### PR TITLE
make sure nic is always defined

### DIFF
--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -333,6 +333,7 @@ def vm_start(conn, vmname, hostname=None, ip=None, netmask=None, gateway=None,
     vm = conn.vms.get(name=vmname)
     use_cloud_init = False
     nics = None
+    nic = None
     if hostname or ip or netmask or gateway or domain or dns or rootpw or key:
         use_cloud_init = True
     if ip and netmask and gateway:


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

ovirt
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.1
```
##### SUMMARY

Fixes #2679 , when networking is not defined, nic var is also undefined.
