### PR TITLE
univention udm_user: override password history.

### DIFF
--- a/univention/udm_user.py
+++ b/univention/udm_user.py
@@ -184,16 +184,18 @@ options:
         default: None
         description:
             - Organisation
-    overridePWHistory:
+    override_pw_history:
         required: false
         default: False
         description:
             - Override password history
-    overridePWLength:
+        aliases: [ overridePWHistory ]
+    override_pw_length:
         required: false
         default: False
         description:
             - Override password check
+        aliases: [ overridePWLength ]
     pager_telephonenumber:
         required: false
         default: []
@@ -401,9 +403,11 @@ def main():
             organisation            = dict(default=None,
                                            type='str'),
             overridePWHistory       = dict(default=False,
-                                           type='bool'),
+                                           type='bool',
+                                           aliases=['override_pw_history']),
             overridePWLength        = dict(default=False,
-                                           type='bool'),
+                                           type='bool',
+                                           aliases=['override_pw_length']),
             pager_telephonenumber   = dict(default=[],
                                            type='list',
                                            aliases=['pagerTelephonenumber']),

--- a/univention/udm_user.py
+++ b/univention/udm_user.py
@@ -184,6 +184,16 @@ options:
         default: None
         description:
             - Organisation
+    overridePWHistory:
+        required: false
+        default: False
+        description:
+            - Override password history
+    overridePWLength:
+        required: false
+        default: False
+        description:
+            - Override password check
     pager_telephonenumber:
         required: false
         default: []
@@ -390,6 +400,10 @@ def main():
                                            aliases=['mobileTelephoneNumber']),
             organisation            = dict(default=None,
                                            type='str'),
+            overridePWHistory       = dict(default=False,
+                                           type='bool'),
+            overridePWLength        = dict(default=False,
+                                           type='bool'),
             pager_telephonenumber   = dict(default=[],
                                            type='list',
                                            aliases=['pagerTelephonenumber']),
@@ -496,6 +510,7 @@ def main():
             for k in obj.keys():
                 if (k != 'password' and
                         k != 'groups' and
+                        k != 'overridePWHistory' and
                         k in module.params and
                         module.params[k] is not None):
                     obj[k] = module.params[k]
@@ -507,6 +522,8 @@ def main():
             else:
                 old_password = obj['password'].split('}', 2)[1]
                 if crypt.crypt(password, old_password) != old_password:
+                    obj['overridePWHistory'] = module.params['overridePWHistory']
+                    obj['overridePWLength']  = module.params['overridePWLength']
                     obj['password'] = password
 
             diff = obj.diff()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

udm_user
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

The  ansible module fails, if there is a password change, which changes the password back to an old one or if the password is too short. To override this options, there are API parameters.
With that PR it's possible to enable password overriding and disable password strength test.
