### PR TITLE
Campfire module fails if the notify option is not set

### DIFF
--- a/notification/campfire.py
+++ b/notification/campfire.py
@@ -117,14 +117,14 @@ def main():
     # Send some audible notification if requested
     if notify:
         response, info = fetch_url(module, target_url, data=NSTR % cgi.escape(notify), headers=headers)
-        if info['status'] != 200:
+        if info['status'] != 201:
             module.fail_json(msg="unable to send msg: '%s', campfire api"
                                 " returned error code: '%s'" %
                                  (notify, info['status']))
 
     # Send the message
     response, info = fetch_url(module, target_url, data=MSTR %cgi.escape(msg), headers=headers)
-    if info['status'] != 200:
+    if info['status'] != 201:
         module.fail_json(msg="unable to send msg: '%s', campfire api"
                             " returned error code: '%s'" %
                              (msg, info['status']))

--- a/notification/campfire.py
+++ b/notification/campfire.py
@@ -117,10 +117,10 @@ def main():
     # Send some audible notification if requested
     if notify:
         response, info = fetch_url(module, target_url, data=NSTR % cgi.escape(notify), headers=headers)
-    if info['status'] != 200:
-        module.fail_json(msg="unable to send msg: '%s', campfire api"
-                            " returned error code: '%s'" %
-                             (notify, info['status']))
+        if info['status'] != 200:
+            module.fail_json(msg="unable to send msg: '%s', campfire api"
+                                " returned error code: '%s'" %
+                                 (notify, info['status']))
 
     # Send the message
     response, info = fetch_url(module, target_url, data=MSTR %cgi.escape(msg), headers=headers)


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

campfire
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /Users/frederikfix/src/konvenit/ansiblator/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Running the campfire module without specifying the `notify` option causes the following crash:

```
TASK [Notify campfire chat] ****************************************************
task path: notify_deploy.yml:46
<x.x.x.x> ESTABLISH SSH CONNECTION FOR USER: root
<x.x.x.x> SSH: EXEC sshpass -d103 ssh -C -q -o ForwardAgent=yes -o StrictHostKeyChecking=no -o User=root -o ConnectTimeout=10 x.x.x.x '/bin/sh -c '"'"'LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 LC_MESSAGES=en_US.UTF-8 /usr/bin/python && sleep 0'"'"''
An exception occurred during task execution. The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_TKXDMN/ansible_module_campfire.py", line 138, in <module>
    main()
  File "/tmp/ansible_TKXDMN/ansible_module_campfire.py", line 120, in main
    if info['status'] != 200:
UnboundLocalError: local variable 'info' referenced before assignment

fatal: [xxxx]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "campfire"}, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_TKXDMN/ansible_module_campfire.py\", line 138, in <module>\n    main()\n  File \"/tmp/ansible_TKXDMN/ansible_module_campfire.py\", line 120, in main\n    if info['status'] != 200:\nUnboundLocalError: local variable 'info' referenced before assignment\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

To reproduce use this definition:

```
- name: Notify campfire chat
  campfire:
    subscription: "{{ campfire_subscription }}"
    token: "{{ campfire_token }}"
    room: "{{ campfire_room }}"
    msg: "some message"
```

Furthermore the module checks for the wrong response code. As specified (https://github.com/basecamp/campfire-api/blob/master/sections/messages.md) the success response code is 201.
