### PR TITLE
gluster_volume adds replica and stripe arguments when adding bricks [#2754]

### DIFF
--- a/system/gluster_volume.py
+++ b/system/gluster_volume.py
@@ -291,8 +291,14 @@ def stop_volume(name):
 def set_volume_option(name, option, parameter):
     run_gluster([ 'volume', 'set', name, option, parameter ])
 
-def add_bricks(name, new_bricks, force):
+def add_bricks(name, new_bricks, stripe, replica, force):
     args = [ 'volume', 'add-brick', name ]
+    if stripe:
+        args.append('stripe')
+        args.append(str(stripe))
+    if replica:
+        args.append('replica')
+        args.append(str(replica))
     args.extend(new_bricks)
     if force:
         args.append('force')
@@ -415,7 +421,7 @@ def main():
                     removed_bricks.append(brick)
 
             if new_bricks:
-                add_bricks(volume_name, new_bricks, force)
+                add_bricks(volume_name, new_bricks, stripes, replicas, force)
                 changed = True
 
             # handle quotas


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

gluster_volume
##### ANSIBLE VERSION

```
ansible 2.1.2.0 (stable-2.1 c9b212c5bd) last updated 2016/08/30 09:30:45 (GMT +300)
  lib/ansible/modules/core: (detached HEAD edbd108b15) last updated 2016/08/30 09:30:59 (GMT +300)
  lib/ansible/modules/extras: (detached HEAD 503158a82c) last updated 2016/08/30 09:35:12 (GMT +300)
  config file = /Users/cqx874/ansible/afunix.org/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Fixes #2754 

Before the change `gluster_volume` module executed `gluster` with incorrect parameters when tried to expand a volume:
`gluster volume add-brick XXX HOST:PATH force`

The changes of pull request add additional arguments to the command:
`gluster volume add-brick XXX replica N HOST:PATH force`
or
`gluster volume add-brick XXX stripe M HOST:PATH force`
or
`gluster volume add-brick XXX stripe M replica N HOST:PATH force`
