### PR TITLE
univention/udm_share: Fix typo in EXAMPLE section

### DIFF
--- a/univention/udm_share.py
+++ b/univention/udm_share.py
@@ -375,7 +375,7 @@ options:
 
 EXAMPLES = '''
 # Create a share named home on the server ucs.example.com with the path /home.
-- udm_sahre: name=home
+- udm_share: name=home
              path=/home
              host=ucs.example.com
              sambaName=Home


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

univention/udm_share
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

There is a typo in the module name in the EXAMPLES section. This PR simply corrects the typo.
