### PR TITLE
limit scope of install.ps1 to fix chocolatey install not returning $result.change = $true

### DIFF
--- a/windows/win_chocolatey.ps1
+++ b/windows/win_chocolatey.ps1
@@ -59,7 +59,8 @@ Function Chocolatey-Install-Upgrade
     if ($ChocoAlreadyInstalled -eq $null)
     {
         #We need to install chocolatey
-        iex ((new-object net.webclient).DownloadString("https://chocolatey.org/install.ps1"))
+        (New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1') |out-file $env:temp\install.ps1
+        & $env:temp\install.ps1
         $result.changed = $true
         $script:executable = "C:\ProgramData\chocolatey\bin\choco.exe"
     }


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

win_chocolatey.ps1
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2.0
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

new install.ps1 for chocolatey from 
https://chocolatey.org/install.ps1
has changed and now uses $result variable inside the script. This script is compromising the $result from the win_chocolatey.ps1 and failing the initial install of any packages. 

idea is to download the file and restrict the scope of execution with "&" so it does not contaminate the variable. 

snip from the install.ps1 

```
if ($url -eq $null -or $url -eq '') {
  Write-Output "Getting latest version of the Chocolatey package for download."
  $url = 'https://chocolatey.org/api/v2/Packages()?$filter=((Id%20eq%20%27chocolatey%27)%20and%20(not%20IsPrerelease))%20and%20IsLatestVersion'
  [xml]$result = Download-String $url
  $url = $result.feed.entry.content.src
}
```

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Before the fix

```
{"changed":false,"msg":"Exception setting \"changed\": \"The property \u0027changed\u0027 cannot be found on this object. Verify that the property exists and can be set.\"","failed":true}
```

After the fix

```
{"changed":true}
```
