### PR TITLE
fix rg issue with _nic_to_public_ips_instance()

### DIFF
--- a/cloud/azure/azure_rm_deployment.py
+++ b/cloud/azure/azure_rm_deployment.py
@@ -644,7 +644,7 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
         return ip_dict
 
     def _nic_to_public_ips_instance(self, nics):
-        return [self.network_client.public_ip_addresses.get(self.resource_group_name, public_ip_id.split('/')[-1])
+        return [self.network_client.public_ip_addresses.get(public_ip_id.split('/')[4], public_ip_id.split('/')[-1])
                   for nic_obj in [self.network_client.network_interfaces.get(self.resource_group_name,
                                                                              nic['dep'].resource_name) for nic in nics]
                   for public_ip_id in [ip_conf_instance.public_ip_address.id


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

extras/azure/azure_rm_deployment
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
```
##### SUMMARY

There is an issue with the method above where there is an assumption that the public IP associated with the vm is in the same resource group as the vm. this isn't always the case. Instead i've just pulled the resource group out of the ID of the resource.

Fixes #2927 

before change:

```
TASK [provision : Provision | Azure Virtual Machine] ***************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: msrestazure.azure_exceptions.CloudError: The Resource 'Microsoft.Networ
k/publicIPAddresses/VIP-VM-003' under resource group 'RAIABR-PRD-INFR-09' was not found.
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_jUIYR2/ansible_module_azur
e_rm_deployment.py\", line 660, in <module>\n    main()\n  File \"/tmp/ansible_jUIYR2/ansible_module_azure_rm_deployment.py\", line 656, in main\n    AzureRMDeploymentM
anager()\n  File \"/tmp/ansible_jUIYR2/ansible_module_azure_rm_deployment.py\", line 438, in __init__\n    supports_check_mode=False)\n  File \"/tmp/ansible_jUIYR2/ansi
ble_modlib.zip/ansible/module_utils/azure_rm_common.py\", line 192, in __init__\n  File \"/tmp/ansible_jUIYR2/ansible_module_azure_rm_deployment.py\", line 455, in exec
_module\n    instances=self._get_instances(deployment)\n  File \"/tmp/ansible_jUIYR2/ansible_module_azure_rm_deployment.py\", line 605, in _get_instances\n    for vm, n
ics in vms_and_nics]\n  File \"/tmp/ansible_jUIYR2/ansible_module_azure_rm_deployment.py\", line 652, in _nic_to_public_ips_instance\n    if ip_conf_instance.public_ip_
address]]\n  File \"/usr/lib/python2.7/site-packages/azure/mgmt/network/operations/public_ip_addresses_operations.py\", line 179, in get\n    raise exp\nmsrestazure.azu
re_exceptions.CloudError: The Resource 'Microsoft.Network/publicIPAddresses/VIP-VM-003' under resource group 'RAIABR-PRD-INFR-09' was not found.\n", "module_stdout": ""
, "msg": "MODULE FAILURE", "parsed": false}
```

after change:

```
TASK [provision : Provision | Azure Virtual Machine] ***************************
changed: [localhost]
```

Fix an issue with _nic_to_public_ips_instance() function. There was an assumption in the code that the Public IP sits in the same resource group, this isn't always the case.
