### PR TITLE
Bugfix bigip_facts that was trying to check the length of an iterator

### DIFF
--- a/network/f5/bigip_facts.py
+++ b/network/f5/bigip_facts.py
@@ -1641,7 +1641,7 @@ def main():
         regex = fnmatch.translate(fact_filter)
     else:
         regex = None
-    include = map(lambda x: x.lower(), module.params['include'])
+    include = [x.lower() for x in module.params['include']]
     valid_includes = ('address_class', 'certificate', 'client_ssl_profile',
                       'device', 'device_group', 'interface', 'key', 'node',
                       'pool', 'provision', 'rule', 'self_ip', 'software',


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/f5/bigip_facts.py
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Recently, a user reported that the bigip_facts module was failing with the error

```
received exception: object of type 'itertools.imap' has no len()
```

This reported was occurring at line 1657 of the bigip_facts module

bug report is here

https://github.com/F5Networks/f5-ansible/issues/25

Upon further investigation, the map function for returning the specified
includes was returning an iterator, and calling len() on an iterator does
not work.

I believe this problem was caused by part of the Python 3.x effort insofar
as the inclusion of this line

https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/basic.py#L143

seems to affect our usage of map(), probably for the better anyway, and we need
to change our expectations in our module's code to no longer assume a list, but
instead assume an iterator.

After crawling through the module_utils/basic code, I think a list
comprehension is more appropriate here anyway, so I'm changing it to be
that. The affected user reported it works this way, and my own testing
on 2.2.0 supports that.
