### PR TITLE
Fix to fail when task_definition or desired_count not defined and sta…

### DIFF
--- a/cloud/amazon/ecs_service.py
+++ b/cloud/amazon/ecs_service.py
@@ -46,16 +46,15 @@ options:
         required: false
     task_definition:
         description:
-          - The task definition the service will run
+          - The task definition the service will run. This parameter is required when state=present
         required: false
     load_balancers:
         description:
           - The list of ELBs defined for this service
         required: false
-
     desired_count:
         description:
-          - The count of how many instances of the service
+          - The count of how many instances of the service. This parameter is required when state=present
         required: false
     client_token:
         description:
@@ -288,23 +287,30 @@ class EcsServiceManager:
     def delete_service(self, service, cluster=None):
         return self.ecs.delete_service(cluster=cluster, service=service)
 
+
 def main():
 
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-        state=dict(required=True, choices=['present', 'absent', 'deleting'] ),
-        name=dict(required=True, type='str' ),
-        cluster=dict(required=False, type='str' ),
-        task_definition=dict(required=False, type='str' ),
-        load_balancers=dict(required=False, type='list' ),
-        desired_count=dict(required=False, type='int' ),
-        client_token=dict(required=False, type='str' ),
-        role=dict(required=False, type='str' ),
+        state=dict(required=True, choices=['present', 'absent', 'deleting']),
+        name=dict(required=True, type='str'),
+        cluster=dict(required=False, type='str'),
+        task_definition=dict(required=False, type='str'),
+        load_balancers=dict(required=False, default=[], type='list'),
+        desired_count=dict(required=False, type='int'),
+        client_token=dict(required=False, default='', type='str'),
+        role=dict(required=False, default='', type='str'),
         delay=dict(required=False, type='int', default=10),
         repeat=dict(required=False, type='int', default=10)
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleModule(argument_spec=argument_spec,
+                           supports_check_mode=True,
+                           required_if=[
+                               ('state', 'present', ['task_definition', 'desired_count'])
+                           ],
+                           required_together=[['load_balancers', 'role']]
+                           )
 
     if not HAS_BOTO:
       module.fail_json(msg='boto is required.')
@@ -312,19 +318,13 @@ def main():
     if not HAS_BOTO3:
       module.fail_json(msg='boto3 is required.')
 
-    if module.params['state'] == 'present':
-        if not 'task_definition' in module.params and module.params['task_definition'] is None:
-            module.fail_json(msg="To use create a service, a task_definition must be specified")
-        if not 'desired_count' in module.params and module.params['desired_count'] is None:
-            module.fail_json(msg="To use create a service, a desired_count must be specified")
-
     service_mgr = EcsServiceManager(module)
     try:
         existing = service_mgr.describe_service(module.params['cluster'], module.params['name'])
     except Exception, e:
         module.fail_json(msg="Exception describing service '"+module.params['name']+"' in cluster '"+module.params['cluster']+"': "+str(e))
 
-    results = dict(changed=False )
+    results = dict(changed=False)
     if module.params['state'] == 'present':
 
         matching = False
@@ -338,18 +338,9 @@ def main():
 
         if not matching:
             if not module.check_mode:
-                if module.params['load_balancers'] is None:
-                    loadBalancers = []
-                else:
-                    loadBalancers = module.params['load_balancers']
-                if module.params['role'] is None:
-                    role = ''
-                else:
-                    role = module.params['role']
-                if module.params['client_token'] is None:
-                    clientToken = ''
-                else:
-                    clientToken = module.params['client_token']
+                loadBalancers = module.params['load_balancers']
+                role = module.params['role']
+                clientToken = module.params['client_token']
 
                 if update:
                     # update required


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ecs_service
##### ANSIBLE VERSION

ansible 2.1.0.0
config file = /etc/ansible/ansible.cfg
configured module search path = Default w/o overrides
##### SUMMARY

There was custom logic to stop when task_definition or desired_count not defined but it didn't work.

I moved it to the built-in Ansible required_if logic instead.

I also made a few pep8 corrections and applied sane defaults to the argument spec removed the need for multiple if statements further in the code.
