### PR TITLE
Enable communication to management API over HTTPS

### DIFF
--- a/messaging/rabbitmq_binding.py
+++ b/messaging/rabbitmq_binding.py
@@ -36,7 +36,7 @@ requirements: [ "requests >= 1.0.0" ]
 options:
     state:
         description:
-            - Whether the exchange should be present or absent
+            - Whether the binding should be present or absent
             - Only present implemented atm
         choices: [ "present", "absent" ]
         required: false
@@ -46,54 +46,6 @@ options:
             - source exchange to create binding on
         required: true
         aliases: [ "src", "source" ]
-    login_user:
-        description:
-            - rabbitMQ user for connection
-        required: false
-        default: guest
-    login_password:
-        description:
-            - rabbitMQ password for connection
-        required: false
-        default: false
-    login_host:
-        description:
-            - rabbitMQ host for connection
-        required: false
-        default: localhost
-    login_port:
-        description:
-            - rabbitMQ management api port
-        required: false
-        default: 15672
-    login_protocol:
-        description:
-            - rabbitMQ management api protocol
-        choices: [ http , https ]
-        required: false
-        default: http
-        version_added: "2.3"
-    cacert:
-        description:
-            - CA certificate to verify SSL connection to management API.
-        required: false
-        version_added: "2.3"
-    cert:
-        description:
-            - Client certificate to send on SSL connections to management API.
-        required: false
-        version_added: "2.3"
-    key:
-        description:
-            - Private key matching the client certificate.
-        required: false
-        version_added: "2.3"
-    vhost:
-        description:
-            - rabbitMQ virtual host
-            - default vhost is /
-        required: false
-        default: "/"
     destination:
         description:
             - destination exchange or queue for the binding
@@ -116,6 +68,7 @@ options:
             - extra arguments for exchange. If defined this argument is a key/value dictionary
         required: false
         default: {}
+extends_documentation.fragment: rabbitmq.documentation
 '''
 
 EXAMPLES = '''
@@ -138,27 +91,21 @@ import requests
 import urllib
 import json
 
+
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
-            state = dict(default='present', choices=['present', 'absent'], type='str'),
-            name = dict(required=True, aliases=[ "src", "source" ], type='str'),
-            login_user = dict(default='guest', type='str'),
-            login_password = dict(default='guest', type='str', no_log=True),
-            login_host = dict(default='localhost', type='str'),
-            login_port = dict(default='15672', type='str'),
-            login_protocol = dict(default='http', choices=['http', 'https'], type='str'),
-            cacert = dict(required=False, type='path', default=None),
-            cert = dict(required=False, type='path', default=None),
-            key = dict(required=False, type='path', default=None),
-            vhost = dict(default='/', type='str'),
-            destination = dict(required=True, aliases=[ "dst", "dest"], type='str'),
-            destination_type = dict(required=True, aliases=[ "type", "dest_type"], choices=[ "queue", "exchange" ],type='str'),
-            routing_key = dict(default='#', type='str'),
-            arguments = dict(default=dict(), type='dict')
-        ),
-        supports_check_mode = True
+
+    argument_spec = rabbitmq_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            name=dict(required=True, aliases=["src", "source"], type='str'),
+            destination=dict(required=True, aliases=["dst", "dest"], type='str'),
+            destination_type=dict(required=True, aliases=["type", "dest_type"], choices=[ "queue", "exchange" ],type='str'),
+            routing_key=dict(default='#', type='str'),
+            arguments=dict(default=dict(), type='dict')
+        )
     )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     if module.params['destination_type'] == "queue":
         dest_type="q"
@@ -260,6 +207,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.rabbitmq import *
 
 if __name__ == '__main__':
     main()

--- a/messaging/rabbitmq_binding.py
+++ b/messaging/rabbitmq_binding.py
@@ -66,6 +66,28 @@ options:
             - rabbitMQ management api port
         required: false
         default: 15672
+    login_protocol:
+        description:
+            - rabbitMQ management api protocol
+        choices: [ http , https ]
+        required: false
+        default: http
+        version_added: "2.3"
+    cacert:
+        description:
+            - CA certificate to verify SSL connection to management API.
+        required: false
+        version_added: "2.3"
+    cert:
+        description:
+            - Client certificate to send on SSL connections to management API.
+        required: false
+        version_added: "2.3"
+    key:
+        description:
+            - Private key matching the client certificate.
+        required: false
+        version_added: "2.3"
     vhost:
         description:
             - rabbitMQ virtual host
@@ -125,6 +147,10 @@ def main():
             login_password = dict(default='guest', type='str', no_log=True),
             login_host = dict(default='localhost', type='str'),
             login_port = dict(default='15672', type='str'),
+            login_protocol = dict(default='http', choices=['http', 'https'], type='str'),
+            cacert = dict(required=False, type='path', default=None),
+            cert = dict(required=False, type='path', default=None),
+            key = dict(required=False, type='path', default=None),
             vhost = dict(default='/', type='str'),
             destination = dict(required=True, aliases=[ "dst", "dest"], type='str'),
             destination_type = dict(required=True, aliases=[ "type", "dest_type"], choices=[ "queue", "exchange" ],type='str'),
@@ -144,7 +170,8 @@ def main():
     else:
         props = urllib.quote(module.params['routing_key'],'')
 
-    url = "http://%s:%s/api/bindings/%s/e/%s/%s/%s/%s" % (
+    url = "%s://%s:%s/api/bindings/%s/e/%s/%s/%s/%s" % (
+        module.params['login_protocol'],
         module.params['login_host'],
         module.params['login_port'],
         urllib.quote(module.params['vhost'],''),
@@ -155,7 +182,8 @@ def main():
     )
 
     # Check if exchange already exists
-    r = requests.get( url, auth=(module.params['login_user'],module.params['login_password']))
+    r = requests.get( url, auth=(module.params['login_user'],module.params['login_password']),
+                     verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
 
     if r.status_code==200:
         binding_exists = True
@@ -186,7 +214,8 @@ def main():
     # Do changes
     if change_required:
         if module.params['state'] == 'present':
-            url = "http://%s:%s/api/bindings/%s/e/%s/%s/%s" % (
+            url = "%s://%s:%s/api/bindings/%s/e/%s/%s/%s" % (
+                module.params['login_protocol'],
                 module.params['login_host'],
                 module.params['login_port'],
                 urllib.quote(module.params['vhost'],''),
@@ -202,10 +231,13 @@ def main():
                     data = json.dumps({
                         "routing_key": module.params['routing_key'],
                         "arguments": module.params['arguments']
-                    })
+                    }),
+                    verify=module.params['cacert'],
+                    cert=(module.params['cert'], module.params['key'])
                 )
         elif module.params['state'] == 'absent':
-            r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']))
+            r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']),
+                                verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
 
         if r.status_code == 204 or r.status_code == 201:
             module.exit_json(

--- a/messaging/rabbitmq_exchange.py
+++ b/messaging/rabbitmq_exchange.py
@@ -65,6 +65,28 @@ options:
             - rabbitMQ management api port
         required: false
         default: 15672
+    login_protocol:
+        description:
+            - rabbitMQ management api protocol
+        choices: [ http , https ]
+        required: false
+        default: http
+        version_added: "2.3"
+    cacert:
+        description:
+            - CA certificate to verify SSL connection to management API.
+        required: false
+        version_added: "2.3"
+    cert:
+        description:
+            - Client certificate to send on SSL connections to management API.
+        required: false
+        version_added: "2.3"
+    key:
+        description:
+            - Private key matching the client certificate.
+        required: false
+        version_added: "2.3"
     vhost:
         description:
             - rabbitMQ virtual host
@@ -127,6 +149,10 @@ def main():
             login_password = dict(default='guest', type='str', no_log=True),
             login_host = dict(default='localhost', type='str'),
             login_port = dict(default='15672', type='str'),
+            login_protocol = dict(default='http', choices=['http', 'https'], type='str'),
+            cacert = dict(required=False, type='path', default=None),
+            cert = dict(required=False, type='path', default=None),
+            key = dict(required=False, type='path', default=None),
             vhost = dict(default='/', type='str'),
             durable = dict(default=True, type='bool'),
             auto_delete = dict(default=False, type='bool'),
@@ -137,7 +163,8 @@ def main():
         supports_check_mode = True
     )
 
-    url = "http://%s:%s/api/exchanges/%s/%s" % (
+    url = "%s://%s:%s/api/exchanges/%s/%s" % (
+        module.params['login_protocol'],
         module.params['login_host'],
         module.params['login_port'],
         urllib.quote(module.params['vhost'],''),
@@ -145,7 +172,8 @@ def main():
     )
 
     # Check if exchange already exists
-    r = requests.get( url, auth=(module.params['login_user'],module.params['login_password']))
+    r = requests.get( url, auth=(module.params['login_user'],module.params['login_password']),
+                     verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
 
     if r.status_code==200:
         exchange_exists = True
@@ -198,10 +226,13 @@ def main():
                         "internal": module.params['internal'],
                         "type": module.params['exchange_type'],
                         "arguments": module.params['arguments']
-                    })
+                    }),
+                    verify=module.params['cacert'],
+                    cert=(module.params['cert'], module.params['key'])
                 )
         elif module.params['state'] == 'absent':
-            r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']))
+            r = requests.delete( url, auth = (module.params['login_user'],module.params['login_password']),
+                                verify=module.params['cacert'], cert=(module.params['cert'], module.params['key']))
 
         if r.status_code == 204:
             module.exit_json(

--- a/messaging/rabbitmq_exchange.py
+++ b/messaging/rabbitmq_exchange.py
@@ -45,53 +45,6 @@ options:
         choices: [ "present", "absent" ]
         required: false
         default: present
-    login_user:
-        description:
-            - rabbitMQ user for connection
-        required: false
-        default: guest
-    login_password:
-        description:
-            - rabbitMQ password for connection
-        required: false
-        default: false
-    login_host:
-        description:
-            - rabbitMQ host for connection
-        required: false
-        default: localhost
-    login_port:
-        description:
-            - rabbitMQ management api port
-        required: false
-        default: 15672
-    login_protocol:
-        description:
-            - rabbitMQ management api protocol
-        choices: [ http , https ]
-        required: false
-        default: http
-        version_added: "2.3"
-    cacert:
-        description:
-            - CA certificate to verify SSL connection to management API.
-        required: false
-        version_added: "2.3"
-    cert:
-        description:
-            - Client certificate to send on SSL connections to management API.
-        required: false
-        version_added: "2.3"
-    key:
-        description:
-            - Private key matching the client certificate.
-        required: false
-        version_added: "2.3"
-    vhost:
-        description:
-            - rabbitMQ virtual host
-        required: false
-        default: "/"
     durable:
         description:
             - whether exchange is durable or not
@@ -122,6 +75,7 @@ options:
             - extra arguments for exchange. If defined this argument is a key/value dictionary
         required: false
         default: {}
+extends_documentation.fragment: rabbitmq.documentation
 '''
 
 EXAMPLES = '''
@@ -140,28 +94,22 @@ import requests
 import urllib
 import json
 
+
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
+
+    argument_spec = rabbitmq_argument_spec()
+    argument_spec.update(
+        dict(
             state = dict(default='present', choices=['present', 'absent'], type='str'),
             name = dict(required=True, type='str'),
-            login_user = dict(default='guest', type='str'),
-            login_password = dict(default='guest', type='str', no_log=True),
-            login_host = dict(default='localhost', type='str'),
-            login_port = dict(default='15672', type='str'),
-            login_protocol = dict(default='http', choices=['http', 'https'], type='str'),
-            cacert = dict(required=False, type='path', default=None),
-            cert = dict(required=False, type='path', default=None),
-            key = dict(required=False, type='path', default=None),
-            vhost = dict(default='/', type='str'),
             durable = dict(default=True, type='bool'),
             auto_delete = dict(default=False, type='bool'),
             internal = dict(default=False, type='bool'),
             exchange_type = dict(default='direct', aliases=['type'], type='str'),
             arguments = dict(default=dict(), type='dict')
-        ),
-        supports_check_mode = True
+        )
     )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     url = "%s://%s:%s/api/exchanges/%s/%s" % (
         module.params['login_protocol'],
@@ -254,6 +202,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.rabbitmq import *
 
 if __name__ == '__main__':
     main()

--- a/messaging/rabbitmq_queue.py
+++ b/messaging/rabbitmq_queue.py
@@ -45,53 +45,6 @@ options:
         choices: [ "present", "absent" ]
         required: false
         default: present
-    login_user:
-        description:
-            - rabbitMQ user for connection
-        required: false
-        default: guest
-    login_password:
-        description:
-            - rabbitMQ password for connection
-        required: false
-        default: false
-    login_host:
-        description:
-            - rabbitMQ host for connection
-        required: false
-        default: localhost
-    login_port:
-        description:
-            - rabbitMQ management api port
-        required: false
-        default: 15672
-    login_protocol:
-        description:
-            - rabbitMQ management api protocol
-        choices: [ http , https ]
-        required: false
-        default: http
-        version_added: "2.3"
-    cacert:
-        description:
-            - CA certificate to verify SSL connection to management API.
-        required: false
-        version_added: "2.3"
-    cert:
-        description:
-            - Client certificate to send on SSL connections to management API.
-        required: false
-        version_added: "2.3"
-    key:
-        description:
-            - Private key matching the client certificate.
-        required: false
-        version_added: "2.3"
-    vhost:
-        description:
-            - rabbitMQ virtual host
-        required: false
-        default: "/"
     durable:
         description:
             - whether queue is durable or not
@@ -136,6 +89,7 @@ options:
             - extra arguments for queue. If defined this argument is a key/value dictionary
         required: false
         default: {}
+extends_documentation.fragment: rabbitmq.documentation
 '''
 
 EXAMPLES = '''
@@ -155,31 +109,25 @@ import requests
 import urllib
 import json
 
+
 def main():
-    module = AnsibleModule(
-        argument_spec = dict(
-            state = dict(default='present', choices=['present', 'absent'], type='str'),
-            name = dict(required=True, type='str'),
-            login_user = dict(default='guest', type='str'),
-            login_password = dict(default='guest', type='str', no_log=True),
-            login_host = dict(default='localhost', type='str'),
-            login_port = dict(default='15672', type='str'),
-            login_protocol = dict(default='http', choices=['http', 'https'], type='str'),
-            cacert = dict(required=False, type='path', default=None),
-            cert = dict(required=False, type='path', default=None),
-            key = dict(required=False, type='path', default=None),
-            vhost = dict(default='/', type='str'),
-            durable = dict(default=True, type='bool'),
-            auto_delete = dict(default=False, type='bool'),
-            message_ttl = dict(default=None, type='int'),
-            auto_expires = dict(default=None, type='int'),
-            max_length = dict(default=None, type='int'),
-            dead_letter_exchange = dict(default=None, type='str'),
-            dead_letter_routing_key = dict(default=None, type='str'),
-            arguments = dict(default=dict(), type='dict')
-        ),
-        supports_check_mode = True
+
+    argument_spec = rabbitmq_argument_spec()
+    argument_spec.update(
+        dict(
+            state=dict(default='present', choices=['present', 'absent'], type='str'),
+            name=dict(required=True, type='str'),
+            durable=dict(default=True, type='bool'),
+            auto_delete=dict(default=False, type='bool'),
+            message_ttl=dict(default=None, type='int'),
+            auto_expires=dict(default=None, type='int'),
+            max_length=dict(default=None, type='int'),
+            dead_letter_exchange=dict(default=None, type='str'),
+            dead_letter_routing_key=dict(default=None, type='str'),
+            arguments=dict(default=dict(), type='dict')
+        )
     )
+    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
     url = "%s://%s:%s/api/queues/%s/%s" % (
         module.params['login_protocol'],
@@ -300,6 +248,7 @@ def main():
 
 # import module snippets
 from ansible.module_utils.basic import *
+from ansible.module_utils.rabbitmq import *	
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME
- rabbitmq_binding
- rabbitmq_exchange
- rabbitmq_queue
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 02e52c319c) last updated 2016/06/09 11:10:49 (GMT +300)
  lib/ansible/modules/core: (detached HEAD a8072f9ef0) last updated 2016/06/09 11:11:06 (GMT +300)
  lib/ansible/modules/extras: (devel e8a5442345) last updated 2016/09/01 13:16:23 (GMT +300)
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The three modules on this PR have the protocol part of the management api URL hardcoded as `http` this makes these modules useless on a deployment where this API is exposed over https.

This PR adds four extra parameters to these modules to specify whether to use http or https and which certificates to use for TLS validation.
