### PR TITLE
gluster_volume module parses out additional hostnames provided by "gluster peer status" command [#1405]

### DIFF
--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -181,16 +181,24 @@ def get_peers():
     hostname = None
     uuid = None
     state = None
+    shortNames = False
     for row in out.split('\n'):
         if ': ' in row:
             key, value = row.split(': ')
             if key.lower() == 'hostname':
                 hostname = value
+                shortNames = False
             if key.lower() == 'uuid':
                 uuid = value
             if key.lower() == 'state':
                 state = value
                 peers[hostname] = [ uuid, state ]
+        elif row.lower() == 'other names:':
+            shortNames = True
+        elif row != '' and shortNames == True:
+            peers[row] = [ uuid, state ]
+        elif row == '':
+            shortNames = False
     return peers
 
 def get_volumes():


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

gluster_volume.py
##### ANSIBLE VERSION

```
ansible 2.1.2.0 (stable-2.1 c9b212c5bd) last updated 2016/08/30 09:30:45 (GMT +300)
  lib/ansible/modules/core: (detached HEAD edbd108b15) last updated 2016/08/30 09:30:59 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD ebd0d64ea3) last updated 2016/08/30 09:31:58 (GMT +300)
  config file = /Users/cqx874/ansible/afunix.org/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #1405 

`gluster_volume` module uses `gluster peer status` command to detect hosts which have been already added to the cluster and executes `gluster peer probe <name>` command to add new nodes to the cluster.

`gluster peer status` outputs FQDN hostname in `Hostname:` field and lists other names (eg: short hostnames) after `other names:` line, eg:

```
Number of Peers: 2

Hostname: emma.int.prhv.afunix.org
Uuid: c536dce8-dda8-4a66-a840-2eea709572da
State: Peer in Cluster (Connected)
Other names:
emma

Hostname: amanda.int.prhv.afunix.org
Uuid: c6654b8f-3ca8-424f-8d0f-7c0b7d8108cc
State: Peer in Cluster (Connected)
Other names:
amanda
```

Before changes of this pull request `gluster_volume` module compared only FQDN names against records in `cluster` argument.

Changes of this pull request add short names to the list of peers allowing to fill `cluster` argument of the module with short names.
