### PR TITLE
Set explicit type for vmware maintenancemode timeout

### DIFF
--- a/cloud/vmware/vmware_maintenancemode.py
+++ b/cloud/vmware/vmware_maintenancemode.py
@@ -178,7 +178,7 @@ def main():
                                            'evacuateAllData',
                                            'noAction']),
         evacuate=dict(required=False, type='bool', default=False),
-        timeout=dict(required=False, default=0),
+        timeout=dict(required=False, default=0, type='int'),
         state=dict(required=False,
                    default='present',
                    choices=['present', 'absent'])))


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/vmware/vmware_maintenancemode.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/root/']
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

vmware_maintenancemode.py needs explicit type for timeout, otherwise it reads timeout as string and breaks.

<!--- Paste verbatim command output below, e.g. before and after your change -->

**BEFORE**

```
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "invocation": {"module_name": "vmware_maintenancemodeV2"}, "module_stderr": "/usr/lib/python2.7/site-packages/urllib3/connectionpool.py:769: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.org/en/latest/security.html\n  InsecureRequestWarning)\nTraceback (most recent call last):\n  File \"/tmp/ansible_XYegBq/ansible_module_vmware_maintenancemodeV2.py\", line 213, in <module>\n    main()\n  File \"/tmp/ansible_XYegBq/ansible_module_vmware_maintenancemodeV2.py\", line 200, in main\n    result = EnterMaintenanceMode(module, host)\n  File \"/tmp/ansible_XYegBq/ansible_module_vmware_maintenancemodeV2.py\", line 132, in EnterMaintenanceMode\n    spec)\n  File \"/usr/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py\", line 566, in <lambda>\n    self.f(*(self.args + (obj,) + args), **kwargs)\n  File \"/usr/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py\", line 374, in _InvokeMethod\n    map(CheckField, info.params, args)\n  File \"/usr/lib/python2.7/site-packages/pyVmomi/VmomiSupport.py\", line 949, in CheckField\n    % (info.name, info.type.__name__, valType.__name__))\nTypeError: For \"timeout\" expected type int, but got str\n", "module_stdout": "", "msg": "MODULE FAILURE", "parsed": false}
```

**AFTER**

```
localhost                  : ok=2    changed=1    unreachable=0    failed=0
```
