### PR TITLE
Added purge_routes and purge_subnets option to ec2_vpc_route_table module

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -33,6 +33,13 @@ options:
       - "Enable route propagation from virtual gateways specified by ID."
     default: None
     required: false
+  purge_routes:
+    version_added: "2.2"
+    description:
+      - "Purge existing routes that are not found in routes"
+    required: false
+    default: 'true'
+    aliases: []
   route_table_id:
     description:
       - "The ID of the route table to update or delete."
@@ -317,7 +324,7 @@ def index_of_matching_route(route_spec, routes_to_match):
 
 
 def ensure_routes(vpc_conn, route_table, route_specs, propagating_vgw_ids,
-                  check_mode):
+                  check_mode, purge_routes):
     routes_to_match = list(route_table.routes)
     route_specs_to_create = []
     for route_spec in route_specs:
@@ -334,13 +341,14 @@ def ensure_routes(vpc_conn, route_table, route_specs, propagating_vgw_ids,
     # The current logic will leave non-propagated routes using propagating
     # VGWs in place.
     routes_to_delete = []
-    for r in routes_to_match:
-        if r.gateway_id:
-            if r.gateway_id != 'local' and not r.gateway_id.startswith('vpce-'):
-                if not propagating_vgw_ids or r.gateway_id not in propagating_vgw_ids:
-                    routes_to_delete.append(r)
-        else:
-            routes_to_delete.append(r)
+    if purge_routes:
+        for r in routes_to_match:
+            if r.gateway_id:
+                if r.gateway_id != 'local' and not r.gateway_id.startswith('vpce-'):
+                    if not propagating_vgw_ids or r.gateway_id not in propagating_vgw_ids:
+                        routes_to_delete.append(r)
+            else:
+                routes_to_delete.append(r)
 
     changed = bool(routes_to_delete or route_specs_to_create)
     if changed:
@@ -501,6 +509,7 @@ def ensure_route_table_present(connection, module):
 
     lookup = module.params.get('lookup')
     propagating_vgw_ids = module.params.get('propagating_vgw_ids')
+    purge_routes = module.params.get('purge_routes')
     route_table_id = module.params.get('route_table_id')
     subnets = module.params.get('subnets')
     tags = module.params.get('tags')
@@ -542,7 +551,7 @@ def ensure_route_table_present(connection, module):
 
     if routes is not None:
         try:
-            result = ensure_routes(connection, route_table, routes, propagating_vgw_ids, module.check_mode)
+            result = ensure_routes(connection, route_table, routes, propagating_vgw_ids, module.check_mode, purge_routes)
             changed = changed or result['changed']
         except EC2ResponseError as e:
             module.fail_json(msg=e.message)
@@ -586,6 +595,7 @@ def main():
         dict(
             lookup = dict(default='tag', required=False, choices=['tag', 'id']),
             propagating_vgw_ids = dict(default=None, required=False, type='list'),
+            purge_routes=dict(default=True, required=False, type='bool'),
             route_table_id = dict(default=None, required=False),
             routes = dict(default=[], required=False, type='list'),
             state = dict(default='present', choices=['present', 'absent']),

--- a/cloud/amazon/ec2_vpc_route_table.py
+++ b/cloud/amazon/ec2_vpc_route_table.py
@@ -34,9 +34,16 @@ options:
     default: None
     required: false
   purge_routes:
-    version_added: "2.2"
+    version_added: "2.3"
     description:
-      - "Purge existing routes that are not found in routes"
+      - "Purge existing routes that are not found in routes."
+    required: false
+    default: 'true'
+    aliases: []
+  purge_subnets:
+    version_added: "2.3"
+    description:
+      - "Purge existing subnets that are not found in subnets."
     required: false
     default: 'true'
     aliases: []
@@ -395,7 +402,7 @@ def ensure_subnet_association(vpc_conn, vpc_id, route_table_id, subnet_id,
 
 
 def ensure_subnet_associations(vpc_conn, vpc_id, route_table, subnets,
-                               check_mode):
+                               check_mode, purge_subnets):
     current_association_ids = [a.id for a in route_table.associations]
     new_association_ids = []
     changed = False
@@ -407,12 +414,13 @@ def ensure_subnet_associations(vpc_conn, vpc_id, route_table, subnets,
             return {'changed': True}
         new_association_ids.append(result['association_id'])
 
-    to_delete = [a_id for a_id in current_association_ids
+    if purge_subnets:
+        to_delete = [a_id for a_id in current_association_ids
                  if a_id not in new_association_ids]
 
-    for a_id in to_delete:
-        changed = True
-        vpc_conn.disassociate_route_table(a_id, dry_run=check_mode)
+        for a_id in to_delete:
+            changed = True
+            vpc_conn.disassociate_route_table(a_id, dry_run=check_mode)
 
     return {'changed': changed}
 
@@ -510,6 +518,7 @@ def ensure_route_table_present(connection, module):
     lookup = module.params.get('lookup')
     propagating_vgw_ids = module.params.get('propagating_vgw_ids')
     purge_routes = module.params.get('purge_routes')
+    purge_subnets = module.params.get('purge_subnets')
     route_table_id = module.params.get('route_table_id')
     subnets = module.params.get('subnets')
     tags = module.params.get('tags')
@@ -578,7 +587,7 @@ def ensure_route_table_present(connection, module):
             )
 
         try:
-            result = ensure_subnet_associations(connection, vpc_id, route_table, associated_subnets, module.check_mode)
+            result = ensure_subnet_associations(connection, vpc_id, route_table, associated_subnets, module.check_mode, purge_subnets)
             changed = changed or result['changed']
         except EC2ResponseError as e:
             raise AnsibleRouteTableException(
@@ -596,6 +605,7 @@ def main():
             lookup = dict(default='tag', required=False, choices=['tag', 'id']),
             propagating_vgw_ids = dict(default=None, required=False, type='list'),
             purge_routes=dict(default=True, required=False, type='bool'),
+            purge_subnets=dict(default=True, required=False, type='bool'),
             route_table_id = dict(default=None, required=False),
             routes = dict(default=[], required=False, type='list'),
             state = dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_vpc_route_table module
##### ANSIBLE VERSION

```
ansible 2.2.0 (devel 28feba2fb3)
```
##### SUMMARY

This adds optional parameter `purge_routes` to allow just appending new routes, instead of replacing them. This was mentioned in #1746 and defaults to `true` to preserve compatibility.

And also adds optional parameter `purge_subnets` to allow just appending new subnets associations, instead of replacing them, this defaults to `true` to preserve compatibility.

This is really useful when you want to manipulate already created route_tables, for example just associate with a new subnet.

Example of appending a new subnet:

```
    - name: Append a new subnet to current route table
      ec2_vpc_route_table:
        vpc_id: "{{ MY_VPC_ID }}"
        region: "{{ MY_AWS_REGION }}"
        subnets:
          - "{{ AWS_DEV_SUBNET_ID }}"
        purge_routes: false
        purge_subnets: false
        route_table_id: "{{ MY_ROUTE_TABLE_ID }}"
        lookup: id
```
