### PR TITLE
Aws ElasticTranscoder Preset

### DIFF
--- a/cloud/amazon/transcoder_preset.py
+++ b/cloud/amazon/transcoder_preset.py
@@ -18,7 +18,7 @@ DOCUMENTATION = '''
 ---
 module: transcoder_preset
 short_description: Manage AWS ElasticTranscoder presets
-version_added: "2.1.1"
+version_added: "2.2"
 description:
   - Create or delete ElasticTranscoder Presets. Preset will be created only if one with the specified name does not exist in AWS.
     If recreate option is set to True, the existing preset will be deleted first, and then created again.

--- a/cloud/amazon/transcoder_preset.py
+++ b/cloud/amazon/transcoder_preset.py
@@ -15,6 +15,7 @@
 # along with this library.  If not, see <http://www.gnu.org/licenses/>.
 
 DOCUMENTATION = '''
+---
 module: transcoder_preset
 short_description: Manage AWS ElasticTranscoder presets
 version_added: "2.1.1"

--- a/cloud/amazon/transcoder_preset.py
+++ b/cloud/amazon/transcoder_preset.py
@@ -1,0 +1,338 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# This is a free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Ansible library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+module: transcoder_preset
+short_description: Create, or delete AWS ElasticTranscoder Preset
+version_added: "2.1.1"
+description:
+  - Create or delete ElasticTranscoder Presets. Preset will be created only if one with the specified name does not exist.
+    If recreate option is set to true, the existing preset will be deleted first, and then created again.
+
+    Please note, preset names are not unique in AWS, but their Id-s are. This module is using using the preset names to manage them in AWS, and maintain their uniqness.
+    Arguably, the preset names are easier for humans (read developers) to refer to, especialy when one needs to work with the same presets accross different AWS accounts.
+
+    For more detils see U(http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/working-with-presets.html)
+
+author: Dimitar Georgievski, @dgeorgievski
+requirements:
+  - "boto3 >= 1.3.0"
+  - "json >= 2.0.9"
+options:
+    name:
+        description:
+            - Name of the preset.
+        required: False
+    description:
+        description:
+            - Description of the preset.
+        required: False
+    state:
+        description:
+            - Create or delete the preset
+        required: false
+        choices: ['present', 'absent']
+        default: 'present'
+    recreate:
+        description
+            - If set to true and state equals to present, recreate the preset by deleting it first.
+              Unfortunately, presets could not be updated in AWS.
+        required: False
+        choices: [true, false]
+        default: false
+    container:
+        description:
+            - The  container  type  for  the output file
+        choices: ['flac', 'flv', 'fmp4', 'gif', 'mp3', 'mp4', 'mpg', 'mxf', 'oga', 'ogg', 'ts', 'webm']
+        required: true
+        default: None
+    preset_template:
+        description:
+            - Path to json file that defines the preset template. The templace could have video, audio and/or thumbnails sections.
+        required: False
+        default: None
+'''
+
+EXAMPLES = '''
+
+- name: Create Preset
+  transcoder_preset:
+    name: "test_300_sd_video"
+    description: "Preset test"
+    container: "mp4"
+    preset_template: "roles/cloudformation/files/example_preset_video.json"
+
+- name: Recreate Preset
+  transcoder_preset:
+    name: "test_preset"
+    description: "Preset test"
+    container: "mp4"
+    recreate: true
+    preset_template: "roles/cloudformation/files/example_preset_video.json"
+
+- name: Delete Preset
+  transcoder_preset:
+    name: "test_preset"
+    state: absent
+
+    Where the template's JSON format is:
+    {
+      "Container": "mp4",
+      "Name": "test_600_sd",
+      "Type": "Custom",
+      "Video": { ... },
+      "Audio": { ... },
+      "Thumbnails": { ... },
+     }
+'''
+
+RETURN = '''
+name:
+    description: Preset's Name
+    returned: success
+    type: string
+    sample: "test_300_sd_video"
+id:
+    description: Preset's Id
+    returned: success
+    type: string
+    sample: "1466672939342-kdjcje"
+arn:
+    description: Preset's Arn
+    returned: success
+    type: string
+    sample: "arn:aws:elastictranscoder:us-east-1:123456789012:preset/1466672939342-kdjcje"
+msg:
+    description: Result of action
+    returned: success
+    type: string
+    sample: "Preset created successfully"
+'''
+import json
+
+try:
+    import boto3
+    from  botocore.exceptions import ClientError
+    HAS_BOTO3 = True
+except ImportError:
+    HAS_BOTO3 = False
+
+
+def cache_aws_presets(client):
+
+    paginator = client.get_paginator('list_presets')
+
+    operation_parameters = {'Ascending': 'true'}
+
+    awsPresets = {}
+
+    page_iterator = paginator.paginate(**operation_parameters)
+    for page in page_iterator:
+        next_token = page.get('NextPageToken', None)
+        if 'Presets' in page.keys():
+            for preset in page['Presets']:
+                if not preset['Name'].startswith("System preset"):
+                    awsPresets[preset['Name']] = { 'Id': preset['Id'], 'Arn': preset['Arn']}
+
+        if next_token is None:
+            break
+        else:
+            operation_parameters['PageToken'] = next_token
+
+    return awsPresets
+
+def get_preset_id(client, preset_name):
+
+    awsPresets = cache_aws_presets(client)
+
+    for name in awsPresets.keys():
+        if name == preset_name:
+            return awsPresets[name]
+
+    return {'Id': None, 'Arn': None }
+
+
+def delete_preset_by_id(client, preset_name, preset_id):
+
+    try:
+        client.delete_preset(Id=preset_id)
+    except botocore.exceptions.ClientError, e:
+        module.fail_json(msg="Failed to delete preset {0}/{1}: {2}".format(preset_name, preset_id, str(e)))
+
+
+def create_preset(client, module):
+
+    params = dict()
+    result = {'name': '',
+              'id': '',
+              'arn': '',
+              'msg': ''}
+
+    if module.params.get('name'):
+        params['Name'] = module.params.get('name')
+    else:
+        module.fail_json(msg="Missing required argument: name")
+
+    recreate = False
+    if module.params.get('recreate'):
+        recreate = module.params.get('recreate')
+
+    preset = get_preset_id(client, params['Name'])
+
+    if (preset['Id'] and not recreate):
+        result['name'] = params['Name']
+        result['id'] = preset['Id']
+        result['arn'] = preset['Arn']
+        result['msg'] = "Preset already exists"
+        return result
+
+    if preset['Id'] and recreate:
+        delete_preset_by_id(client, params['Name'], preset['Id'])
+
+    if module.params.get('description'):
+        params['Description'] = module.params.get('description')
+
+    if module.params.get('container'):
+        params['Container']=module.params.get('container')
+    else:
+        module.fail_json(msg = "Missing required argument: container")
+
+    PresetTemplate = {}
+    if module.params.get('preset_template'):
+        spec_path = module.params.get('preset_template')
+        if not os.path.isfile(spec_path):
+            module.fail_json(msg = "Wrong path for preset_template: {0}".format(spec_path))
+
+        try:
+            with open(spec_path) as f:
+                PresetTemplate = json.load(f)
+        except IOError, e:
+            module.fail_json(msg = "Can't open video_template file - " + str(e))
+
+    if 'Video' in PresetTemplate:
+        params['Video'] = PresetTemplate['Video']
+
+    if 'Audio' in PresetTemplate:
+        params['Audio'] = PresetTemplate['Audio']
+
+    if 'Thumbnails' in PresetTemplate:
+        params['Thumbnails'] = PresetTemplate['Thumbnails']
+
+    if (len(params['Video']) == 0 and
+        len(params['Audio']) == 0 and
+        len(params['Thumbnails']) == 0):
+        module.fail_json(msg="No specs provided for Video, Audio, or Thumbnails. ")
+
+    try:
+        create_result = client.create_preset(**params)
+    except botocore.exceptions.ClientError, e:
+        module.fail_json(msg="Invalid preset settings: " + str(e))
+
+    result['name'] = create_result['Preset']['Name']
+    result['id'] = create_result['Preset']['Id']
+    result['arn'] = create_result['Preset']['Arn']
+    result['msg'] = 'Preset created successfully'
+    result['changed'] = 'true'
+
+    return result
+
+def delete_preset(client, module):
+    params = dict()
+    result = {'name':'',
+            'id': '',
+            'arn': '',
+            'msg':''}
+
+    if module.params.get('name'):
+        params['Name'] = module.params.get('name')
+    else:
+        module.fail_json(msg="Missing required argument: name")
+
+    preset = get_preset_id(client, params['Name'])
+
+    if preset['Id']:
+        try:
+            client.delete_preset(Id=preset['Id'])
+        except botocore.exceptions.ClientError, e:
+            module.fail_json(msg="Failed to delete preset {0}: {1}".format(params['Name'],  e))
+
+    result['name']  = params['Name']
+    result['id'] = preset['Id']
+    result['arn'] = preset['Arn']
+    result['msg'] = 'Preset deleted successfully'
+    result['changed'] = 'true'
+
+    return result
+
+def main():
+    argument_spec = ec2_argument_spec()
+    argument_spec.update(dict(
+        name = dict(type='str', required=True),
+        description = dict(type='str'),
+        container = dict(
+            type='str',
+            default=None,
+            choices=[
+                'flac',
+                'flv',
+                 'fmp4',
+                 'gif',
+                 'mp3',
+                 'mp4',
+                 'mpg',
+                 'mxf',
+                 'oga',
+                 'ogg',
+                 'ts',
+                 'webm']),
+        state = dict(
+            type='str',
+            default='present',
+            choices=['present', 'absent']),
+        recreate = dict(
+            type='bool',
+            default=False,
+            choices=[True, False]),
+        preset_template = dict(type='str')
+        )
+    )
+
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True)
+
+    if not HAS_BOTO3:
+        module.fail_json(msg='boto3 required for this module')
+
+    try:
+        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+        transcoder = boto3_conn(module, conn_type='client', resource='elastictranscoder', region=region, endpoint=ec2_url, **aws_connect_kwargs)
+    except boto.exception.NoAuthHandlerFound, e:
+        module.fail_json(msg="Can't authorize connection - "+str(e))
+
+    invocations = {
+        'present': create_preset,
+        'absent': delete_preset,
+    }
+    results = invocations[module.params.get('state')](transcoder, module)
+
+    module.exit_json(**results)
+
+# import module snippets
+from ansible.module_utils.basic import *
+from ansible.module_utils.ec2 import *
+
+if __name__ == '__main__':
+    main()

--- a/cloud/amazon/transcoder_preset.py
+++ b/cloud/amazon/transcoder_preset.py
@@ -20,11 +20,14 @@ module: transcoder_preset
 short_description: Manage AWS ElasticTranscoder presets
 version_added: "2.1.1"
 description:
-  - Create or delete ElasticTranscoder Presets. Preset will be created only if one with the specified name does not exist.
-    If recreate option is set to true, the existing preset will be deleted first, and then created again.
+  - Create or delete ElasticTranscoder Presets. Preset will be created only if one with the specified name does not exist in AWS.
+    If recreate option is set to True, the existing preset will be deleted first, and then created again.
 
-    Please note, preset names are not unique in AWS, but their Id-s are. This module is using using the preset names to manage them in AWS, and maintain their uniqness.
-    Arguably, the preset names are easier for humans (read developers) to refer to, especialy when one needs to work with the same presets accross different AWS accounts.
+    Please note, preset names are not unique in AWS, but their Ids are. The preset names is used as
+    a unique identifier by the module to manage presets in AWS.
+
+    Arguably, the preset names are easier for humans to refer to,
+    especialy when one needs to work with the same presets accross different AWS accounts.
 
     For more detils see U(http://docs.aws.amazon.com/elastictranscoder/latest/developerguide/working-with-presets.html)
 
@@ -33,38 +36,38 @@ requirements:
   - "boto3 >= 1.3.0"
   - "json >= 2.0.9"
 options:
-    name:
-        description:
-            - Name of the preset.
-        required: False
+  name:
     description:
-        description:
-            - Description of the preset.
-        required: False
-    state:
-        description:
-            - Create or delete the preset
-        required: false
-        choices: ['present', 'absent']
-        default: 'present'
-    recreate:
-        description
-            - If set to true and state equals to present, recreate the preset by deleting it first.
-              Unfortunately, presets could not be updated in AWS.
-        required: False
-        choices: [true, false]
-        default: false
-    container:
-        description:
-            - The  container  type  for  the output file
-        choices: ['flac', 'flv', 'fmp4', 'gif', 'mp3', 'mp4', 'mpg', 'mxf', 'oga', 'ogg', 'ts', 'webm']
-        required: true
-        default: None
-    preset_document:
-        description:
-            - Path to a json document that defines the preset template. The templace could have video, audio and/or thumbnails sections.
-        required: False
-        default: None
+      - Name of the preset.
+    required: false
+  description:
+    description:
+      - Description of the preset.
+    required: false
+  state:
+    description:
+      - Create or delete the preset
+    required: false
+    choices: ['present', 'absent']
+    default: 'present'
+  recreate:
+    description:
+      - If set to true and state equals to present, recreate the preset by deleting it first.
+        Presets could not be updated in AWS.
+    required: false
+    choices: [true, false]
+    default: false
+  container:
+    description:
+      - The  container  type  for  the output file
+    choices: ['flac', 'flv', 'fmp4', 'gif', 'mp3', 'mp4', 'mpg', 'mxf', 'oga', 'ogg', 'ts', 'webm']
+    required: true
+    default: None
+  preset_document:
+    description:
+      - Path to a json document that defines the preset template. The templace could have video, audio and/or thumbnails sections.
+    required: False
+    default: None
 
 '''
 
@@ -159,7 +162,7 @@ def delete_preset_by_id(client, preset_name, preset_id):
 
     try:
         client.delete_preset(Id=preset_id)
-    except botocore.exceptions.ClientError, e:
+    except botocore.exceptions.ClientError as e:
         module.fail_json(msg="Failed to delete preset {0}/{1}: {2}".format(preset_name, preset_id, str(e)))
 
 
@@ -214,7 +217,7 @@ def create_preset(client, module):
         try:
             with open(spec_path) as f:
                 PresetTemplate = json.load(f)
-        except IOError, e:
+        except IOError as e:
             module.fail_json(msg = "Can't open video_template file - " + str(e))
 
     if 'Video' in PresetTemplate:
@@ -237,7 +240,7 @@ def create_preset(client, module):
             result['name'] = create_result['Preset']['Name']
             result['id'] = create_result['Preset']['Id']
             result['arn'] = create_result['Preset']['Arn']
-        except botocore.exceptions.ClientError, e:
+        except botocore.exceptions.ClientError as e:
             module.fail_json(msg="Invalid preset settings: " + str(e))
 
     result['msg'] = 'Preset created successfully'
@@ -272,7 +275,7 @@ def delete_preset(client, module):
         if not module.check_mode:
             try:
                 client.delete_preset(Id=PresetId)
-            except botocore.exceptions.ClientError, e:
+            except botocore.exceptions.ClientErro as e:
                 module.fail_json(msg="Failed to delete preset {0}: {1}".format(PresetName,  e))
 
     else:
@@ -326,7 +329,7 @@ def main():
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
         transcoder = boto3_conn(module, conn_type='client', resource='elastictranscoder', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except boto.exception.NoAuthHandlerFound, e:
+    except boto.exception.NoAuthHandlerFound as e:
         module.fail_json(msg="Can't authorize connection - "+str(e))
 
     invocations = {


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request

[test_600_sd.json.zip](https://github.com/ansible/ansible-modules-extras/files/447754/test_600_sd.json.zip)
##### COMPONENT NAME

   transcoder_preset
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Automate the management of AWS ElasticTranscoder presets.  The module assumes the preset names are unique, which simplifies the management of presets across different AWS accounts. 
In our case clients access the same presets by name in multiple AWS accounts.

Please note, AWS doesn't enforce preset name uniqueness. Instead it is using their Id to uniquely identify them.  

Presets could not be updated in AWS, which means a preset definition could be updated by deleting the preset first, and then creating it again (recreate: true).

The preset definition should be provided the the module in the form of a JSON document. An example is attached to this PR.

The segments of the JSON document could be used  as an input to the AWS CLI command for creating a preset:
`aws elastictranscoder create-preset`  

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
PLAY [localhost] ***************************************************************

TASK [Delete Preset] ***********************************************************
changed: [localhost] => {"arn": "arn:aws:elastictranscoder:us-east-1:12345678901:preset/1572439857191-lvl2zr", "changed": "true", "id": "1472659857191-lvl2zr", "msg": "Preset deleted successfully", "name": "test_300_sd_video"}

TASK [Create Preset] ***********************************************************
changed: [localhost] => {"arn": "arn:aws:elastictranscoder:us-east-1:12345678901:preset/1572659868197-3jinu8", "changed": "true", "id": "1472659868199-3jinu8", "msg": "Preset created successfully", "name": "test_300_sd_video"}

TASK [ReCreate Preset] *********************************************************
changed: [localhost] => {"arn": "arn:aws:elastictranscoder:us-east-1:12345678901:preset/1572659869799-l7p0ip", "changed": "true", "id": "1472659869798-l7p0ip", "msg": "Preset created successfully", "name": "test_300_sd_video"}

PLAY RECAP *********************************************************************
localhost                  : ok=3    changed=3    unreachable=0    failed=0
```
