### PR TITLE
Fixes domains method not defined

### DIFF
--- a/network/f5/bigip_routedomain.py
+++ b/network/f5/bigip_routedomain.py
@@ -260,6 +260,20 @@ class BigIpRouteDomain(object):
             p['service_policy'] = str(r.servicePolicy)
         return p
 
+    def domains(self):
+        result = []
+
+        domains = self.api.tm.net.route_domains.get_collection()
+        for domain in domains:
+            # Just checking for the addition of the partition here for
+            # different versions of BIG-IP
+            if '/' + self.params['partition'] + '/' in domain.name:
+                result.append(domain.name)
+            else:
+                full_name = '/%s/%s' % (self.params['partition'], domain.name)
+                result.append(full_name)
+        return result
+
     def create(self):
         params = dict()
         params['id'] = self.params['id']
@@ -284,7 +298,7 @@ class BigIpRouteDomain(object):
 
         if parent is not None:
             parent = '/%s/%s' % (partition, parent)
-            if parent in self.domains:
+            if parent in self.domains():
                 params['parent'] = parent
             else:
                 raise F5ModuleError(


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/f5/bigip_routedomain.py
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

The domains method was not defined, and therefore when specifying
a parent domain during route domain creation, the process would
fail.

Tests have been added to detect this going forward
