### PR TITLE
Fix ec2_asg_facts module when using name parameter (#2840)

### DIFF
--- a/cloud/amazon/ec2_asg_facts.py
+++ b/cloud/amazon/ec2_asg_facts.py
@@ -302,7 +302,7 @@ def find_asgs(conn, module, name=None, tags=None):
     name_prog = re.compile(r'^' + name)
     for asg in asgs['AutoScalingGroups']:
         if name:
-            matched_name = name_prog.search(asg['auto_scaling_group_name'])
+            matched_name = name_prog.search(asg['AutoScalingGroupName'])
         else:
             matched_name = True
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ec2_asg_facts
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 4457985062) last updated 2016/09/02 09:55:19 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 7e79c59d38) last updated 2016/09/02 09:58:46 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD e8a5442345) last updated 2016/09/02 09:58:47 (GMT -400)
  config file = /Users/jeffreyearl/Projects/mps-platform/ansible-infrastructure/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Change name search to use the correct key int he boto3 results.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Fixes issue #2840 

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
