### PR TITLE
Delete lxd container in state stopped

### DIFF
--- a/cloud/lxd/lxd_container.py
+++ b/cloud/lxd/lxd_container.py
@@ -364,7 +364,7 @@ class LXDContainerManagement(object):
         self.actions.append('restart')
 
     def _delete_container(self):
-        return self.client.do('DELETE', '/1.0/containers/{0}'.format(self.name))
+        self.client.do('DELETE', '/1.0/containers/{0}'.format(self.name))
         self.actions.append('delete')
 
     def _freeze_container(self):
@@ -446,7 +446,8 @@ class LXDContainerManagement(object):
         if self.old_state != 'absent':
             if self.old_state == 'frozen':
                 self._unfreeze_container()
-            self._stop_container()
+            if self.old_state != 'stopped':
+                self._stop_container()
             self._delete_container()
 
     def _frozen(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

cloud/lxd_container
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = /Users/nils/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When a LXD container is stopped and the desired state is absent, the module still tries to stop it before deletion. But stop will not work, because the container is already stopped and it ends with an error. The solution to this problem is to check whether the container is already stopped and only stop it if necessary.

Before:

```
$ ansible -m lxd_container -a "name=template state=absent" h-004a
h-004a | FAILED! => {
    "actions": [],
    "changed": false,
    "failed": true,
    "msg": "container is not running"
}
```

After:

```
$ ansible -m lxd_container -a "name=template state=absent" h-004a
h-004a | SUCCESS => {
    "actions": [
        "delete"
    ],
    "changed": true,
    "log_verbosity": 0,
    "old_state": "stopped"
}
```
