### PR TITLE
Corrects an implied map() usage as list

### DIFF
--- a/network/f5/bigip_facts.py
+++ b/network/f5/bigip_facts.py
@@ -1079,7 +1079,7 @@ class AddressClasses(object):
     def get_address_class(self):
         key = self.api.LocalLB.Class.get_address_class(self.address_classes)
         value = self.api.LocalLB.Class.get_address_class_member_data_value(key)
-        result = map(zip, [x['members'] for x in key], value)
+        result = list(map(zip, [x['members'] for x in key], value))
         return result
 
     def get_description(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

network/f5/bigip_facts.py
##### ANSIBLE VERSION

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

In the six package, the map() function returns an iterator instead
of a list. This code was continuing to use the map() return value
as if it were a list and this broke the address_class facts.

This patch changes the code to use the list() method on the return
value of map().
