### PR TITLE
add require_full_window boolean option for datadog_monitor

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -108,6 +108,11 @@ options:
         required: false
         default: False
         version_added: 2.2
+    require_full_window:
+        description: ["A boolean indicating whether this monitor needs a full window of data before it's evaluated. We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped."]
+        required: false
+        default: null
+        version_added: 2.2
 '''
 
 EXAMPLES = '''
@@ -164,7 +169,8 @@ def main():
             notify_audit=dict(required=False, default=False, type='bool'),
             thresholds=dict(required=False, type='dict', default=None),
             tags=dict(required=False, type='list', default=None),
-            locked=dict(required=False, default=False, type='bool')
+            locked=dict(required=False, default=False, type='bool'),
+            require_full_window=dict(required=False, default=None, type='bool')
         )
     )
 
@@ -248,6 +254,7 @@ def install_monitor(module):
         "escalation_message": module.params['escalation_message'],
         "notify_audit": module.boolean(module.params['notify_audit']),
         "locked": module.boolean(module.params['locked']),
+        "require_full_window" : module.boolean(module.params['require_full_window']),
     }
 
     if module.params['type'] == "service check":


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

datadog_monitor
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add support for the `require_full_window` flag for Datadog monitors, as documented on http://docs.datadoghq.com/api/#monitors

> require_full_window a boolean indicating whether this monitor needs a full window of data before it's evaluated. We highly recommend you set this to False for sparse metrics, otherwise some evaluations will be skipped.
> Default: True for "on average", "at all times" and "in total" aggregation. False otherwise.

This is a duplicate of #2653 which appears to have been abandoned, but it has no merge conflicts with devel at time of writing.
