### PR TITLE
New dimensiondata load balancer

### DIFF
--- a/cloud/dimensiondata/dimensiondata_load_balancer.py
+++ b/cloud/dimensiondata/dimensiondata_load_balancer.py
@@ -1,0 +1,320 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Dimension Data
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   - Aimon Bustardo <aimon.bustardo@dimensiondata.com>
+#   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
+#   - Jay Riddell    <Jay.Riddell@dimensiondata.com>
+#
+from ansible.module_utils.basic import *
+from ansible.module_utils.dimensiondata import *
+try:
+    from libcloud.common.dimensiondata import DimensionDataAPIException
+    from libcloud.loadbalancer.types import Provider as LBProvider
+    from libcloud.compute.types import Provider as ComputeProvider
+    from libcloud.loadbalancer.providers import get_driver as get_lb_driver
+    from libcloud.compute.providers import get_driver as get_cp_driver
+    from libcloud.loadbalancer.base import Member, Algorithm
+    import libcloud.security
+    HAS_LIBCLOUD = True
+except:
+    HAS_LIBCLOUD = False
+
+# Get regions early to use in docs etc.
+dd_regions = get_dd_regions()
+
+# Virtual Listener Protocols
+protocols = ['any', 'tcp', 'udp', 'http', 'ftp', 'smtp']
+# Load Balancing algorithms
+lb_algs = ['ROUND_ROBIN', 'LEAST_CONNECTIONS',
+           'SHORTEST_RESPONSE', 'PERSISTENT_IP']
+
+DOCUMENTATION = '''
+---
+module: dimensiondata_load_balancer
+description:
+  - Create, update or delete load balancers.
+short_description: Create, update or delete load balancers.
+version_added: "2.2"
+author: 'Aimon Bustardo (@aimonb)'
+options:
+  region:
+    description:
+      - The target region.
+    choices:
+      - Regions choices are defined in Apache libcloud project [libcloud/common/dimensiondata.py]
+      - Regions choices are also listed in https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html
+      - Note that the region values are available as list from dd_regions().
+      - Note that the default value "na" stands for "North America".  The code prepends 'dd-' to the region choice.
+    default: na
+  location:
+    description:
+      - The target datacenter.
+    required: true
+  network_domain:
+    description:
+      - The target network name or UUID/ID for the network.
+    required: true
+    default: None
+  name:
+    description:
+      - Name of the Load Balancer.
+    required: true
+  port:
+    description:
+        - An integer in the range of 1-65535.
+        - If not supplied, it will be taken to mean "Any Port"
+    required: false
+    default: None
+  listener_ip_address:
+    description:
+        - Must be a valid IPv4 in dot-decimal notation (x.x.x.x).
+        - If not provided (or == ""), value will be auto-provisioned
+    required: false
+    default: None
+  protocol:
+    description:
+        - Choice of an enumeration of protocols
+    required: false
+    choices: [any, tcp, udp, http, ftp, smtp]
+    default: http
+  algorithm:
+    description:
+        - Choice of an enumerations of algorithms
+    required: false
+    choices: [ROUND_ROBIN, LEAST_CONNECTIONS, SHORTEST_RESPONSE, PERSISTENT_IP]
+    default: ROUND_ROBIN
+  members:
+    description:
+      - List of members as dictionaries.
+      - See Examples for format.
+    required: true
+  verify_ssl_cert:
+    description:
+      - Check that SSL certificate is valid.
+    required: false
+    default: true
+  ensure:
+    description:
+      - present, absent.
+    choices: [present, absent]
+    default: present
+'''
+
+
+EXAMPLES = '''
+# Construct Load Balancer
+- dimensiondata_load_balancer:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: web_lb01
+    port: 80
+    protocol: http
+    algorithm: ROUND_ROBIN
+    members:
+        - name: webserver1
+          port: 8080
+          ip: 192.168.0.11
+        - name: webserver3
+          port: 8080
+          ip: 192.168.0.13
+    ensure: present
+'''
+
+RETURN = '''
+load_balancer:
+    description: Dictionary describing the Load Balancer.
+    returned: On success when I(ensure) is 'present'
+    type: dictionary
+    contains:
+        id:
+            description: Load Balancer ID.
+            type: string
+            sample: "aaaaa000-a000-4050-a215-2808934ccccc"
+        name:
+            description: Virtual Listener name.
+            type: string
+            sample: "My Virtual Listener"
+        state:
+            description: state of the Load Balancer
+            type: integer
+            sample: 0=RUNNING,  1=PENDING, 2=UNKNOWN, 3=ERROR, 4=DELETED
+        ip:
+            description: Listener IP of Load Balancer.
+            type: string
+            sample: 168.128.1.1
+        port:
+            description: Port of Load Balancer listener (if port was supplied; else = 'Any Port')
+            type: integer
+            sample: 80
+'''
+
+
+def get_balancer(module, lb_driver, name):
+    if is_uuid(name):
+        try:
+            return lb_driver.get_balancer(name)
+        except DimensionDataAPIException as e:
+            if e.code == 'RESOURCE_NOT_FOUND':
+                return False
+            else:
+                module.fail_json("Unexpected API error code: %s" % e.code)
+    else:
+        balancers = list_balancers(module, lb_driver)
+        found_balancers = filter(lambda x: x.name == name, balancers)
+        if len(found_balancers) > 0:
+            lb_id = found_balancers[0].id
+            try:
+                return lb_driver.get_balancer(lb_id)
+            except DimensionDataAPIException as e:
+                module.fail_json(msg="Unexpected error while retrieving load" +
+                                 " balancer details with id %s" % lb_id)
+        else:
+            return False
+
+
+def balancer_obj_to_dict(lb_obj):
+    return {
+        'id': lb_obj.id,
+        'name': lb_obj.name,
+        'state': int(lb_obj.state),
+        'ip': lb_obj.ip,
+        'port': 'Any Port' if lb_obj.port is None else int(lb_obj.port)
+    }
+
+
+def create_balancer(module, lb_driver, cp_driver, network_domain):
+    # Build mebers list
+    members_list = [Member(m['name'], m['ip'], m.get('port'))
+                    for m in module.params['members']]
+
+    listener_ip_address = module.params['listener_ip_address']
+    if not(listener_ip_address and listener_ip_address.strip()):
+        # Get addresses
+        res = get_unallocated_public_ips(module, cp_driver, lb_driver,
+                                         network_domain, True, 1)
+        listener_ip_address = res['addresses'][0]
+
+    try:
+        balancer = lb_driver.create_balancer(
+            module.params['name'],
+            module.params['port'],
+            module.params['protocol'],
+            getattr(Algorithm, module.params['algorithm']),
+            members_list,
+            ex_listener_ip_address=listener_ip_address)
+        module.exit_json(changed=True, msg="Success.",
+                         load_balancer=balancer_obj_to_dict(balancer))
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Error while creating load balancer: %s" % e)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            region=dict(default='na', choices=dd_regions),
+            location=dict(required=True, type='str'),
+            network_domain=dict(required=True, type='str'),
+            name=dict(required=True, type='str'),
+            port=dict(default=None, type='int'),
+            protocol=dict(default='http', choices=protocols),
+            algorithm=dict(default='ROUND_ROBIN', choices=lb_algs),
+            members=dict(default=None, type='list'),
+            ensure=dict(default='present', choices=['present', 'absent']),
+            verify_ssl_cert=dict(required=False, default=True, type='bool'),
+            listener_ip_address=dict(required=False, default=None, type='str')
+        ),
+    )
+
+    if not HAS_LIBCLOUD:
+        module.fail_json(msg='libcloud is required for this module.')
+
+    # set short vars for readability
+    credentials = get_credentials()
+    if credentials is False:
+        module.fail_json(msg="User credentials not found")
+    user_id = credentials['user_id']
+    key = credentials['key']
+    region = 'dd-%s' % module.params['region']
+    location = module.params['location']
+    network_domain = module.params['network_domain']
+    name = module.params['name']
+    verify_ssl_cert = module.params['verify_ssl_cert']
+    ensure = module.params['ensure']
+
+    # -------------------
+    # Instantiate drivers
+    # -------------------
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
+    # Instantiate Load Balancer Driver
+    DDLoadBalancer = get_lb_driver(LBProvider.DIMENSIONDATA)
+    lb_driver = DDLoadBalancer(user_id, key, region=region)
+    # Instantiate Compute Driver
+    DDCompute = get_cp_driver(ComputeProvider.DIMENSIONDATA)
+    cp_driver = DDCompute(user_id, key, region=region)
+
+    # Get Network Domain Object
+    net_domain = get_network_domain(cp_driver, network_domain, location)
+    if net_domain is False:
+        module.fail_json(msg="Network domain could not be found.")
+
+    # Set Load Balancer Driver network domain
+    try:
+        lb_driver.ex_set_current_network_domain(net_domain.id)
+    except:
+        module.fail_json(msg="Current network domain could not be set.")
+
+    # Process action
+    if ensure == 'present':
+        balancer = get_balancer(module, lb_driver, name)
+        if balancer is False:
+            create_balancer(module, lb_driver, cp_driver, net_domain)
+        else:
+            module.exit_json(changed=False, msg="Load balancer already " +
+                             "exists.", load_balancer=balancer_obj_to_dict(
+                                 balancer))
+    elif ensure == 'absent':
+        balancer = get_balancer(module, lb_driver, name)
+        if balancer is False:
+            module.exit_json(changed=False, msg="Load balancer with name " +
+                             "%s does not exist" % name)
+        try:
+            pool_id = balancer.extra.get('pool_id')
+            if pool_id:
+                pool = lb_driver.ex_get_pool(pool_id)
+
+            res = lb_driver.destroy_balancer(balancer)
+
+            if pool:
+                members = lb_driver.ex_get_pool_members(pool_id)
+                for member in members:
+                    lb_driver.ex_destroy_pool_member(member, destroy_node=True)
+                lb_driver.ex_destroy_pool(pool)
+
+            module.exit_json(changed=True, msg="Load balancer deleted. " +
+                             "Status: %s" % res)
+        except DimensionDataAPIException as e:
+            module.fail_json(msg="Unexpected error when attempting to delete" +
+                             " load balancer: %s" % e)
+    else:
+        fail_json(msg="Requested ensure was " +
+                  "'%s'. Status must be one of 'present', 'absent'." % ensure)
+
+if __name__ == '__main__':
+    main()

--- a/cloud/dimensiondata/dimensiondata_load_balancer.py
+++ b/cloud/dimensiondata/dimensiondata_load_balancer.py
@@ -20,9 +20,13 @@
 #   - Aimon Bustardo <aimon.bustardo@dimensiondata.com>
 #   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
 #   - Jay Riddell    <Jay.Riddell@dimensiondata.com>
-#
-from ansible.module_utils.basic import *
-from ansible.module_utils.dimensiondata import *
+#   - Mark Maglana   <mark.maglana@dimensiondata.com>
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.dimensiondata import \
+    get_credentials, get_dd_regions, get_network_domain, is_uuid, \
+    get_unallocated_public_ips
+
 try:
     from libcloud.common.dimensiondata import DimensionDataAPIException
     from libcloud.loadbalancer.types import Provider as LBProvider
@@ -35,14 +39,6 @@ try:
 except:
     HAS_LIBCLOUD = False
 
-# Get regions early to use in docs etc.
-dd_regions = get_dd_regions()
-
-# Virtual Listener Protocols
-protocols = ['any', 'tcp', 'udp', 'http', 'ftp', 'smtp']
-# Load Balancing algorithms
-lb_algs = ['ROUND_ROBIN', 'LEAST_CONNECTIONS',
-           'SHORTEST_RESPONSE', 'PERSISTENT_IP']
 
 DOCUMENTATION = '''
 ---
@@ -116,7 +112,6 @@ options:
     default: present
 '''
 
-
 EXAMPLES = '''
 # Construct Load Balancer
 - dimensiondata_load_balancer:
@@ -166,155 +161,241 @@ load_balancer:
 '''
 
 
-def get_balancer(module, lb_driver, name):
-    if is_uuid(name):
-        try:
-            return lb_driver.get_balancer(name)
-        except DimensionDataAPIException as e:
-            if e.code == 'RESOURCE_NOT_FOUND':
-                return False
-            else:
-                module.fail_json("Unexpected API error code: %s" % e.code)
-    else:
-        balancers = list_balancers(module, lb_driver)
-        found_balancers = filter(lambda x: x.name == name, balancers)
-        if len(found_balancers) > 0:
-            lb_id = found_balancers[0].id
-            try:
-                return lb_driver.get_balancer(lb_id)
-            except DimensionDataAPIException as e:
-                module.fail_json(msg="Unexpected error while retrieving load" +
-                                 " balancer details with id %s" % lb_id)
-        else:
-            return False
+# ==========
+# EXCEPTIONS
+# ==========
+
+class CreateError(Exception):
+    pass
 
 
-def balancer_obj_to_dict(lb_obj):
-    return {
-        'id': lb_obj.id,
-        'name': lb_obj.name,
-        'state': int(lb_obj.state),
-        'ip': lb_obj.ip,
-        'port': 'Any Port' if lb_obj.port is None else int(lb_obj.port)
-    }
+class DeleteError(Exception):
+    pass
 
 
-def create_balancer(module, lb_driver, cp_driver, network_domain):
-    # Build mebers list
-    members_list = [Member(m['name'], m['ip'], m.get('port'))
-                    for m in module.params['members']]
+class GetLoadBalancerError(Exception):
+    pass
 
-    listener_ip_address = module.params['listener_ip_address']
-    if not(listener_ip_address and listener_ip_address.strip()):
-        # Get addresses
-        res = get_unallocated_public_ips(module, cp_driver, lb_driver,
-                                         network_domain, True, 1)
-        listener_ip_address = res['addresses'][0]
+
+class InitializeError(Exception):
+    pass
+
+
+# =========
+# FUNCTIONS
+# =========
+
+def create_lb(lb_con, compute_con, net_domain, name, port, protocol,
+              listener_ip_address, members, algorithm, mod, **kwargs):
+    members = [Member(m['name'], m['ip'], m.get('port'))
+               for m in members]
+
+    ip_address = str(listener_ip_address).strip()
+
+    if not ip_address:
+        # This is the only part where mod is used. Once the method call
+        # below is freed from its dependency on AnsibleModule, this function
+        # will also no longer need it.
+        res = get_unallocated_public_ips(mod, compute_con, lb_con,
+                                         net_domain, True, 1)
+        ip_address = res['addresses'][0]
+
+    algorithms = getattr(Algorithm, algorithm)
 
     try:
-        balancer = lb_driver.create_balancer(
-            module.params['name'],
-            module.params['port'],
-            module.params['protocol'],
-            getattr(Algorithm, module.params['algorithm']),
-            members_list,
-            ex_listener_ip_address=listener_ip_address)
-        module.exit_json(changed=True, msg="Success.",
-                         load_balancer=balancer_obj_to_dict(balancer))
-    except DimensionDataAPIException as e:
-        module.fail_json(msg="Error while creating load balancer: %s" % e)
+        balancer = lb_con.create_balancer(name,
+                                          port,
+                                          protocol,
+                                          algorithms,
+                                          members,
+                                          ex_listener_ip_address=ip_address)
+    except DimensionDataAPIException as err:
+        msg = "Failed to create load balancer %s: %s" % (name, err)
+        raise CreateError(msg)
+
+    balancer_d = {
+        'id': balancer.id,
+        'name': balancer.name,
+        'state': int(balancer.state),
+        'ip': balancer.ip,
+        'port': int(balancer.port) if balancer.port else 'Any Port'
+    }
+
+    return True, "Load balancer created.", balancer_d
+
+
+def delete_lb(lb, lb_con, **kwargs):
+    pool_id = lb.extra.get('pool_id')
+    if pool_id:
+        pool = lb_con.ex_get_pool(pool_id)
+
+    try:
+        res = lb_con.destroy_balancer(lb)
+    except DimensionDataAPIException as err:
+        msg = "Could not delete load balancer %s: %s" % (lb.name, err)
+        raise DeleteError(msg)
+
+    if pool:
+        members = lb_con.ex_get_pool_members(pool_id)
+        for member in members:
+            lb_con.ex_destroy_pool_member(member, destroy_node=True)
+
+        lb_con.ex_destroy_pool(pool)
+
+    balancer_d = {
+        'id': lb.id,
+        'name': lb.name
+    }
+
+    return True, "Load balancer %s deleted" % res, balancer_d
+
+
+def do_nothing(name, ensure, lb, **kwargs):
+    if lb:
+        balancer_d = {
+            'id': lb.id,
+            'name': lb.name
+        }
+    else:
+        balancer_d = {}
+
+    return False, "Load balancer %s already %s" % (name, ensure), balancer_d
+
+
+def get_action(lb, ensure):
+    if ensure == "present" and not lb:
+        return create_lb
+    elif ensure == "absent" and lb:
+        return delete_lb
+    else:
+        return do_nothing
+
+
+def get_lb(lb_con, name, **kwargs):
+    """
+    Retrieves and returns the load balancer object referred to by ``name``.
+    Returns None if the load balancer is not found.
+    """
+    if is_uuid(name):
+        return get_lb_by_id(lb_con, name)
+    else:
+        return get_lb_by_name(lb_con, name)
+
+
+def get_lb_by_id(lb_con, name):
+    try:
+        return lb_con.get_balancer(name)
+    except DimensionDataAPIException as err:
+        if err.code == 'RESOURCE_NOT_FOUND':
+            return None
+        else:
+            msg = "Error in retrieving load balancer %s: %s" % (name, err)
+            raise GetLoadBalancerError(msg)
+
+
+def get_lb_by_name(lb_con, name):
+    balancers = lb_con.list_balancers()
+    found = filter(lambda x: x.name == name, balancers)
+
+    if found:
+        return found[0]
+    else:
+        return None
+
+
+def initialize(region, location, network_domain, verify_ssl_cert, **kwargs):
+    """
+    Initialize backend sessions/connections required by this module
+    """
+    credentials = get_credentials()
+    username = credentials["user_id"]
+    password = credentials["key"]
+    region = 'dd-%s' % region
+
+    # Verify the API server's SSL certificate?
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
+
+    # Connect to compute service
+    compute_drv = get_cp_driver(ComputeProvider.DIMENSIONDATA)
+    compute_con = compute_drv(username, password, region=region)
+
+    # Get Network Domain Object
+    net_domain = get_network_domain(compute_con, network_domain, location)
+
+    if not net_domain:
+        raise InitializeError("Network domain %s could not be found" %
+                              network_domain)
+
+    # Connect to load balancer service
+    lb_drv = get_lb_driver(LBProvider.DIMENSIONDATA)
+    lb_con = lb_drv(username, password, region=region)
+
+    lb_con.ex_set_current_network_domain(net_domain.id)
+
+    return lb_con, compute_con, net_domain
+
+
+def start(mod):
+    if not HAS_LIBCLOUD:
+        mod.fail_json(msg="apache-libcloud is required for this module.")
+
+    try:
+        lb_con, compute_con, net_domain = initialize(**mod.params)
+
+        lb = get_lb(lb_con=lb_con, **mod.params)
+
+        action = get_action(lb=lb, ensure=mod.params["ensure"])
+
+        # Passing in the AnsibleModule instance below is not ideal, but I
+        # don't have much choice (and time) right now. Ideally, none of the
+        # methods called by start() should have to know about AnsibleModule
+        # but since the dependency on it runs deep in the underlying code,
+        # we'll have to pass it in until we can clean the various parts.
+        changed, msg, lb_dict = action(lb=lb,
+                                       lb_con=lb_con,
+                                       compute_con=compute_con,
+                                       net_domain=net_domain,
+                                       mod=mod,
+                                       **mod.params)
+
+        mod.exit_json(changed=changed,
+                      msg=msg,
+                      load_balancer=lb_dict)
+    except (CreateError,
+            DeleteError,
+            GetLoadBalancerError,
+            InitializeError) as err:
+        msg = "%r" % err
+        mod.fail_json(msg=msg)
 
 
 def main():
+    regions = get_dd_regions()
+
+    protocols = ['any', 'tcp', 'udp', 'http', 'ftp', 'smtp']
+
+    algorithms = ['ROUND_ROBIN',
+                  'LEAST_CONNECTIONS',
+                  'SHORTEST_RESPONSE',
+                  'PERSISTENT_IP']
+
     module = AnsibleModule(
         argument_spec=dict(
-            region=dict(default='na', choices=dd_regions),
+            region=dict(default='na', choices=regions),
             location=dict(required=True, type='str'),
             network_domain=dict(required=True, type='str'),
             name=dict(required=True, type='str'),
             port=dict(default=None, type='int'),
             protocol=dict(default='http', choices=protocols),
-            algorithm=dict(default='ROUND_ROBIN', choices=lb_algs),
+            algorithm=dict(default='ROUND_ROBIN', choices=algorithms),
             members=dict(default=None, type='list'),
             ensure=dict(default='present', choices=['present', 'absent']),
-            verify_ssl_cert=dict(required=False, default=True, type='bool'),
-            listener_ip_address=dict(required=False, default=None, type='str')
+            verify_ssl_cert=dict(default=True, type='bool'),
+            listener_ip_address=dict(default=None, type='str')
         ),
     )
 
-    if not HAS_LIBCLOUD:
-        module.fail_json(msg='libcloud is required for this module.')
-
-    # set short vars for readability
-    credentials = get_credentials()
-    if credentials is False:
-        module.fail_json(msg="User credentials not found")
-    user_id = credentials['user_id']
-    key = credentials['key']
-    region = 'dd-%s' % module.params['region']
-    location = module.params['location']
-    network_domain = module.params['network_domain']
-    name = module.params['name']
-    verify_ssl_cert = module.params['verify_ssl_cert']
-    ensure = module.params['ensure']
-
-    # -------------------
-    # Instantiate drivers
-    # -------------------
-    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
-    # Instantiate Load Balancer Driver
-    DDLoadBalancer = get_lb_driver(LBProvider.DIMENSIONDATA)
-    lb_driver = DDLoadBalancer(user_id, key, region=region)
-    # Instantiate Compute Driver
-    DDCompute = get_cp_driver(ComputeProvider.DIMENSIONDATA)
-    cp_driver = DDCompute(user_id, key, region=region)
-
-    # Get Network Domain Object
-    net_domain = get_network_domain(cp_driver, network_domain, location)
-    if net_domain is False:
-        module.fail_json(msg="Network domain could not be found.")
-
-    # Set Load Balancer Driver network domain
-    try:
-        lb_driver.ex_set_current_network_domain(net_domain.id)
-    except:
-        module.fail_json(msg="Current network domain could not be set.")
-
-    # Process action
-    if ensure == 'present':
-        balancer = get_balancer(module, lb_driver, name)
-        if balancer is False:
-            create_balancer(module, lb_driver, cp_driver, net_domain)
-        else:
-            module.exit_json(changed=False, msg="Load balancer already " +
-                             "exists.", load_balancer=balancer_obj_to_dict(
-                                 balancer))
-    elif ensure == 'absent':
-        balancer = get_balancer(module, lb_driver, name)
-        if balancer is False:
-            module.exit_json(changed=False, msg="Load balancer with name " +
-                             "%s does not exist" % name)
-        try:
-            pool_id = balancer.extra.get('pool_id')
-            if pool_id:
-                pool = lb_driver.ex_get_pool(pool_id)
-
-            res = lb_driver.destroy_balancer(balancer)
-
-            if pool:
-                members = lb_driver.ex_get_pool_members(pool_id)
-                for member in members:
-                    lb_driver.ex_destroy_pool_member(member, destroy_node=True)
-                lb_driver.ex_destroy_pool(pool)
-
-            module.exit_json(changed=True, msg="Load balancer deleted. " +
-                             "Status: %s" % res)
-        except DimensionDataAPIException as e:
-            module.fail_json(msg="Unexpected error when attempting to delete" +
-                             " load balancer: %s" % e)
-    else:
-        fail_json(msg="Requested ensure was " +
-                  "'%s'. Status must be one of 'present', 'absent'." % ensure)
+    start(module)
 
 if __name__ == '__main__':
     main()

--- a/cloud/dimensiondata/dimensiondata_load_balancer_node.py
+++ b/cloud/dimensiondata/dimensiondata_load_balancer_node.py
@@ -1,0 +1,269 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Dimension Data
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   - Aimon Bustardo <aimon.bustardo@dimensiondata.com>
+#   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
+#   - Jay Riddell    <Jay.Riddell@dimensiondata.com>
+#
+from ansible.module_utils.basic import *
+from ansible.module_utils.dimensiondata import *
+try:
+    from libcloud.common.dimensiondata import DimensionDataAPIException
+    from libcloud.loadbalancer.types import Provider as LBProvider
+    from libcloud.compute.types import Provider as ComputeProvider
+    from libcloud.loadbalancer.providers import get_driver as get_lb_driver
+    from libcloud.compute.providers import get_driver as get_cp_driver
+    import libcloud.security
+    HAS_LIBCLOUD = True
+except:
+    HAS_LIBCLOUD = False
+
+# Get regions early to use in docs etc.
+dd_regions = get_dd_regions()
+
+DOCUMENTATION = '''
+---
+module: dimensiondata_load_balancer_node
+description:
+  - Create, update or delete a Load Balancer Node.
+short_description: Create, update or delete load balancer nodes.
+version_added: "2.2"
+author: 'Aimon Bustardo (@aimonb)'
+options:
+  region:
+    description:
+      - The target region.
+    choices:
+      - Regions choices are defined in Apache libcloud project [libcloud/common/dimensiondata.py]
+      - Regions choices are also listed in https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html
+      - Note that the region values are available as list from dd_regions().
+      - Note that the default value "na" stands for "North America".  The code prepends 'dd-' to the region choice.
+    default: na
+  location:
+    description:
+      - The target datacenter.
+    required: true
+  network_domain:
+    description:
+      - The target network name or ID.
+    required: true
+  name:
+    description:
+      - Name of the node.
+    required: true
+  description:
+    description:
+      - Description of the node.
+    required: false
+    default: null
+  ip:
+    description:
+        - Node IP address.
+    required: false
+    default: null
+  connection_limit:
+    description:
+        - Maximum number of concurrent connections per second.
+    required: false
+    default: 2000
+  connection_rate_limit:
+    description:
+        - Maximum number of concuurrent sessions.
+    required: false
+    default: 25000
+  verify_ssl_cert:
+    description:
+      - Check that SSL certificate is valid.
+    required: false
+    default: true
+  ensure:
+    description:
+      - present, absent.
+    choices: ['present', 'absent']
+    default: present
+'''
+
+
+EXAMPLES = '''
+# Construct Load Balancer Node
+- dimensiondata_load_balancer_node:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: web_lb01_node01
+    ensure: present
+'''
+
+
+RETURN = '''
+load_balancer_node:
+    description: Dictionary describing the Load Balancer Node.
+    returned: On success when I(ensure) is 'present'
+    type: dictionary
+    contains:
+        id:
+            description: Load Balancer Node ID.
+            type: string
+            sample: "aaaaa000-a000-4050-a215-2808934ccccc"
+        name:
+            description: Node name.
+            type: string
+            sample: "lb01_node01"
+        ip:
+            description: IP address of node.
+            type: string
+            sample: 10.0.0.4
+        description:
+            description: Node description.
+            type: string
+            sample: My web node 1.
+        connection_limit:
+            description: Maximum number of concurrent connections per second.
+            type: integer
+            sample: 2000
+        connection_rate_limit:
+            description: Maximum number of concurrent sessions.
+            type: integer
+            sample: 25000
+        status:
+            description: Node status.
+            type: integer
+            sample: NORMAL
+'''
+
+
+def list_nodes(module, lb_driver):
+    try:
+        nodes = lb_driver.ex_get_nodes()
+        return nodes
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Failed to retrieve a list of nodes: %s" % e)
+
+
+def node_obj_to_dict(node_obj):
+    return {
+        'id': node_obj.id,
+        'name': node_obj.name,
+        'ip': node_obj.ip,
+        'connection_limit': node_obj.connection_limit,
+        'connection_rate_limit': node_obj.connection_rate_limit,
+        'status': node_obj.status
+    }
+
+
+def create_node(module, lb_driver, domain_id):
+    try:
+        node = lb_driver.ex_create_node(domain_id, module.params['name'],
+                                        module.params['ip'],
+                                        module.params['description'],
+                                        module.params['connection_limit'],
+                                        module.params['connection_rate_limit'])
+        module.exit_json(changed=True, msg="Success.",
+                         load_balancer_node=node_obj_to_dict(node))
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Error while creating load balancer node: %s" % e)
+
+
+def destroy_node(module, lb_driver, node):
+    try:
+        res = lb_driver.ex_destroy_node(node.id)
+        module.exit_json(changed=True, msg="Load balancer node deleted. " +
+                         "Status: %s" % res)
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Faield to delete/destroy node '%s'" % node.name +
+                         ': %s' % e)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec=dict(
+            region=dict(default='na', choices=dd_regions),
+            location=dict(required=True, type='str'),
+            network_domain=dict(required=True, type='str'),
+            name=dict(required=True, type='str'),
+            description=dict(default=None, type='str'),
+            ip=dict(default=None, type='str'),
+            connection_limit=dict(required=False, default=2000, type='int'),
+            connection_rate_limit=dict(required=False, default=25000,
+                                       type='int'),
+            ensure=dict(default='present', choices=['present', 'absent']),
+            verify_ssl_cert=dict(required=False, default=True, type='bool'),
+        ),
+    )
+
+    if not HAS_LIBCLOUD:
+        module.fail_json(msg='libcloud is required for this module.')
+
+    # set short vars for readability
+    credentials = get_credentials()
+    if credentials is False:
+        module.fail_json(msg="User credentials not found")
+    user_id = credentials['user_id']
+    key = credentials['key']
+    region = 'dd-%s' % module.params['region']
+    location = module.params['location']
+    network_domain = module.params['network_domain']
+    verify_ssl_cert = module.params['verify_ssl_cert']
+    ensure = module.params['ensure']
+
+    # -------------------
+    # Instantiate drivers
+    # -------------------
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
+    # Instantiate Load Balancer Driver
+    DDLoadBalancer = get_lb_driver(LBProvider.DIMENSIONDATA)
+    lb_driver = DDLoadBalancer(user_id, key, region=region)
+    # Instantiate Compute Driver
+    DDCompute = get_cp_driver(ComputeProvider.DIMENSIONDATA)
+    cp_driver = DDCompute(user_id, key, region=region)
+
+    # Get Network Domain Object
+    net_domain = get_network_domain(cp_driver, network_domain, location)
+    if net_domain is False:
+        module.fail_json(msg="Network domain could not be found.")
+
+    # Set Load Balancer Driver network domain
+    try:
+        lb_driver.ex_set_current_network_domain(net_domain.id)
+    except:
+        module.fail_json(msg="Current network domain could not be set.")
+
+    # Process action
+    node = get_node_by_name_and_ip(module, lb_driver, module.params['name'],
+                                   module.params['ip'])
+    if ensure == 'present':
+        if node is None:
+            create_node(module, lb_driver, net_domain.id)
+        else:
+            module.exit_json(changed=False, msg="Load balancer node already " +
+                             "exists.",
+                             load_balancer_node=node_obj_to_dict(node))
+    elif ensure == 'absent':
+        if node is None:
+            module.exit_json(changed=False, msg="Load balancer node with " +
+                             "name %s does not exist." % module.params['name'])
+        else:
+            destroy_node(module, lb_driver, node)
+    else:
+        fail_json(msg="Requested ensure was " +
+                  "'%s'. Status must be one of 'present', 'absent'." % ensure)
+
+if __name__ == '__main__':
+    main()

--- a/cloud/dimensiondata/dimensiondata_load_balancer_node.py
+++ b/cloud/dimensiondata/dimensiondata_load_balancer_node.py
@@ -186,8 +186,8 @@ def destroy_node(module, lb_driver, node):
         module.exit_json(changed=True, msg="Load balancer node deleted. " +
                          "Status: %s" % res)
     except DimensionDataAPIException as e:
-        module.fail_json(msg="Faield to delete/destroy node '%s'" % node.name +
-                         ': %s' % e)
+        module.fail_json(msg="Error while attempting to delete/destroy" + 
+                         " node '%s' : %s" % ( node.name, e))
 
 
 def main():

--- a/cloud/dimensiondata/dimensiondata_load_balancer_pool.py
+++ b/cloud/dimensiondata/dimensiondata_load_balancer_pool.py
@@ -1,0 +1,457 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Dimension Data
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   - Aimon Bustardo <aimon.bustardo@dimensiondata.com>
+#   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
+#   - Jay Riddell    <Jay.Riddell@dimensiondata.com>
+#
+from ansible.module_utils.basic import *
+from ansible.module_utils.dimensiondata import *
+try:
+    from libcloud.common.dimensiondata import DimensionDataAPIException
+    from libcloud.loadbalancer.types import Provider as LBProvider
+    from libcloud.compute.types import Provider as ComputeProvider
+    from libcloud.loadbalancer.providers import get_driver as get_lb_driver
+    from libcloud.compute.providers import get_driver as get_cp_driver
+    import libcloud.security
+    HAS_LIBCLOUD = True
+except:
+    HAS_LIBCLOUD = False
+
+# Get regions early to use in docs etc.
+dd_regions = get_dd_regions()
+
+# Virtual Listener Protocols
+protocols = ['any', 'tcp', 'udp', 'http', 'ftp', 'smtp']
+# Load Balancing algorithms
+lb_algs = ['ROUND_ROBIN', 'LEAST_CONNECTIONS',
+           'SHORTEST_RESPONSE', 'PERSISTENT_IP']
+
+DOCUMENTATION = '''
+---
+module: dimensiondata_load_balancer_pool
+description:
+  - Create, update or delete .
+short_description: Create, update or delete load balancer pools.
+version_added: "2.2"
+author: 'Aimon Bustardo (@aimonb)'
+options:
+  region:
+    description:
+      - The target region.
+    choices:
+      - Regions choices are defined in Apache libcloud project [libcloud/common/dimensiondata.py]
+      - Regions choices are also listed in https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html
+      - Note that the region values are available as list from dd_regions().
+      - Note that the default value "na" stands for "North America".  The code prepends 'dd-' to the region choice.
+    default: na
+  location:
+    description:
+      - The target datacenter.
+    required: true
+  network_domain:
+    description:
+      - The target network name or target network ID.
+    required: true
+  name:
+    description:
+      - Name of the Load Balancer Pool.
+    required: true
+  description:
+    description:
+      - Description of the Load Balancer Pool.
+    required: false
+    default: null
+  load_balance_method:
+    description:
+        - The load balancer algorithm (required).
+    required: False
+    choices:
+        - 'ROUND_ROBIN'
+        - 'LEAST_CONNECTIONS'
+        - 'SHORTEST_RESPONSE'
+        - 'PERSISTENT_IP'
+    default: ROUND_ROBIN
+  health_monitor_1:
+    description:
+        - Health monitor 1.
+    required: false
+    default: null
+    choices: ['Http', 'Https', 'Tcp', 'TcpHalfOpen', 'Udp']
+  health_monitor_2:
+    description:
+        - Health monitor 2.
+    required: false
+    default: null
+    choices: ['Http', 'Https', 'Tcp', 'TcpHalfOpen', 'Udp']
+  service_down_action:
+    description:
+      -  What to do when node is unavailable NONE, DROP or RESELECT.
+    required: false
+    choices: ['NONE', 'DROP', 'RESELECT']
+    default: 'NONE'
+  slow_ramp_time:
+    description:
+        - Number of seconds to stagger ramp up of nodes.
+    required: false
+    default: 30
+  members:
+    description:
+      - Nested dictionaries of pool members name ip and port.
+      - "In format of {<name>: {'ip': <ip>, 'port': <port>}, ...}"
+    required: false
+    default: null
+  destroy_nodes:
+    description:
+      - Destroy nodes when removing members.
+    required: false
+    type: bool
+    default: true
+  verify_ssl_cert:
+    description:
+      - Check that SSL certificate is valid.
+    required: false
+    default: true
+  ensure:
+    description:
+      - present, absent.
+    choices: ['present', 'absent']
+    default: present
+'''
+
+
+EXAMPLES = '''
+# Construct Load Balancer Pool
+- dimensiondata_load_balancer_pool:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: web_lb01_pool01
+    load_balance_method: ROUND_ROBIN
+    members:
+        node01:
+            ip: 10.0.0.4
+            port: 80
+        node02
+            ip: 10.0.0.5
+            port: 80
+        10.0.0.6
+            ip: 10.0.0.6
+            port: 8080
+    ensure: present
+# Remove one member from same Load Balancer Pool
+- dimensiondata_load_balancer_pool:
+    region: na
+    location: NA5
+    network_domain: 09bb085f-c1cb-5c59-aa1d-53b3d8be214c
+    name: web_lb01_pool01
+    load_balance_method: ROUND_ROBIN
+    members:
+        node01:
+            ip: 10.0.0.4
+            port: 80
+        node02:
+            ip: 10.0.0.5
+            port: 80
+    ensure: present
+# Delete Pool
+- dimensiondata_load_balancer_pool:
+    region: na
+    location: NA5
+    network_domain: test_network
+    name: web_lb01_pool01
+    ensure: absent
+'''
+
+
+RETURN = '''
+load_balancer_pool:
+    description: Dictionary describing the Load Balancer Pool.
+    returned: On success when I(ensure) is 'present'
+    type: dictionary
+    contains:
+        id:
+            description: Load Balancer Pool ID.
+            type: string
+            sample: "aaaaa000-a000-4050-a215-2808934ccccc"
+        name:
+            description: Pool name.
+            type: string
+            sample: "lb01_pool01"
+        load_balance_method:
+            description: Member load balancing method.
+            type: string
+            sample: ROUND_ROBIN
+        slow_ramp_time:
+            description: Number of seconds to stagger ramp up of nodes.
+            type: integer
+            sample: 30
+        service_down_action:
+            description: What to do when node is unavailable.
+            type: string
+            sample: RESELECT
+        health_monitor_id:
+            description: ID of chosen health monitor.
+            type: string
+            example: None
+        members:
+            description: List of attached nodes and their ports.
+            type: list
+            example:
+                node01:
+                    id: b78dfbf8-ff7c-48c3-8fc9-aaaaaaaaaaaa
+                    node_id: 618f5527-3d83-4539-aaaaaaaaaaaa
+                    ip: 192.168.0.4
+                    port: 80
+                    status: NORMAL
+                node02:
+                    id: b78dfbf8-ff7c-48c3-8fc9-bbbbbbbbbbbb
+                    node_id: 618f5527-3d83-4539-bbbbbbbbbbbb
+                    ip: 192.168.0.5
+                    port: 80
+                    status: NORMAL
+        status:
+            description: Load balancer pool status.
+            type: integer
+            sample: NORMAL
+'''
+
+
+def list_pools(module, lb_driver):
+    try:
+        pools = lb_driver.ex_get_pools()
+        return pools
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Failed to retrieve a list of pools: %s" % e)
+
+
+def get_pool(module, lb_driver):
+    if is_uuid(module.params['name']):
+        try:
+            return lb_driver.ex_get_pool(module.params['name'])
+        except DimensionDataAPIException as e:
+            if e.code == 'RESOURCE_NOT_FOUND':
+                return False
+            else:
+                module.fail_json("Unexpected API error code: %s" % e.code)
+    else:
+        pools = list_pools(module, lb_driver)
+        found_pools = filter(lambda x: x.name == module.params['name'], pools)
+        if len(found_pools) > 0:
+            pool_id = found_pools[0].id
+            try:
+                return lb_driver.ex_get_pool(pool_id)
+            except DimensionDataAPIException as e:
+                module.fail_json(msg="Unexpected error while retrieving load" +
+                                 " balancer pool details with id" +
+                                 " %s" % pool_id)
+        else:
+            return False
+
+
+def pool_obj_to_dict(pool_obj, members):
+    return {
+        'id': pool_obj.id,
+        'name': pool_obj.name,
+        'description': pool_obj.description,
+        'status': pool_obj.status,
+        'load_balance_method': pool_obj.load_balance_method,
+        'slow_ramp_time': pool_obj.slow_ramp_time,
+        'service_down_action': pool_obj.service_down_action,
+        'health_monitor_id': pool_obj.health_monitor_id,
+        'members': pool_members_to_dict(members)
+    }
+
+
+def pool_members_to_dict(members):
+    members_dict = {}
+    for member in members:
+        members_dict[member.name] = {'id': member.node_id,
+                                     'ip': member.ip,
+                                     'port': member.port
+                                     }
+    return members_dict
+
+
+def to_health_monitor(module, domain_id, lb_driver, monitor_txt):
+    mon_string = 'CCDEFAULT.%s' % monitor_txt
+    try:
+        monitors = lb_driver.ex_get_default_health_monitors(domain_id)
+        monitor_list = filter(lambda x: x.name == mon_string, monitors)
+        if len(monitor_list) > 0:
+            return monitor_list[0]
+        else:
+            module.fail_json(msg="Health monitor '%s' not found." % mon_string)
+    except DimensionDataAPIException as e:
+        module.fail_json(msg='Failed to get monitor list: %s' % e)
+
+
+def create_pool(module, lb_driver, domain_id):
+    # Build monitors
+    monitors = [to_health_monitor(module, domain_id, lb_driver,
+                module.params['health_monitor_1']),
+                to_health_monitor(module, domain_id, lb_driver,
+                module.params['health_monitor_2'])
+                ]
+    try:
+        pool = lb_driver.ex_create_pool(domain_id, module.params['name'],
+                                        module.params['load_balance_method'],
+                                        module.params['description'],
+                                        monitors,
+                                        module.params['service_down_action'],
+                                        module.params['slow_ramp_time'])
+        return pool
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Error while creating load balancer pool: %s" % e)
+
+
+def quiesce_members(module, lb_driver, pool):
+    changed = False
+    # Desired members
+    desired_members = module.params['members']
+    # Get current list of members
+    existing_members = lb_driver.ex_get_pool_members(pool.id)
+    # Quiesced members
+    quiesced_members = []
+    # Get desired members details / Make sure they exist
+    for name, data in desired_members.iteritems():
+        # Quiesce node
+        node = get_node_by_name_and_ip(module, lb_driver, name, data['ip'])
+        if node is None:
+            # Exit with error since nodes should pre-exist
+            module.fail_json(msg="Node '%s' does not exist. " % name +
+                             "You must create node first.")
+        else:
+            # node exists, let see if its attached and attach if not.
+            res = filter(lambda x: x.node_id == node.id,
+                         existing_members)
+            if len(res) == 0:
+                # We need to attach it (create member object)
+                try:
+                    mem_port = module.params['members'][node.name]['port']
+                    n_member = lb_driver.ex_create_pool_member(pool=pool,
+                                                               node=node,
+                                                               port=mem_port)
+                    # Add to quiesced list
+                    quiesced_members.append(n_member)
+                    changed = True
+                except DimensionDataAPIException as e:
+                    module.fail_json(msg="Creation of pool member failed: " +
+                                     "%s" % e)
+            else:
+                # Node is attached, add to quiesced list
+                quiesced_members.append(res[0])
+    # Remove unlisted nodes
+    to_delete = list(set(existing_members) - set(quiesced_members))
+    for member in to_delete:
+        dn = module.params['destroy_nodes']
+        lb_driver.ex_destroy_pool_member(member, destroy_node=dn)
+        changed = True
+    return (changed, quiesced_members)
+
+
+def main():
+
+    monitor_methods = ['Http', 'Https', 'Tcp', 'TcpHalfOpen', 'Udp']
+    down_actions = ['DROP', 'RESELECT', 'NONE']
+    lb_methods = ['ROUND_ROBIN', 'LEAST_CONNECTIONS', 'SHORTEST_RESPONSE',
+                  'PERSISTENT_IP']
+    module = AnsibleModule(
+        argument_spec=dict(
+            region=dict(default='na', choices=dd_regions),
+            location=dict(required=True, type='str'),
+            network_domain=dict(required=True, type='str'),
+            name=dict(required=True, type='str'),
+            description=dict(default=None, type='str'),
+            load_balance_method=dict(default='ROUND_ROBIN',
+                                     choices=lb_methods),
+            health_monitor_1=dict(default=None, choices=monitor_methods),
+            health_monitor_2=dict(default=None, choices=monitor_methods),
+            service_down_action=dict(default='NONE', choices=down_actions),
+            slow_ramp_time=dict(required=False, default=30, type='int'),
+            members=dict(required=False, default=None, type='dict'),
+            destroy_nodes=dict(required=False, default=True, type='bool'),
+            ensure=dict(default='present', choices=['present', 'absent']),
+            verify_ssl_cert=dict(required=False, default=True, type='bool'),
+        ),
+    )
+
+    if not HAS_LIBCLOUD:
+        module.fail_json(msg='libcloud is required for this module.')
+
+    # set short vars for readability
+    credentials = get_credentials()
+    if credentials is False:
+        module.fail_json(msg="User credentials not found")
+    user_id = credentials['user_id']
+    key = credentials['key']
+    region = 'dd-%s' % module.params['region']
+    location = module.params['location']
+    network_domain = module.params['network_domain']
+    verify_ssl_cert = module.params['verify_ssl_cert']
+    ensure = module.params['ensure']
+
+    # -------------------
+    # Instantiate drivers
+    # -------------------
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
+    # Instantiate Load Balancer Driver
+    DDLoadBalancer = get_lb_driver(LBProvider.DIMENSIONDATA)
+    lb_driver = DDLoadBalancer(user_id, key, region=region)
+    # Instantiate Compute Driver
+    DDCompute = get_cp_driver(ComputeProvider.DIMENSIONDATA)
+    cp_driver = DDCompute(user_id, key, region=region)
+
+    # Get Network Domain Object
+    net_domain = get_network_domain(cp_driver, network_domain, location)
+    if net_domain is False:
+        module.fail_json(msg="Network domain could not be found.")
+
+    # Set Load Balancer Driver network domain
+    try:
+        lb_driver.ex_set_current_network_domain(net_domain.id)
+    except:
+        module.fail_json(msg="Current network domain could not be set.")
+
+    # Process action
+    pool = get_pool(module, lb_driver)
+    if ensure == 'present':
+        if pool is False:
+            pool = create_pool(module, lb_driver, net_domain.id)
+        changed, qm = quiesce_members(module, lb_driver, pool)
+        module.exit_json(changed=changed, msg="Load balancer pool " +
+                         "successfully quiesced.",
+                         load_balancer_pool=pool_obj_to_dict(pool, qm))
+    elif ensure == 'absent':
+        if pool is False:
+            module.exit_json(changed=False, msg="Load balancer pool with " +
+                             "name %s does not exist" % module.params['name'])
+        try:
+            res = lb_driver.ex_destroy_pool(pool)
+            module.exit_json(changed=True, msg="Load balancer pool deleted. " +
+                             "Status: %s" % res)
+        except DimensionDataAPIException as e:
+            module.fail_json(msg="Unexpected error when attempting to delete" +
+                             " load balancer pool: %s" % e)
+    else:
+        fail_json(msg="Requested ensure was " +
+                  "'%s'. Status must be one of 'present', 'absent'." % ensure)
+
+if __name__ == '__main__':
+    main()

--- a/cloud/dimensiondata/dimensiondata_load_balancer_pool.py
+++ b/cloud/dimensiondata/dimensiondata_load_balancer_pool.py
@@ -335,8 +335,8 @@ def quiesce_members(module, lb_driver, pool):
         node = get_node_by_name_and_ip(module, lb_driver, name, data['ip'])
         if node is None:
             # Exit with error since nodes should pre-exist
-            module.fail_json(msg="Node '%s' does not exist. " % name +
-                             "You must create node first.")
+            module.fail_json(msg="Node '%s' does not exist. " +
+                             "You must create node first." % name)
         else:
             # node exists, let see if its attached and attach if not.
             res = filter(lambda x: x.node_id == node.id,

--- a/cloud/dimensiondata/dimensiondata_virtual_listener.py
+++ b/cloud/dimensiondata/dimensiondata_virtual_listener.py
@@ -1,0 +1,620 @@
+#!/usr/bin/python
+
+# -*- coding: utf-8 -*-
+#
+# Copyright (c) 2016 Dimension Data
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors:
+#   - Jay Riddell <jay.riddell@dimensiondata.com>
+#   - Bert Diwa      <Lamberto.Diwa@dimensiondata.com>
+#
+from ansible.module_utils.basic import *
+from ansible.module_utils.dimensiondata import *
+try:
+    from libcloud.common.dimensiondata import DimensionDataAPIException
+    from libcloud.loadbalancer.types import Provider as LBProvider
+    from libcloud.compute.types import Provider as ComputeProvider
+    from libcloud.loadbalancer.providers import get_driver as get_lb_driver
+    from libcloud.compute.providers import get_driver as get_cp_driver
+    import libcloud.security
+    HAS_LIBCLOUD = True
+except:
+    HAS_LIBCLOUD = False
+
+# enumerated type/choices
+persis_type_choices = ['STANDARD', 'PERFORMANCE_LAYER_4',
+                       'standard', 'performance_layer_4']
+std_protocol_choices = ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP',
+                        'any', 'tcp', 'udp', 'http', 'ftp', 'smtp']
+combined_protocol_choices = ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP',
+                             'any', 'tcp', 'udp', 'http', 'ftp', 'smtp']
+perf4_protocol_choices = ['ANY', 'TCP', 'UDP', 'HTTP',
+                          'any', 'tcp', 'udp', 'http']
+source_port_choices = ['PRESERVE', 'PRESERVE_STRICT', 'CHANGE',
+                       'preserve', 'preserve_strict', 'change']
+ensure_choices = ['PRESENT', 'ABSENT',
+                  'present', 'absent']
+
+# Get regions early to use in docs etc.
+dd_regions = get_dd_regions()
+
+DOCUMENTATION = '''
+---
+module: dimensiondata_virtual_listener
+description:
+  - Create or delete virtual listeners
+short_description: Create or delete virtual listeners
+version_added: 2.2
+author: 'Jay Riddell (@jr2730)'
+options:
+  region:
+    description:
+      - The target region.
+    choices:
+      - Regions choices are defined in Apache libcloud project [libcloud/common/dimensiondata.py]
+      - Regions choices are also listed in https://libcloud.readthedocs.io/en/latest/compute/drivers/dimensiondata.html
+      - Note that the region values are available as list from dd_regions().
+      - Note that the default value "na" stands for "North America".  The code prepends 'dd-' to the region choice.
+    default: na
+  location:
+    description:
+      - The target datacenter.
+    required: true
+  network_domain:
+    description:
+      - The target network name or ID.
+    required: true
+  name:
+    description:
+      - Name of the Virtual Listener.
+    required: true
+  ex_description:
+    description:
+        - description of the virtual listener
+    required: false
+    default: None
+  pool_name:
+    description:
+        - name of the listener pool
+    required: false
+    default: None
+  port:
+    description:
+        - An integer in the range of 1-65535.
+        - If not supplied, it will be taken to mean "Any Port"
+    required: false
+    default: None
+  persis_prof_type:
+    description:
+        - Describes the TYPE of the Persistence Profile that is desired
+        - One of STANDARD or PERFORMANCE_LAYER_4
+        - If this is not None, then persis_prof_protocol must be not None
+        - If this is None, then persis_prof_protocol must be None
+    required: false
+    choices: ['STANDARD', 'PERFORMANCE_LAYER_4']
+    default: None
+  persis_prof_protocol:
+    description:
+        - Describes the protocol of the Persistence Profile that is desired
+        - The value of persis_prof_type controls the legal values here
+        - STANDARD- choices are ANY, TCP, UDP, HTTP, FTP, SMTP
+        - PERFORMANCE_LAYER_4- choices are ANY, TCP, UDP, HTTP
+        - If this is not None, then persis_prof_type must be not None
+        - If this is None, then persis_prof_type must be None
+    required: false
+    choices: ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP']
+    default: None
+  fb_persis_prof_type:
+    description:
+        - This describes the Fallback persistence profile that is desired
+        - (All same persis_* "rules" apply here)
+        - Also, cannot have fb_* (aka Fallback) unless you have "regular"
+        - So, fb_* cannot be not None unless persis_* values are not None
+        - Also, fb_* values must be different than persis_* values
+    required: false
+    choices: ['STANDARD', 'PERFORMANCE_LAYER_4']
+    default: None
+  fb_persis_prof_protocol:
+    description:
+        - (see fb_persis_prof_type)
+    required: false
+    choices: ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP']
+    default: None
+  irule_persis_prof_type:
+    description:
+        - This describes the iRule persistence profile that is desired
+        - (All same persis_* "rules" apply here)
+    required: false
+    choices: ['STANDARD', 'PERFORMANCE_LAYER_4']
+    default: None
+  irule_persis_prof_protocol:
+    description:
+        - (see irule_persis_prof_type)
+    required: false
+    choices: ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP']
+    default: None
+  protocol:
+    description:
+        - The protocol for the connection.
+        - Permitted range of value are govened by the port value.
+        - If port is 80 or 443, then STANDARD else Layer4
+        - STANDARD- choose from ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP']
+        - PERFORMANCE_LAYER_4- choose from ['ANY', 'TCP', 'UDP', 'HTTP']
+    choices: ['ANY', 'TCP', 'UDP', 'HTTP', 'FTP', 'SMTP']
+    required: true
+    default: HTTP
+  verify_ssl_cert:
+    description:
+      - Check that SSL certificate is valid.
+    required: false
+    default: true
+  listener_ip_address:
+    description:
+        - The address on which the virtual listener should listen
+        - Must be a valid IPv4 in dot-decimal notation (x.x.x.x).
+        - Is opt here; but must be supplied before this object is viable
+    required: false
+    default: None
+  connection_limit:
+    description:
+        - Integer in range 1..25,000
+    required: false
+    default: 25000
+  connection_rate_limit:
+    description:
+        - Integer in range 1..4,000
+    required: false
+    default: 2000
+  source_port_preservation:
+    description:
+        - Must be one of PRESERVE, PRESERVE_STRICT or CHANGE
+    required: true
+    choices: ['PRESERVE', 'PRESERVE_STRICT', 'CHANGE']
+    default: PRESERVE
+  ensure:
+    description:
+      - Indicates state that is desired.
+      - present = create as needed
+      - absent = delete as needed
+    choices: ['present', 'absent']
+    default: present
+'''
+
+
+EXAMPLES = '''
+# Construct Virtual Listener
+    - name: Create a Virtual Listener with new params
+      dimensiondata_virtual_listener:
+        region: na
+        location: NA12
+        network_domain: my_network
+        name: my_virtual_listener
+        pool_name: my_pool
+        port: 80
+        persis_prof_type: STANDARD
+        persis_prof_protocol: SMTP
+        protocol: HTTP
+        ensure: present
+'''
+
+RETURN = '''
+virtual_listener:
+    description: Dictionary describing the Virtual Listener.
+    returned: On success when I(ensure) is 'present'
+    type: dictionary
+    contains:
+        id:
+            description: Virtual Listener ID.
+            type: string
+            sample: "aaaaa000-a000-4050-a215-2808934ccccc"
+        name:
+            description: Virtual Listener name.
+            type: string
+            sample: "My Virtual Listener"
+        status:
+            description: state returned from libcloud.loadbalancer.types.State
+            type: integer
+            sample: 0
+        ip:
+            description: Listen VIP of Virtual Listener.
+            type: string
+            sample: 168.128.1.1
+'''
+
+
+def does_virt_compat_match_type_and_protocol(vl_compat_list,
+                                             type_to_match,
+                                             protocol_to_match):
+    retval = False
+    if vl_compat_list is None or \
+       type_to_match is None or \
+       protocol_to_match is None or \
+       vl_compat_list.compatible_listeners is None:
+        retval = False
+    else:
+        up_protocol_to_match = protocol_to_match.upper()
+        for vl_compat in vl_compat_list.compatible_listeners:
+
+            if vl_compat.type != type_to_match:
+                retval = False
+            else:
+                if vl_compat.protocol.upper() == 'ANY':
+                    retval = True
+                else:
+                    retval = vl_compat.protocol.upper() == up_protocol_to_match
+            if retval:
+                return True
+
+    return False
+
+
+def list_pools(module, lb_driver):
+    try:
+        pools = lb_driver.ex_get_pools()
+        return pools
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Failed to retrieve a list of pools: %s" % e)
+
+
+def get_pool_given_name(module, lb_driver, name):
+    if name is None:
+        return None
+    pools = list_pools(module, lb_driver)
+    found_pools = filter(lambda x: x.name == name, pools)
+    if len(found_pools) > 0:
+        pool = found_pools[0]
+        return pool
+    else:
+        return None
+
+
+def get_vl_given_name(lb_driver, name):
+    virt_list = lb_driver.list_balancers()
+    found_vl = filter(lambda x: x.name == name, virt_list)
+    if len(found_vl) > 0:
+        vl = found_vl[0]
+        return vl
+    else:
+        return None
+
+
+def vl_obj_to_dict(vl_obj, is_really_balancer):
+    return {
+        'id': vl_obj.id,
+        'name': vl_obj.name,
+        'status': vl_obj.state if is_really_balancer else vl_obj.status,
+        'ip': vl_obj.ip
+    }
+
+
+# if this returns, then the validation passed
+# else it calls module.fail_json with an error
+# Allows for 2 different error messages
+# (to allow you to figure out which case was hit)
+def validate_type_and_protocol(module,
+                               the_type,
+                               the_protocol,
+                               the_error_message_1,
+                               the_error_message_2):
+
+    if (the_type is None and the_protocol is not None) or \
+       (the_type is not None and the_protocol is None):
+        module.fail_json(msg=the_error_message_1)
+
+    # AnsibleModule checked if protocol was in COMBINED list
+    # now check if in particular list for the given listener
+    if the_type is not None:
+        ppt = the_type.upper()
+        ppp = the_protocol.upper()
+        aok = True
+        if ppt == 'STANDARD':
+            aok = (ppp in std_protocol_choices)
+        else:
+            # ppt is layer4
+            aok = (ppp in perf4_protocol_choices)
+            if not aok:
+                module.fail_json(msg=the_error_message_2)
+
+
+def create_virtual_listener(module,
+                            network_domain,
+                            name,
+                            ex_description,
+                            port,
+                            listener_pool_name,
+                            lb_driver,
+                            cp_driver,
+                            listener_ip_address=None,
+                            persis_prof_type=None,
+                            persis_prof_protocol=None,
+                            fb_persis_prof_type=None,
+                            fb_persis_prof_protocol=None,
+                            irule_persis_prof_type=None,
+                            irule_persis_prof_protocol=None,
+                            protocol='TCP',
+                            connection_limit=25000,
+                            connection_rate_limit=2000,
+                            source_port_preservation='PRESERVE'):
+
+    matched_persis = None
+    fb_matched_persis = None
+    irule_matched_persis = None
+
+    # so we have to search for matching profile(s)
+    default_persis_profiles = \
+        lb_driver.ex_get_default_persistence_profiles(network_domain.id)
+
+    # loop through all the profiles that are compat with this network
+    for this_persis_prof in default_persis_profiles:
+
+        # persis
+        if does_virt_compat_match_type_and_protocol(this_persis_prof,
+           persis_prof_type, persis_prof_protocol):
+            matched_persis = this_persis_prof
+        else:
+            # same prof cannot be both "regular" and fb
+            # so if didn't match as "regularr", then attempt to match as FB
+            if this_persis_prof.fallback_compatible:
+                if does_virt_compat_match_type_and_protocol(this_persis_prof,
+                   fb_persis_prof_type, fb_persis_prof_protocol):
+                    fb_matched_persis = this_persis_prof
+
+    # now do mostly the same thing for iRules
+    default_irules = \
+        lb_driver.ex_get_default_irules(network_domain.id)
+
+    for this_persis_prof in default_irules:
+
+        if does_virt_compat_match_type_and_protocol(this_persis_prof,
+           irule_persis_prof_type, irule_persis_prof_protocol):
+            irule_matched_persis = this_persis_prof
+
+    # get the pool for the the given pool name
+    listener_pool = get_pool_given_name(module, lb_driver, listener_pool_name)
+
+    try:
+        virt_list = lb_driver.ex_create_virtual_listener(
+            network_domain_id=network_domain.id,
+            name=name,
+            ex_description=ex_description,
+            port=port,
+            pool=listener_pool,
+            listener_ip_address=listener_ip_address,
+            persistence_profile=matched_persis,
+            fallback_persistence_profile=fb_matched_persis,
+            irule=irule_matched_persis,
+            protocol=protocol.upper(),
+            connection_limit=connection_limit,
+            connection_rate_limit=connection_rate_limit,
+            source_port_preservation=source_port_preservation)
+
+        module.exit_json(changed=True, msg="Success.",
+                         virtual_listener=vl_obj_to_dict(virt_list, False))
+    except DimensionDataAPIException as e:
+        module.fail_json(msg="Error while creating virtual listener: %s" % e)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            region=dict(default='na', choices=dd_regions),
+            location=dict(required=True, type='str'),
+            network_domain=dict(required=True, type='str'),
+            name=dict(required=True, type='str'),
+            ex_description=dict(default=None, type='str'),
+            pool_name=dict(default=None, type='str'),
+            port=dict(default=None, type='int'),
+            persis_prof_type=dict(default=None,
+                                  choices=persis_type_choices),
+            persis_prof_protocol=dict(default=None,
+                                      choices=combined_protocol_choices),
+            fb_persis_prof_type=dict(default=None,
+                                     choices=persis_type_choices),
+            fb_persis_prof_protocol=dict(default=None,
+                                         choices=combined_protocol_choices),
+            irule_persis_prof_type=dict(default=None,
+                                        choices=persis_type_choices),
+            irule_persis_prof_protocol=dict(default=None,
+                                            choices=combined_protocol_choices),
+            protocol=dict(default='HTTP', choices=combined_protocol_choices),
+            verify_ssl_cert=dict(required=False, default=True, type='bool'),
+            listener_ip_address=dict(required=False, default=None, type='str'),
+            connection_limit=dict(required=False, default=25000, type='int'),
+            connection_rate_limit=dict(required=False, default=2000,
+                                       type='int'),
+            source_port_preservation=dict(default=source_port_choices[0],
+                                          choices=source_port_choices),
+            ensure=dict(default='present', choices=ensure_choices)
+        ),
+    )
+
+    # validation
+    #
+    # first, persis profile type and persis profile protocol
+    persis_prof_type = module.params['persis_prof_type']
+    persis_prof_protocol = module.params['persis_prof_protocol']
+    ppt = None
+    ppp = None
+    if persis_prof_type is not None:
+        ppt = persis_prof_type.upper()
+    if persis_prof_protocol is not None:
+        ppp = persis_prof_protocol.upper()
+
+    # want slightly different errors so I can tell why it failed
+    validate_type_and_protocol(
+        module,
+        ppt,
+        ppp,
+        'VirtListener: Persis Prof params do not match.',
+        'VirtListener: Persis Profile params do not match.')
+
+    # next, fallback persis profile type and fallback persis profile protocol
+    fb_persis_prof_type = module.params['fb_persis_prof_type']
+    fb_persis_prof_protocol = module.params['fb_persis_prof_protocol']
+    fbppt = None
+    fbppp = None
+
+    if fb_persis_prof_type is not None:
+        fbppt = fb_persis_prof_type.upper()
+    if fb_persis_prof_protocol is not None:
+        fbppp = fb_persis_prof_protocol.upper()
+
+    validate_type_and_protocol(
+        module,
+        fbppt,
+        fbppp,
+        'VirtListener: Fallback Persis Prof params do not match.',
+        'VirtListener: Fallback Persis Profile params do not match.')
+
+    # lastly, irule persis profile type and fallback persis profile protocol
+    irule_persis_prof_type = module.params['irule_persis_prof_type']
+    irule_persis_prof_protocol = module.params['irule_persis_prof_protocol']
+    irppt = None
+    irppp = None
+
+    if irule_persis_prof_type is not None:
+        irppt = irule_persis_prof_type.upper()
+    if irule_persis_prof_protocol is not None:
+        irppp = irule_persis_prof_protocol.upper()
+
+    validate_type_and_protocol(
+        module,
+        irppt,
+        irppp,
+        'VirtListener: iRule Persis Prof params do not match.',
+        'VirtListener: iRule Persis Profile params do not match.')
+
+    # attempt to validate protocol
+    port = module.params['port']
+    if port is not None:
+        protocol = module.params['protocol']
+        # imply listener type by port specification
+        if port is 80 or 443:
+            # listener_type = 'PERFORMANCE_LAYER_4'
+            # validate protocol against the compatible choices
+            if (protocol not in perf4_protocol_choices):
+                module.fail_json(
+                    msg="Protocol was " + "'%s'. " +
+                    "Not in list of choices for PERFORMANCE_LAYER_4 type."
+                    % protocol)
+        else:
+            # listener_type = 'STANDARD'
+            # validate protocol against the compatible choices
+            if (protocol not in std_protocol_choices):
+                module.fail_json(
+                    msg="Protocol was " + "'%s'. " +
+                    "Not in list of choices for STANDARD type."
+                    % protocol)
+
+    # check if libcloud was found
+    if not HAS_LIBCLOUD:
+        module.fail_json(msg='libcloud is required for this module.')
+
+    # set short vars for readability
+    credentials = get_credentials()
+    if credentials is False:
+        module.fail_json(msg="User credentials not found")
+
+    user_id = credentials['user_id']
+    key = credentials['key']
+    region = 'dd-%s' % module.params['region']
+    location = module.params['location']
+    network_domain = module.params['network_domain']
+    name = module.params['name']
+    ex_description = module.params['ex_description']
+    verify_ssl_cert = module.params['verify_ssl_cert']
+    pool_name = module.params['pool_name']
+    port = module.params['port']
+    protocol = module.params['protocol']
+    listener_ip_address = module.params['listener_ip_address']
+    connection_limit = module.params['connection_limit']
+    connection_rate_limit = module.params['connection_rate_limit']
+    source_port_preservation = module.params['source_port_preservation']
+    ensure = module.params['ensure']
+
+    # -------------------
+    # Instantiate drivers
+    # -------------------
+    libcloud.security.VERIFY_SSL_CERT = verify_ssl_cert
+    # Instantiate Load Balancer Driver
+    DDLoadBalancer = get_lb_driver(LBProvider.DIMENSIONDATA)
+    lb_driver = DDLoadBalancer(user_id, key, region=region)
+    # Instantiate Compute Driver
+    DDCompute = get_cp_driver(ComputeProvider.DIMENSIONDATA)
+    cp_driver = DDCompute(user_id, key, region=region)
+
+    # Get Network Domain Object
+    net_domain = get_network_domain(cp_driver, network_domain, location)
+    if net_domain is False:
+        module.fail_json(msg="Network domain could not be found.")
+
+    module.debug("%s" % net_domain)
+
+    # Set network domain
+    try:
+        lb_driver.ex_set_current_network_domain(net_domain.id)
+    except:
+        module.fail_json(msg="Current network domain could not be set.")
+
+    # get the existing Virtual Listener with the given name (if exists)
+    vl = get_vl_given_name(lb_driver, name)
+
+    if ensure.lower() == 'present':
+        if vl is None:
+            # create it
+            vl = create_virtual_listener(
+                module,
+                net_domain,
+                name,
+                ex_description,
+                port,
+                pool_name,
+                lb_driver,
+                cp_driver,
+                listener_ip_address,
+                ppt,
+                ppp,
+                fbppt,
+                fbppp,
+                irppt,
+                irppp,
+                protocol,
+                connection_limit,
+                connection_rate_limit,
+                source_port_preservation)
+        else:
+            module.exit_json(changed=False, msg="Virtual Listener already " +
+                             "exists.", virtual_listener=vl_obj_to_dict(vl,
+                                                                        True))
+    elif ensure.lower() == 'absent':
+        if vl is None:
+            module.exit_json(changed=False, msg="Virtual Listener with " +
+                             "name %s does not exist" % module.params['name'])
+        try:
+            res = lb_driver.destroy_balancer(vl)
+            module.exit_json(changed=True, msg="Virtual Listener deleted. " +
+                             "Status: %s" % res)
+        except DimensionDataAPIException as e:
+            module.fail_json(msg="Unexpected error when attempting to delete" +
+                             " virtual listener: %s" % e)
+    else:
+        fail_json(msg="Requested ensure was " +
+                  "'%s'. Status must be one of 'present', 'absent'." % ensure)
+
+    return vl
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ansible-module-extras/cloud/dimensiondata/dimensiondata_load_balancer.py
ansible-module-extras/cloud/dimensiondata/dimensiondata_load_balancer_node.py
ansible-module-extras/cloud/dimensiondata/dimensiondata_load_balancer_pool.py
ansible-module-extras/cloud/dimensiondata/dimensiondata_virtual_listener.py
##### ANSIBLE VERSION

```
ansible 2.2.0
```
##### SUMMARY

This is Ansible module support for apache-libcloud functions.
Specifically, this code supports Ansible invocations of DimensionData's 
Load Balancer functionality.

This is to support a new capability within ansible, so there is no "BEFORE".
Note that this routine has an "action verb" which allows multiple different
actions to be performed on a vlan.  Also, there are several routines involved
in the Load Balancer functionality.  Below shows the ansible call to create
a load balancer, along with its output.

```
    - name: Create Demo Load Balancer
    dimensiondata_load_balancer:
      region: "{{ dimension_data_region }}"
      location: "{{ dimension_data_location }}"
      network_domain: "{{ dimension_data_network_domain }}"
      name: "{{ dd_tests_lb_name }}"
      port: 80
      protocol: http
      members:
          - name: webserver1
            port: 80
            ip: 192.168.1.8
          - name: webserver3
            port: 80
            ip: 192.168.1.9
      ensure: present

    TASK [Create Demo Load Balancer] ***********************************************
    changed: [127.0.0.1] => {"changed": true, "load_balancer": {"id": "a0dbee50-492c-4953-b3dc-1da19fd307a7", "ip": "168.128.29.228", "name": "demo_lb01", "port": 80, "state": 0}, "msg": "Success."}

```
###### REQUIRES

https://github.com/ansible/ansible/pull/17604
https://github.com/apache/libcloud/pull/858
