### PR TITLE
Start zypper in non-interactive mode

### DIFF
--- a/packaging/os/zypper_repository.py
+++ b/packaging/os/zypper_repository.py
@@ -129,9 +129,17 @@ REPO_OPTS = ['alias', 'name', 'priority', 'enabled', 'autorefresh', 'gpgcheck']
 
 from distutils.version import LooseVersion
 
+def _get_cmd(*args):
+    """Combines the non-interactive zypper command with arguments/subcommands"""
+    cmd = ['/usr/bin/zypper', '--quiet', '--non-interactive']
+    cmd.extend(args)
+
+    return cmd
+
+
 def _parse_repos(module):
-    """parses the output of zypper -x lr and return a parse repo dictionary"""
-    cmd = ['/usr/bin/zypper', '-x', 'lr']
+    """parses the output of zypper --xmlout repos and return a parse repo dictionary"""
+    cmd = _get_cmd('--xmlout', 'repos')
 
     from xml.dom.minidom import parseString as parseXML
     rc, stdout, stderr = module.run_command(cmd, check_rc=False)
@@ -207,7 +215,7 @@ def repo_exists(module, repodata, overwrite_multiple):
 def addmodify_repo(module, repodata, old_repos, zypper_version, warnings):
     "Adds the repo, removes old repos before, that would conflict."
     repo = repodata['url']
-    cmd = ['/usr/bin/zypper', 'ar', '--check']
+    cmd = _get_cmd('addrepo', '--check')
     if repodata['name']:
         cmd.extend(['--name', repodata['name']])
 
@@ -251,7 +259,7 @@ def addmodify_repo(module, repodata, old_repos, zypper_version, warnings):
 
 def remove_repo(module, repo):
     "Removes the repo."
-    cmd = ['/usr/bin/zypper', 'rr', repo]
+    cmd = _get_cmd('removerepo', repo)
 
     rc, stdout, stderr = module.run_command(cmd, check_rc=True)
     return rc, stdout, stderr
@@ -265,7 +273,7 @@ def get_zypper_version(module):
 
 def runrefreshrepo(module, auto_import_keys=False, shortname=None):
     "Forces zypper to refresh repo metadata."
-    cmd = ['/usr/bin/zypper', 'refresh', '--force']
+    cmd = _get_cmd('refresh', '--force')
     if auto_import_keys:
         cmd.append('--gpg-auto-import-keys')
     if shortname is not None:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

zypper_repository
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 9963ae1d3e) last updated 2016/09/02 11:02:10 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 7e79c59d38) last updated 2016/09/02 11:03:39 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD e8a5442345) last updated 2016/09/02 11:03:40 (GMT +200)
```
##### SUMMARY

zypper is running in interactive mode right now. So it asks for input in some issues.
In this PR it will be changed to run in non-interactive mode similiar like in zypper.py module.

Example: Non responsible repo
Before:

```
ansible -m zypper_repository -a 'repo=http://download.opensuse.org/repositories/devel:/languages:/python/SLE_11_SP3/devel:languages:python.repo' server1 -b
[ERROR]: User interrupted execution
```

After:

```
server1| FAILED! => {
    "changed": false,
    "failed": true,
    "msg": "Zypper failed with rc 4",
    "rc": 4,
    "repodata": {
        "alias": null,
        "autorefresh": "1",
        "enabled": "1",
        "gpgcheck": "1",
        "name": null,
        "priority": null,
        "url": "http://download.opensuse.org/repositories/devel:/languages:/python/SLE_11_SP3/devel:languages:python.repo"
    },
    "state": "present",
    "stderr": "File '/repositories/devel:/languages:/python/SLE_11_SP3/devel:languages:python.repo' not found on medium 'http://download.opensuse.org/'\n\nProblem accessing the file at the specified URI:\nFile '/repositories/devel:/languages:/python/SLE_11_SP3/devel:languages:python.repo' not found on medium 'http://download.opensuse.org/'\n\n",
    "stdout": "Abort, retry, ignore? [a/r/i/? shows all options] (a): a\n",
    "stdout_lines": [
        "Abort, retry, ignore? [a/r/i/? shows all options] (a): a"
    ],
    "warnings": []
}
```
