### PR TITLE
Adding "File" Attribute for Upload Files

### DIFF
--- a/windows/win_uri.ps1
+++ b/windows/win_uri.ps1
@@ -57,12 +57,13 @@ Set-Attr $result.win_uri "content_type" $content_type
 $webrequest_opts.UseBasicParsing = $use_basic_parsing
 Set-Attr $result.win_uri "use_basic_parsing" $use_basic_parsing
 
+
 if ($file -ne $null) {
-    if (Test-Path $in_file -PathType leaf) {
+    if (Test-Path $file -PathType leaf) {
         $webrequest_opts.InFile = $file
         Set-Attr $result.win_url "file" $file
     } else {
-        Fail-Json $result "$in_file does not exist!"
+        Fail-Json $result "$file does not exist!"
     }
 }
 

--- a/windows/win_uri.ps1
+++ b/windows/win_uri.ps1
@@ -42,6 +42,7 @@ $method = Get-AnsibleParam -obj $params "method" -default "GET"
 $content_type = Get-AnsibleParam -obj $params -name "content_type"
 $headers = Get-AnsibleParam -obj $params -name "headers"
 $body = Get-AnsibleParam -obj $params -name "body"
+$file = Get-AnsibleParam -obj $params -name "file"
 $use_basic_parsing = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "use_basic_parsing" -default $true)
 
 $webrequest_opts.Uri = $url
@@ -55,6 +56,15 @@ Set-Attr $result.win_uri "content_type" $content_type
 
 $webrequest_opts.UseBasicParsing = $use_basic_parsing
 Set-Attr $result.win_uri "use_basic_parsing" $use_basic_parsing
+
+if ($file -ne $null) {
+    if (Test-Path $in_file -PathType leaf) {
+        $webrequest_opts.InFile = $file
+        Set-Attr $result.win_url "file" $file
+    } else {
+        Fail-Json $result "$in_file does not exist!"
+    }
+}
 
 if ($headers -ne $null) {
     $req_headers = @{}

--- a/windows/win_uri.ps1
+++ b/windows/win_uri.ps1
@@ -42,6 +42,7 @@ $method = Get-AnsibleParam -obj $params "method" -default "GET"
 $content_type = Get-AnsibleParam -obj $params -name "content_type"
 $headers = Get-AnsibleParam -obj $params -name "headers"
 $body = Get-AnsibleParam -obj $params -name "body"
+$file = Get-AnsibleParam -obj $params -name "file"
 $use_basic_parsing = ConvertTo-Bool (Get-AnsibleParam -obj $params -name "use_basic_parsing" -default $true)
 
 $webrequest_opts.Uri = $url
@@ -55,6 +56,15 @@ Set-Attr $result.win_uri "content_type" $content_type
 
 $webrequest_opts.UseBasicParsing = $use_basic_parsing
 Set-Attr $result.win_uri "use_basic_parsing" $use_basic_parsing
+
+if ($file -ne $null) {
+    if (Test-Path $file -PathType leaf) {
+        $webrequest_opts.InFile = $file
+        Set-Attr $result.win_url "file" $file
+    } else {
+        Fail-Json $result "$file does not exist!"
+    }
+}
 
 if ($headers -ne $null) {
     $req_headers = @{}

--- a/windows/win_uri.py
+++ b/windows/win_uri.py
@@ -53,6 +53,7 @@ options:
   file:
     description:
       - Use the contents of a file as the body of your web request.
+    version_added: "2.3"
   body:
     description:
       - The body of the HTTP request/response to the web service.

--- a/windows/win_uri.py
+++ b/windows/win_uri.py
@@ -106,7 +106,7 @@ EXAMPLES = """
   win_uri:
     url: http://myrepo.com/upload_endpoint
     method: PUT
-    file: C:\some\file\path.zip
+    file: C:/some/file/path.zip
 """
 
 RETURN = """
@@ -129,7 +129,7 @@ file:
     description: The file path used to generate the body of a web-request.
     returned: always
     type: string
-    sample: "C:\some\file\path"
+    sample: "C:/some/file/path"
 use_basic_parsing:
   description: The state of the "use_basic_parsing" flag.
   returned: always

--- a/windows/win_uri.py
+++ b/windows/win_uri.py
@@ -52,7 +52,7 @@ options:
       - Sets the "Content-Type" header.
   file:
     description:
-      - Use the contents of a file as your web request.
+      - Use the contents of a file as the body of your web request.
   body:
     description:
       - The body of the HTTP request/response to the web service.

--- a/windows/win_uri.py
+++ b/windows/win_uri.py
@@ -50,6 +50,9 @@ options:
   content_type:
     description:
       - Sets the "Content-Type" header.
+  file:
+    description:
+      - Use the contents of a file as your web request.
   body:
     description:
       - The body of the HTTP request/response to the web service.
@@ -97,6 +100,13 @@ EXAMPLES = """
     url: http://www.somesite.com
     method: POST
     body: "{ 'some': 'json' }"
+
+# Upload a file
+- name: Upload file to Repo.
+  win_uri:
+    url: http://myrepo.com/upload_endpoint
+    method: PUT
+    file: C:\some\file\path.zip
 """
 
 RETURN = """
@@ -115,6 +125,11 @@ content_type:
   returned: always
   type: string
   sample: "application/json"
+file:
+    description: The file path used to generate the body of a web-request.
+    returned: always
+    type: string
+    sample: "C:\some\file\path"
 use_basic_parsing:
   description: The state of the "use_basic_parsing" flag.
   returned: always


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

win_uri
##### SUMMARY

This is to address Issue #2999.

User was attempting to upload a file using the "body" attribute. This
resulted in a zero length file being uploaded. This solution here:

https://www.jfrog.com/knowledge-base/how-do-i-execute-a-file-upload-via-powershell/

Says to use the "-InFile" flag for Invoke-WebRequest.

I added a "file" attribute that, when specified, sets that "-InFile"
flag.
