### PR TITLE
Add new parameters to taskdefinition module - network_mode and task_r…

### DIFF
--- a/cloud/amazon/ecs_taskdefinition.py
+++ b/cloud/amazon/ecs_taskdefinition.py
@@ -47,6 +47,16 @@ options:
             - A list of containers definitions 
         required: False
         type: list of dicts with container definitions
+    network_mode:
+        description:
+            - The Docker networking mode to use for the containers in the task.
+        required: false
+        default: bridge
+        choices: [ 'bridge', 'host', 'none' ]
+    task_role_arn:
+        description:
+            - The Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers in this task are granted the permissions that are specified in this role.
+        required: false
     volumes:
         description:
             - A list of names of volumes to be attached
@@ -133,9 +143,16 @@ class EcsTaskManager:
         except botocore.exceptions.ClientError:
             return None
 
-    def register_task(self, family, container_definitions, volumes):
-        response = self.ecs.register_task_definition(family=family,
-            containerDefinitions=container_definitions, volumes=volumes)
+    def register_task(self, family, task_role_arn, network_mode, container_definitions, volumes):
+        try:
+            response = self.ecs.register_task_definition(family=family,
+                                                         taskRoleArn=task_role_arn,
+                                                         networkMode=network_mode,
+                                                         containerDefinitions=container_definitions,
+                                                         volumes=volumes)
+        except botocore.exceptions.ClientError as e:
+            self.module.fail_json(msg=e.message, **camel_dict_to_snake_dict(e.response))
+
         return response['taskDefinition']
 
     def describe_task_definitions(self, family):
@@ -169,6 +186,7 @@ class EcsTaskManager:
         response = self.ecs.deregister_task_definition(taskDefinition=taskArn)
         return response['taskDefinition']
 
+
 def main():
 
     argument_spec = ec2_argument_spec()
@@ -178,8 +196,9 @@ def main():
         family=dict(required=False, type='str'),
         revision=dict(required=False, type='int'),
         containers=dict(required=False, type='list'),
-        volumes=dict(required=False, type='list')
-    ))
+        network_mode=dict(required=False, default='bridge', choices=['bridge', 'host', 'none'], type='str'),
+        task_role_arn=dict(required=False, default='', type='str'),
+        volumes=dict(required=False, type='list')))
 
     module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
 
@@ -305,7 +324,10 @@ def main():
                 # Doesn't exist. create it.
                 volumes = module.params.get('volumes', []) or []
                 results['taskdefinition'] = task_mgr.register_task(module.params['family'],
-                                                                   module.params['containers'], volumes)
+                                                                   module.params['task_role_arn'],
+                                                                   module.params['network_mode'],
+                                                                   module.params['containers'],
+                                                                   volumes)
             results['changed'] = True
 
     elif module.params['state'] == 'absent':
@@ -334,7 +356,6 @@ def main():
                 results['changed'] = True
 
     module.exit_json(**results)
-
 
 if __name__ == '__main__':
     main()

--- a/cloud/amazon/ecs_taskdefinition.py
+++ b/cloud/amazon/ecs_taskdefinition.py
@@ -53,10 +53,12 @@ options:
         required: false
         default: bridge
         choices: [ 'bridge', 'host', 'none' ]
+        version_added: 2.2
     task_role_arn:
         description:
             - The Amazon Resource Name (ARN) of the IAM role that containers in this task can assume. All containers in this task are granted the permissions that are specified in this role.
         required: false
+        version_added: 2.2
     volumes:
         description:
             - A list of names of volumes to be attached


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ecs_taskdefinition
##### ANSIBLE VERSION

2.2
##### SUMMARY

Resolves #3015 

Adds two new parameters to the module:

task_role_arn 
network_mode

These are new features in AWS
