### PR TITLE
Fix one character typo in my previous PR for debconf module

### DIFF
--- a/system/debconf.py
+++ b/system/debconf.py
@@ -164,7 +164,7 @@ def main():
         if module._diff:
             after = prev.copy()
             after.update(curr)
-            diffdict = {'before': prev, 'after': after}
+            diff_dict = {'before': prev, 'after': after}
         else:
             diff_dict = {}
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

debconf
##### SUMMARY

Small oops in my previous PR #2530 commit.

Instead of `diff_dict` it slipped through as `diffdict`. This makes the module fail.

Please merge and sorry.
