### PR TITLE
Adds documentation fragment to bigip modules

### DIFF
--- a/network/f5/bigip_facts.py
+++ b/network/f5/bigip_facts.py
@@ -36,44 +36,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  password:
-    description:
-      - BIG-IP password
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites.  Prior to 2.0, this module would always
-        validate on python >= 2.7.9 and never validate on python <= 2.7.8
-    required: false
-    default: yes
-    choices:
-      - yes
-      - no
-    version_added: 2.0
   session:
     description:
       - BIG-IP session support; may be useful to avoid concurrency
@@ -115,6 +77,7 @@ options:
     default: null
     choices: []
     aliases: []
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_gtm_virtual_server.py
+++ b/network/f5/bigip_gtm_virtual_server.py
@@ -37,23 +37,6 @@ notes:
 requirements:
     - bigsuds
 options:
-    server:
-        description:
-            - BIG-IP host
-        required: true
-    server_port:
-        description:
-            - BIG-IP server port
-        required: false
-        default: 443
-    user:
-        description:
-            - BIG-IP username
-        required: true
-    password:
-        description:
-            - BIG-IP password
-        required: true
     state:
         description:
             - Virtual server state
@@ -79,6 +62,7 @@ options:
             - Virtual server port
         required: false
         default: None
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_gtm_wide_ip.py
+++ b/network/f5/bigip_gtm_wide_ip.py
@@ -37,24 +37,6 @@ notes:
 requirements:
     - bigsuds
 options:
-    server:
-        description:
-            - BIG-IP host
-        required: true
-    server_port:
-        description:
-            - BIG-IP server port
-        required: false
-        default: 443
-        version_added: "2.2"
-    user:
-        description:
-            - BIG-IP username
-        required: true
-    password:
-        description:
-            - BIG-IP password
-        required: true
     lb_method:
         description:
             - LB method of wide ip
@@ -64,17 +46,11 @@ options:
                       'vs_capacity', 'least_conn', 'lowest_rtt', 'lowest_hops',
                       'packet_rate', 'cpu', 'hit_ratio', 'qos', 'bps',
                       'drop_packet', 'explicit_ip', 'connection_rate', 'vs_score']
-    validate_certs:
-        description:
-            - If C(no), SSL certificates will not be validated. This should only be
-              used on personally controlled sites using self-signed certificates.
-        required: false
-        default: true
-        version_added: "2.2"
     wide_ip:
         description:
             - Wide IP name
         required: true
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_monitor_http.py
+++ b/network/f5/bigip_monitor_http.py
@@ -38,38 +38,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-    default: null
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-    default: null
-  password:
-    description:
-      - BIG-IP password
-    required: true
-    default: null
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites.  Prior to 2.0, this module would always
-        validate on python >= 2.7.9 and never validate on python <= 2.7.8
-    required: false
-    default: 'yes'
-    choices:
-      - yes
-      - no
-    version_added: 2.0
   state:
     description:
       - Monitor state
@@ -153,6 +121,7 @@ options:
         from the node. The default API setting is 0.
     required: false
     default: none
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_monitor_tcp.py
+++ b/network/f5/bigip_monitor_tcp.py
@@ -36,38 +36,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-    default: null
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-    default: null
-  password:
-    description:
-      - BIG-IP password
-    required: true
-    default: null
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites.  Prior to 2.0, this module would always
-        validate on python >= 2.7.9 and never validate on python <= 2.7.8
-    required: false
-    default: 'yes'
-    choices:
-      - yes
-      - no
-    version_added: 2.0
   state:
     description:
       - Monitor state
@@ -159,6 +127,7 @@ options:
         from the node. The default API setting is 0.
     required: false
     default: none
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_node.py
+++ b/network/f5/bigip_node.py
@@ -35,42 +35,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  password:
-    description:
-      - BIG-IP password
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites.  Prior to 2.0, this module would always
-        validate on python >= 2.7.9 and never validate on python <= 2.7.8
-    required: false
-    default: 'yes'
-    choices: ['yes', 'no']
-    version_added: 2.0
   state:
     description:
       - Pool member state
@@ -144,6 +108,7 @@ options:
     required: false
     default: null
     choices: []
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_pool.py
+++ b/network/f5/bigip_pool.py
@@ -35,44 +35,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  password:
-    description:
-      - BIG-IP password
-    required: true
-    default: null
-    choices: []
-    aliases: []
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites.  Prior to 2.0, this module would always
-        validate on python >= 2.7.9 and never validate on python <= 2.7.8
-    required: false
-    default: 'yes'
-    choices:
-      - yes
-      - no
-    version_added: 2.0
   state:
     description:
       - Pool/pool member state
@@ -194,6 +156,7 @@ options:
     default: null
     choices: []
     aliases: []
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_pool_member.py
+++ b/network/f5/bigip_pool_member.py
@@ -36,35 +36,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-  password:
-    description:
-      - BIG-IP password
-    required: true
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites.  Prior to 2.0, this module would always
-        validate on python >= 2.7.9 and never validate on python <= 2.7.8
-    required: false
-    default: 'yes'
-    choices:
-      - yes
-      - no
-    version_added: 2.0
   state:
     description:
       - Pool member state
@@ -145,6 +116,7 @@ options:
       - yes
       - no
     version_added: 2.1
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''

--- a/network/f5/bigip_virtual_server.py
+++ b/network/f5/bigip_virtual_server.py
@@ -35,33 +35,6 @@ notes:
 requirements:
   - bigsuds
 options:
-  server:
-    description:
-      - BIG-IP host
-    required: true
-  server_port:
-    description:
-      - BIG-IP server port
-    required: false
-    default: 443
-    version_added: "2.2"
-  user:
-    description:
-      - BIG-IP username
-    required: true
-  password:
-    description:
-      - BIG-IP password
-    required: true
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled sites using self-signed certificates.
-    required: false
-    default: 'yes'
-    choices:
-      - yes
-      - no
   state:
     description:
       - Virtual Server state
@@ -133,6 +106,7 @@ options:
       - Virtual server description
     required: false
     default: None
+extends_documentation_fragment: f5
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

bigip_\* modules in network/f5
##### ANSIBLE VERSION

```
ansible 2.1.0.0
```
##### SUMMARY

This patch removes the common documentation bits and replaces them
with a doc fragment that already exists in core
