### PR TITLE
Docs: Add port range in ufw examples.

### DIFF
--- a/system/ufw.py
+++ b/system/ufw.py
@@ -153,6 +153,9 @@ ufw: rule=allow name=OpenSSH delete=yes
 # Deny all access to port 53:
 ufw: rule=deny port=53
 
+# Allow port range 60000-61000
+ufw: rule=allow port=60000:61000
+
 # Allow all access to tcp port 80:
 ufw: rule=allow port=80 proto=tcp
 


### PR DESCRIPTION
Adds small port range example in the docs.
