### PR TITLE
Fixes #1375, will check for new and outdated packages when running.

### DIFF
--- a/packaging/language/npm.py
+++ b/packaging/language/npm.py
@@ -252,7 +252,10 @@ def main():
     elif state == 'latest':
         installed, missing = npm.list()
         outdated = npm.list_outdated()
-        if len(missing) or len(outdated):
+        if len(missing):
+            changed = True
+            npm.install()
+        if len(outdated):
             changed = True
             npm.update()
     else: #absent


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

packaging/language/npm.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixes #1375 and addresses issue missed by PR #1498.

Module now tests for a list of NPM modules that need to be installed or updated as separate conditionals.

It will now run an `npm.install()` to install new versions and will also run `npm.update()` to update packages that have already been installed.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
