### PR TITLE
add php_module for PHP module management on Debian/Ubuntu

### DIFF
--- a/web_infrastructure/php_module.py
+++ b/web_infrastructure/php_module.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+#coding: utf-8 -*-
+
+# (c) 2016, Wong Hoi Sing Edison <hswong3i@pantarei-design.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: php_module
+version_added: 2.2
+author: "Wong Hoi Sing Edison (@hswong3i)"
+short_description: enables/disables a module of the PHP
+description:
+   - Enables or disables a specified module of the PHP.
+options:
+   name:
+     description:
+        - name of the module to enable/disable
+     required: true
+   state:
+     description:
+        - indicate the desired state of the resource
+     choices: ['present', 'absent']
+     default: present
+
+requirements: ["phpenmod","phpdismod"]
+'''
+
+EXAMPLES = '''
+# enables the PHP module "gd"
+- php_module: state=present name=gd
+
+# disables the PHP module "gd"
+- php_module: state=absent name=gd
+'''
+
+RETURN = '''
+'''
+
+import re
+
+def _check_module(module):
+    name = module.params['name']
+
+    result, stdout, stderr = module.run_command("%s -m %s" % (module.get_bin_path('phpenmod'), name))
+    
+    if re.search(r'Not enabling the ' + name + r' module', stderr):
+        return 'absent'
+    else:
+        return 'present'
+
+def _enable_module(module):
+    name = module.params['name']
+    state = module.params['state']
+    
+    current_state = _check_module(module)
+
+    result, stdout, stderr = module.run_command("%s %s" % (module.get_bin_path('phpenmod'), name))
+    
+    if result != 0:
+        module.fail_json(msg="Failed to enable %s: %s" % (name, stdout))
+    else:
+        module.exit_json(changed = (current_state != state), result = "%s %s" % (name, state))
+
+def _disable_module(module):
+    name = module.params['name']
+    state = module.params['state']
+    
+    current_state = _check_module(module)
+    
+    result, stdout, stderr = module.run_command("%s %s" % (module.get_bin_path('phpdismod'), name))
+    
+    if result != 0:
+        module.fail_json(msg="Failed to disable %s: %s" % (name, stdout))
+    else:
+        module.exit_json(changed = (current_state != state), result = "%s %s" % (name, state))
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name  = dict(required=True),
+            state = dict(default='present', choices=['absent', 'present'])
+        ),
+        supports_check_mode = True,
+    )
+
+    for binary in ['phpenmod', 'phpdismod']:
+        bin_path = module.get_bin_path(binary)
+        if bin_path is None:
+            module.fail_json(msg = "%s not found" % binary)
+
+    if module.check_mode:
+        module.exit_json(changed = (_check_module(module) != module.params['state']))
+
+    if module.params['state']  == 'present':
+        _enable_module(module)
+    
+    if module.params['state']  == 'absent':
+        _disable_module(module)
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

php_module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Clone apache2_module for Debian/Ubuntu as php_module, handling PHP module enable/disable management with phpenmod/phpdismod.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
