### PR TITLE
Fix mongodb_user default role value when update_password is set

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -322,7 +322,7 @@ def main():
     ssl_cert_reqs = None
     if ssl:
         ssl_cert_reqs = getattr(ssl_lib, module.params['ssl_cert_reqs'])
-    roles = module.params['roles']
+    roles = module.params['roles'] or []
     state = module.params['state']
     update_password = module.params['update_password']
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

mongodb_user
##### ANSIBLE VERSION

```
ansible 2.1.1.0
```
##### SUMMARY

We can't create an user when the `update_password` directive is set to `on_create`.
###### error

``` python
fatal: [127.0.0.1]: FAILED! => {"changed": false, "failed": true, "msg": "Unable to add or update user: 'NoneType' object is not iterable"}
```
###### example

``` yaml
- name: test | new user with password
  mongodb_user:
    login_user: "{{ login_user }}"
    login_password: "{{ login_password }}"
    login_host: "{{ login_host }}"
    login_port: "{{ login_port }}"
    login_database: "{{ login_database }}"
    name: "{{ name }}"
    password: "{{ password }}"
    database: "{{ database }}"

- name: test | user with new password without the update directive
  mongodb_user:
    login_user: "{{ login_user }}"
    login_password: "{{ login_password }}"
    login_host: "{{ login_host }}"
    login_port: "{{ login_port }}"
    login_database: "{{ login_database }}"
    name: "{{ name }}"
    password: "new_{{ password }}"
    database: "{{ database }}"
    update_password: "on_create"
```
###### why
- `None` is the default value
- However, in a case of the `update_password` set to `on_create` we need to check if a role changed. This function iter throught the role list.
