### PR TITLE
Fix share aliases logic (#2862)

### DIFF
--- a/system/zfs.py
+++ b/system/zfs.py
@@ -198,8 +198,9 @@ class Zfs(object):
             if source == 'local':
                 properties[prop] = value
         # Add alias for enhanced sharing properties
-        properties['sharenfs'] = properties.get('share.nfs', None)
-        properties['sharesmb'] = properties.get('share.smb', None)
+        if self.enhanced_sharing:
+            properties['sharenfs'] = properties.get('share.nfs', None)
+            properties['sharesmb'] = properties.get('share.smb', None)
         return properties
 
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

zfs module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 9fe4308670) last updated 2016/09/06 19:42:49 (GMT +200)
  lib/ansible/modules/core: (detached HEAD 982c4557d2) last updated 2016/09/06 19:43:03 (GMT +200)
  lib/ansible/modules/extras: (fix_zfs_share_aliases 4b079e3e9a) last updated 2016/09/06 20:34:27 (GMT +200)
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/usr/share/ansible']
```
##### SUMMARY

Corrects the logic for when to add aliases for enhanced sharing properties

**Test setup**
localhost is running Ubuntu 15.10
192.168.56.101 is running Solaris 11 x86

**Test playbook**

```

---
- hosts: all
  vars:
    pool: rpool
  gather_facts: no
  tasks:
    - name: Reset all state
      zfs:
        name: "{{ pool }}/test"
        state: absent
      ignore_errors: yes

    - name: Set sharesmb on
      zfs:
        name: "{{ pool }}/test"
        state: present
        sharesmb: on
      register: zfs_result
      failed_when: zfs_result|changed != True

    - name: Set sharesmb on
      zfs:
        name: "{{ pool }}/test"
        state: present
        sharesmb: on
      register: zfs_result
      failed_when: zfs_result|changed

    - name: Reset all state
      zfs:
        name: "{{ pool }}/test"
        state: absent
      ignore_errors: yes
```

**Before**

```
$ ansible-playbook -i hosts zfs_2862.yml 

PLAY [all] *********************************************************************

TASK [Reset all state] *********************************************************
ok: [localhost]
ok: [192.168.56.101]

TASK [Set sharesmb on] *********************************************************
changed: [localhost]
changed: [192.168.56.101]

TASK [Set sharesmb on] *********************************************************
fatal: [localhost]: FAILED! => {"changed": true, "failed": true, "failed_when_result": true, "name": "rpool/test", "sharesmb": "on", "state": "present"}
ok: [192.168.56.101]

TASK [Reset all state] *********************************************************
changed: [192.168.56.101]
        to retry, use: --limit @zfs_2862.retry

PLAY RECAP *********************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1   
```

**After**

```
$ ansible-playbook -i hosts zfs_2862.yml 

PLAY [all] *********************************************************************

TASK [Reset all state] *********************************************************
ok: [localhost]
ok: [192.168.56.101]

TASK [Set sharesmb on] *********************************************************
changed: [localhost]
changed: [192.168.56.101]

TASK [Set sharesmb on] *********************************************************
ok: [localhost]
ok: [192.168.56.101]

TASK [Reset all state] *********************************************************
changed: [localhost]
changed: [192.168.56.101]

PLAY RECAP *********************************************************************
```
