### PR TITLE
Fix 'netapp_e_lun_mapping ... documentation error'

### DIFF
--- a/storage/netapp/netapp_e_lun_mapping.py
+++ b/storage/netapp/netapp_e_lun_mapping.py
@@ -21,8 +21,7 @@ DOCUMENTATION = '''
 ---
 module: netapp_e_lun_mapping
 author: Kevin Hulquest (@hulquest)
-short_description:
-     - Create or Remove LUN Mappings
+short_description: Create or Remove LUN Mappings
 description:
      - Allows for the creation and removal of volume to host mappings for NetApp E-series storage arrays.
 version_added: "2.2"


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

storage/netapp/netapp_e_lun_mapping.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

ansible 2.2.0 (devel 6247e7bc38) last updated 2016/09/19 10:25:23 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 488f082761) last updated 2016/09/16 19:38:36 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 24da3602c6) last updated 2016/09/16 19:38:37 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

The 'short_description' in netapp_e_lun_mapping was a
list instead of txt.

This fixes errors on 'ansible-doc -l' of form:

```
    ERROR! module netapp_e_lun_mapping has a documentation
    error formatting or is missing documentation
```

Fixes: #17634 (ansible/ansible)
