### PR TITLE
lldp bug fix when same keys exist

### DIFF
--- a/network/lldp.py
+++ b/network/lldp.py
@@ -66,7 +66,8 @@ def gather_lldp():
             for path_component in path_components:
                 current_dict[path_component] = current_dict.get(path_component, {})
                 current_dict = current_dict[path_component]
-            current_dict[final] = value
+            if type(current_dict) == dict:
+                current_dict[final] = value
         return output_dict
             
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/lldp
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

current lldp parsing code does not work at same lldp item such as multiple unknown-tlvs.unknown-tlv.
Just skip the error case when current_dict is not the dict type.
First out of multiple keys will be displayed. 

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
{"lldp": {"enp1s0f0": {"via": "LLDP", "age": "4 days, 06:35:47", "vlan": {"vlan-id": "2", "pvid": "yes"}, "unknown-tlvs": {"unknown-tlv": "01"}, "chassis": {"Bridge": {"enabled": "on"}, "name": "N6001-B", "descr": "Cisco Nexus Operating System (NX-OS) Software 7.2(0)N1(1) TAC support: http://www.cisco.com/tac Copyright (c) 2002-2015, Cisco Systems, Inc. All rights reserved.", "mgmt-ip": "10.72.86.10", "mac": "24:b6:57:16:a6:da", "ttl": "120"}, "rid": "1", "port": {"local": "Eth101/1/25", "descr": "Ethernet101/1/25"}}, "enp8s0": {"via": "LLDP", "age": "4 days, 05:25:36", "unknown-tlvs": {"unknown-tlv": "01,0A,00,00,01,39,33,38,30,39,32,34,30,2D,34,37,34,34,2D,31,31,65,36,2D,62,63,36,38,2D,37,33,39,38,63,31,63,35,32,34,38,65,02,0A,00,00,02,64,36,33,35,64,38,66,63,2D,34,37,35,38,2D,31,31,65,36,2D,61,39,30,33,2D,62,39,34,35,63,63,37,34,36,37,30,39,03,0A,00,00,03,31,62,66,34,30,32,38,38,2D,34,37,35,39,2D,31,31,65,36,2D,39,39,35,31,2D,65,31,34,30,39,61,62,36,36,34,31,30"}, "chassis": {"Bridge": {"enabled": "on"}, "name": "LEAF1002", "descr": "topology/pod-1/node-1002", "mac": "f4:0f:1b:ad:ec:c1", "ttl": "120", "Router": {"enabled": "on"}}, "rid": "4", "port": {"local": "Eth1/25", "descr": "topology/pod-1/paths-1002/pathep-[eth1/25]"}}, "enp9s0": {"via": "LLDP", "age": "4 days, 05:25:07", "unknown-tlvs": {"unknown-tlv": "01,0A,00,00,01,39,33,38,30,39,32,34,30,2D,34,37,34,34,2D,31,31,65,36,2D,62,63,36,38,2D,37,33,39,38,63,31,63,35,32,34,38,65,02,0A,00,00,02,64,36,33,35,64,38,66,63,2D,34,37,35,38,2D,31,31,65,36,2D,61,39,30,33,2D,62,39,34,35,63,63,37,34,36,37,30,39,03,0A,00,00,03,31,62,66,34,30,32,38,38,2D,34,37,35,39,2D,31,31,65,36,2D,39,39,35,31,2D,65,31,34,30,39,61,62,36,36,34,31,30"}, "chassis": {"Bridge": {"enabled": "on"}, "name": "LEAF1001", "descr": "topology/pod-1/node-1001", "mgmt-ip": "10.72.86.27", "mac": "f4:0f:1b:6f:52:f9", "ttl": "120", "Router": {"enabled": "on"}}, "rid": "5", "port": {"local": "Eth1/25", "descr": "topology/pod-1/paths-1001/pathep-[eth1/25]"}}}}
```
