### PR TITLE
when write_config is no, we should not try to write any configuration…

### DIFF
--- a/network/a10/a10_server.py
+++ b/network/a10/a10_server.py
@@ -257,8 +257,8 @@ def main():
         else:
             result = dict(msg="the server was not present")
 
-    # if the config has changed, or we want to force a save, save the config unless otherwise requested
-    if changed or write_config:
+    # if the config has changed, save the config unless otherwise requested
+    if changed and write_config:
         write_result = axapi_call(module, session_url + '&method=system.action.write_memory')
         if axapi_failure(write_result):
             module.fail_json(msg="failed to save the configuration: %s" % write_result['response']['err']['msg'])


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/a10_server.py
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

When `write_config` is set to no (default value), we should not try to write the configuration to the server.

Current status makes totally impossible to use a lower privileged account (with no write permissions) to dynamically add or remove hosts from the load balancer pool.

This change makes the `a10_server` behave as other a10 modules (`a10_service_group` and `a10_virtual_server`) where a user without write access can make temporary changes to the load balancer configuration.
