### PR TITLE
Fix vmware_dvs_portgroup destroy task

### DIFF
--- a/cloud/vmware/vmware_dvs_portgroup.py
+++ b/cloud/vmware/vmware_dvs_portgroup.py
@@ -68,7 +68,7 @@ EXAMPLES = '''
         password: vcenter_password
         portgroup_name: Management
         switch_name: dvSwitch
-        vlan_id: 123 
+        vlan_id: 123
         num_ports: 120
         portgroup_type: earlyBinding
         state: present
@@ -93,7 +93,7 @@ class VMwareDvsPortgroup(object):
         self.dv_switch = None
         self.state = self.module.params['state']
         self.content = connect_to_api(module)
-        
+
     def process_state(self):
         try:
             dvspg_states = {
@@ -143,7 +143,7 @@ class VMwareDvsPortgroup(object):
         result = None
 
         if not self.module.check_mode:
-            task = dvs_portgroup.Destroy_Task()
+            task = self.dvs_portgroup.Destroy_Task()
             changed, result = wait_for_task(task)
         self.module.exit_json(changed=changed, result=str(result))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

vmware_dvs_portgroup module
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Minor change to fix the dvs portgroup destroy task syntax.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
[root@rhel72 test]# ../ansible/hacking/test-module -m vmware_dvs_portgroup.py -a "hostname=10.0.10.10 username=root password=xxxxxx portgroup_name=Test-Group switch_name=dvSwitch vlan_id=130 num_ports=120 portgroup_type=earlyBinding state=present"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ziploader module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"invocation": {"module_args": {"username": "root", "portgroup_name": "Test-Group", "portgroup_type": "earlyBinding", "hostname": "10.0.10.10", "state": "present", "num_ports": 120, "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "validate_certs": true, "switch_name": "dvSwitch", "vlan_id": 130}}, "changed": true, "result": "None"}

/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)

***********************************
PARSED OUTPUT
{
    "changed": true,
    "invocation": {
        "module_args": {
            "hostname": "10.0.10.10",
            "num_ports": 120,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "portgroup_name": "Test-Group",
            "portgroup_type": "earlyBinding",
            "state": "present",
            "switch_name": "dvSwitch",
            "username": "root",
            "validate_certs": true,
            "vlan_id": 130
        }
    },
    "result": "None"
}
[root@rhel72 test]# ../ansible/hacking/test-module -m vmware_dvs_portgroup.py -a "hostname=10.0.10.10 username=root password=xxxxxxx portgroup_name=Test-Group switch_name=dvSwitch vlan_id=130 num_ports=120 portgroup_type=earlyBinding state=absent"
* including generated source, if any, saving to: /root/.ansible_module_generated
* ziploader module detected; extracted module source to: /root/debug_dir
***********************************
RAW OUTPUT

{"invocation": {"module_args": {"username": "root", "portgroup_name": "Test-Group", "portgroup_type": "earlyBinding", "hostname": "10.0.10.10", "state": "absent", "num_ports": 120, "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", "validate_certs": true, "switch_name": "dvSwitch", "vlan_id": 130}}, "changed": true, "result": "None"}

/usr/lib/python2.7/site-packages/requests/packages/urllib3/connectionpool.py:838: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/security.html
  InsecureRequestWarning)

***********************************
PARSED OUTPUT
{
    "changed": true,
    "invocation": {
        "module_args": {
            "hostname": "10.0.10.10",
            "num_ports": 120,
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "portgroup_name": "Test-Group",
            "portgroup_type": "earlyBinding",
            "state": "absent",
            "switch_name": "dvSwitch",
            "username": "root",
            "validate_certs": true,
            "vlan_id": 130
        }
    },
    "result": "None"
}
```

Fixes #2761
