### PR TITLE
correctly iterate and return results of any service checks.

### DIFF
--- a/clustering/consul.py
+++ b/clustering/consul.py
@@ -315,7 +315,7 @@ def add_service(module, service):
                      service_id=result.id,
                      service_name=result.name,
                      service_port=result.port,
-                     checks=map(lambda x: x.to_dict(), service.checks),
+                     checks=[check.to_dict() for check in service.checks],
                      tags=result.tags)
 
 
@@ -484,8 +484,7 @@ class ConsulCheck():
         if duration:
             duration_units = ['ns', 'us', 'ms', 's', 'm', 'h']
             if not any((duration.endswith(suffix) for suffix in duration_units)):
-                    raise Exception('Invalid %s %s you must specify units (%s)' %
-                        (name, duration, ', '.join(duration_units)))
+                duration = "{}s".format(duration)
         return duration
 
     def register(self, consul_api):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

consul
##### ANSIBLE VERSION

```
ansible 2.2.0 (consul-test-updates fb09c88f40) last updated 2016/09/07 21:50:29 (GMT +100)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras:  not found - use git submodule update --init lib/ansible/modules/extras
  config file = /Users/sgargan/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

current implementation was breaking making the module unusable, changing to the list comprehension fixes this. Also default to seconds instead of throwing a exception when no duration units are supplied as this causes tests to fail
