### PR TITLE
Make sure we don't catch rc=0 as a timeout

### DIFF
--- a/commands/expect.py
+++ b/commands/expect.py
@@ -224,7 +224,7 @@ def main():
         changed=True,
     )
 
-    if rc:
+    if rc is not None:
         module.exit_json(**ret)
     else:
         ret['msg'] = 'command exceeded timeout'


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

expect.py
##### ANSIBLE VERSION

```
v2.2
```
##### SUMMARY

Extension of https://github.com/ansible/ansible-modules-extras/pull/2485, ensures we don't catch rc=0 as a timeout.
