### PR TITLE
firewalld should fail nicely when service is stopped

### DIFF
--- a/system/firewalld.py
+++ b/system/firewalld.py
@@ -114,10 +114,7 @@ try:
     from firewall.client import Rich_Rule
     from firewall.client import FirewallClient
     fw = FirewallClient()
-    if not fw.connected:
-        HAS_FIREWALLD = False
-    else:
-        HAS_FIREWALLD = True
+    HAS_FIREWALLD = True
 except ImportError:
     HAS_FIREWALLD = False
 
@@ -359,6 +356,13 @@ def main():
     ## Pre-run version checking
     if FW_VERSION < "0.2.11":
         module.fail_json(msg='unsupported version of firewalld, requires >= 2.0.11')
+    ## Check for firewalld running
+    try:
+        if fw.connected == False:
+            module.fail_json(msg='firewalld service must be running')
+    except AttributeError:
+        module.fail_json(msg="firewalld connection can't be established,\
+                installed version (%s) likely too old. Requires firewalld >= 2.0.11" % FW_VERSION)
 
     ## Global Vars
     changed=False
@@ -385,14 +389,6 @@ def main():
     timeout = module.params['timeout']
     interface = module.params['interface']
     masquerade = module.params['masquerade']
-
-    ## Check for firewalld running
-    try:
-        if fw.connected == False:
-            module.fail_json(msg='firewalld service must be running')
-    except AttributeError:
-        module.fail_json(msg="firewalld connection can't be established,\
-                version likely too old. Requires firewalld >= 2.0.11")
 
     modification_count = 0
     if service != None:


### PR DESCRIPTION
- Feature Pull Request
##### COMPONENT NAME

firewalld
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel c752b25ced) last updated 2016/09/07 00:54:00 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 5a5c1491ae) last updated 2016/09/07 01:08:07 (GMT -400)
  lib/ansible/modules/extras: (devel 8bfdcfcab2) last updated 2016/09/07 01:09:04 (GMT -400)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

If firewalld is not running, it should print out a nice error message suggesting that it should be running, and not complain about potentially missing modules.

Before:

```
$ ansible -m firewalld -a "state=enabled permanent=true" localhost
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "firewalld and its python 2 module are required for this module"
}
```

After:

```
$ ansible -m firewalld -a "state=enabled permanent=true" localhost
 [WARNING]: Host file not found: /etc/ansible/hosts

 [WARNING]: provided hosts list is empty, only localhost is available

localhost | FAILED! => {
    "changed": false, 
    "failed": true, 
    "msg": "firewalld must be running to use this module"
}
```
