### PR TITLE
letsencrypt: Improve error handling

### DIFF
--- a/web_infrastructure/letsencrypt.py
+++ b/web_infrastructure/letsencrypt.py
@@ -169,14 +169,18 @@ def simple_get(module,url):
     result = None
     try:
         content = resp.read()
+    except AttributeError:
+        if info['body']:
+            content = info['body']
+
+    if content:
         if info['content-type'].startswith('application/json'):
-            result = module.from_json(content.decode('utf8'))
+            try:
+                result = module.from_json(content.decode('utf8'))
+            except ValueError:
+                module.fail_json(msg="Failed to parse the ACME response: {0} {1}".format(url,content))
         else:
             result = content
-    except AttributeError:
-        result = None
-    except ValueError:
-        module.fail_json(msg="Failed to parse the ACME response: {0} {1}".format(url,content))
 
     if info['status'] >= 400:
         module.fail_json(msg="ACME request failed: CODE: {0} RESULT:{1}".format(info['status'],result))
@@ -370,14 +374,18 @@ class ACMEAccount(object):
         result = None
         try:
             content = resp.read()
+        except AttributeError:
+            if info['body']:
+                content = info['body']
+
+        if content:
             if info['content-type'].startswith('application/json'):
-                result = self.module.from_json(content.decode('utf8'))
+                try:
+                    result = self.module.from_json(content.decode('utf8'))
+                except ValueError:
+                    self.module.fail_json(msg="Failed to parse the ACME response: {0} {1}".format(url,content))
             else:
                 result = content
-        except AttributeError:
-            result = None
-        except ValueError:
-            self.module.fail_json(msg="Failed to parse the ACME response: {0} {1}".format(url,content))
 
         return result,info
 

--- a/web_infrastructure/letsencrypt.py
+++ b/web_infrastructure/letsencrypt.py
@@ -645,7 +645,7 @@ class ACMEClient(object):
                 "keyAuthorization": keyauthorization,
             }
             result, info = self.account.send_signed_request(uri, challenge_response)
-            if info['status'] != 200:
+            if info['status'] not in [200,202]:
                 self.module.fail_json(msg="Error validating challenge: CODE: {0} RESULT: {1}".format(info['status'], result))
 
         status = ''


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

web_infrastructure/letsencrypt
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel abbb93e117) last updated 2016/09/06 23:02:31 (GMT +200)
  lib/ansible/modules/core: (detached HEAD a746eff954) last updated 2016/09/06 23:03:03 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 1474bde864) last updated 2016/09/06 23:03:03 (GMT +200)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Thanks to ansible/ansible#14915 it is now possible to get the body of a HTTPError response. Add support for the new `info['body']` field returned by `fetch_url`.

Also fix an unexpected HTTP status 202 response from the letsencrypt server when polling the challenge validation.
