### PR TITLE
Add path type in homebrew 'path' option

### DIFF
--- a/packaging/os/homebrew.py
+++ b/packaging/os/homebrew.py
@@ -791,6 +791,7 @@ def main():
             path=dict(
                 default="/usr/local/bin",
                 required=False,
+                type='path',
             ),
             state=dict(
                 default="present",


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

homebrew
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 420a2f11af) last updated 2016/08/06 12:40:17 (GMT -500)
  lib/ansible/modules/core: (devel d05ed8e2d8) last updated 2016/08/06 12:42:33 (GMT -500)
  lib/ansible/modules/extras: (devel 73a3cd6aeb) last updated 2016/08/06 12:42:01 (GMT -500)
  config file = /Users/Indrajit/Projects/Personal/ansible-config/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Added  `type='path'` in homebrew 'path' option (inspired by @resmo's [comment](https://github.com/ansible/ansible-modules-extras/pull/2682#discussion_r73799487)).
