### PR TITLE
roll up of updates to asa_template

### DIFF
--- a/network/asa/asa_template.py
+++ b/network/asa/asa_template.py
@@ -19,7 +19,7 @@ DOCUMENTATION = """
 ---
 module: asa_template
 version_added: "2.2"
-author: "Peter Sprygada (@privateip) & Patrick Ogenstad (@ogenstad)"
+author: "Peter Sprygada (@privateip), Patrick Ogenstad (@ogenstad)"
 short_description: Manage Cisco ASA device configurations over SSH
 description:
   - Manages Cisco ASA network device configurations over SSH.  This module
@@ -115,14 +115,14 @@ responses:
   type: list
   sample: ['...', '...']
 """
-
+from ansible.module_utils.netcfg import NetworkConfig, dumps
+from ansible.module_utils.asa import NetworkModule, NetworkError
 
 def get_config(module):
     config = module.params['config'] or dict()
     if not config and not module.params['force']:
-        config = module.config
+        config = module.config.get_config()
     return config
-
 
 def main():
     """ main entry point for module execution
@@ -138,9 +138,9 @@ def main():
 
     mutually_exclusive = [('config', 'backup'), ('config', 'force')]
 
-    module = get_module(argument_spec=argument_spec,
-                        mutually_exclusive=mutually_exclusive,
-                        supports_check_mode=True)
+    module = NetworkModule(argument_spec=argument_spec,
+                           mutually_exclusive=mutually_exclusive,
+                           supports_check_mode=True)
 
     result = dict(changed=False)
 
@@ -149,17 +149,18 @@ def main():
     contents = get_config(module)
     if contents:
         config = NetworkConfig(contents=contents, indent=1)
-        result['_backup'] = contents
+        result['_backup'] = str(contents)
 
     if not module.params['force']:
         commands = candidate.difference(config)
+        commands = dumps(commands, 'commands').split('\n')
+        commands = [str(c) for c in commands if c]
     else:
         commands = str(candidate).split('\n')
 
     if commands:
         if not module.check_mode:
-            commands = [str(c).strip() for c in commands]
-            response = module.configure(commands)
+            response = module.config(commands)
             result['responses'] = response
         result['changed'] = True
 
@@ -167,9 +168,5 @@ def main():
     module.exit_json(**result)
 
 
-from ansible.module_utils.basic import *
-from ansible.module_utils.shell import *
-from ansible.module_utils.netcfg import *
-from ansible.module_utils.asa import *
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
This updates the asa_template module with updates for Ansible 2.2.
- removes get_module() in favor of NetworkModule
- fixes up import statements
