### PR TITLE
Remove redundant doc keys for netapp_e_ modules

### DIFF
--- a/storage/netapp/netapp_e_auth.py
+++ b/storage/netapp/netapp_e_auth.py
@@ -26,20 +26,6 @@ description:
 version_added: "2.2"
 author: Kevin Hulquest (@hulquest)
 options:
-    api_username:
-        required: true
-        description:
-        - The username to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-    api_password:
-        required: true
-        description:
-        - The password to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-    api_url:
-        required: true
-        description:
-        - The url to the SANtricity WebServices Proxy or embedded REST API.
-        example:
-        - https://prod-1.wahoo.acme.com/devmgr/v2
     validate_certs:
         required: false
         default: true

--- a/storage/netapp/netapp_e_lun_mapping.py
+++ b/storage/netapp/netapp_e_lun_mapping.py
@@ -27,20 +27,6 @@ description:
      - Allows for the creation and removal of volume to host mappings for NetApp E-series storage arrays.
 version_added: "2.2"
 options:
-  api_username:
-      required: true
-      description:
-      - The username to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-  api_password:
-      required: true
-      description:
-      - The password to authenticate with the SANtricity WebServices Proxy or embedded REST API.
-  api_url:
-      required: true
-      description:
-      - The url to the SANtricity WebServices Proxy or embedded REST API.
-      example:
-      - https://prod-1.wahoo.acme.com/devmgr/v2
   validate_certs:
       required: false
       default: true


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

storage/netapp/netapp_e_auth
storage/netapp/netapp_e_lun_mapping
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0 (devel 6247e7bc38) last updated 2016/09/19 10:25:23 (GMT -400)
  lib/ansible/modules/core: (detached HEAD 488f082761) last updated 2016/09/16 19:38:36 (GMT -400)
  lib/ansible/modules/extras: (detached HEAD 24da3602c6) last updated 2016/09/16 19:38:37 (GMT -400)
  config file = /home/adrian/ansible/ansible.cfg
  configured module search path = ['/home/adrian/src/ansible-modules-core', '/home/adrian/src/ansible-modules-extras']

```
##### SUMMARY

Fix a warning from 'ansible-doc' about the redundant keys in the doc strings.

Fixes #2967
