### PR TITLE
Update xenserver_facts module to work with xenserver 6.5

### DIFF
--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -129,25 +129,27 @@ def change_keys(recs, key='uuid', filter_func=None):
 
 def get_host(session):
     """Get the host"""
-    host_recs = session.xenapi.host.get_all()
+    host_recs = session.xenapi.host.get_all_records()
     # We only have one host, so just return its entry
     return session.xenapi.host.get_record(host_recs[0])
 
 def get_vms(session):
     xs_vms = {}
-    recs = session.xenapi.VM.get_all()
+    recs = session.xenapi.VM.get_all_records()
     if not recs:
         return None
 
     vms = change_keys(recs, key='uuid')
     for vm in vms.itervalues():
+       for k in vm.keys():
+           vm[k] = str(vm[k])
        xs_vms[vm['name_label']] = vm
     return xs_vms
 
 
 def get_srs(session):
     xs_srs = {}
-    recs = session.xenapi.SR.get_all()
+    recs = session.xenapi.SR.get_all_records()
     if not recs:
         return None
     srs = change_keys(recs, key='uuid')

--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -190,7 +190,7 @@ def main():
     if xs_srs:
         data['xs_srs'] = xs_srs
 
-    module.exit_json(ansible=data)
+    module.exit_json(ansible_facts=data)
 
 from ansible.module_utils.basic import *
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- xenserver_facts
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

xenserver_facts did not work with XenServer 6.5 because it appears than XenAPI have changed 
some data structures. This update makes changes that make it work with 6.5. I am not certain whether it still works with XenServer < 6.5 as I have no such servers to test with, so it would be great if someone can test that. 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Before this change, running against XenServer 6.5 yields the following error:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: AttributeError: 'list' object has no attribute 'iteritems'
dc4virt2 | FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_GYY4_W/ansible_module_xenserver_facts.py\", line 195, in ?\n    main()\n  File \"/tmp/ansible_GYY4_W/ansible_module_xenserver_facts.py\", line 175, in main\n    xs_vms = get_vms(session)\n  File \"/tmp/ansible_GYY4_W/ansible_module_xenserver_facts.py\", line 142, in get_vms\n    vms = change_keys(recs, key='uuid')\n  File \"/tmp/ansible_GYY4_W/ansible_module_xenserver_facts.py\", line 121, in change_keys\n    for ref, rec in recs.iteritems():\nAttributeError: 'list' object has no attribute 'iteritems'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE",
    "parsed": false
}
```

After this change, running against XenServer 6.5 yields a full set of gathered facts for XenServer VMs.
