### PR TITLE
Add win_chocolatey proxy support

### DIFF
--- a/windows/win_chocolatey.py
+++ b/windows/win_chocolatey.py
@@ -86,7 +86,19 @@ options:
       - Ignore dependencies, only install/upgrade the package itself
     default: false
     version_added: '2.1'
-author: "Trond Hindenes (@trondhindenes), Peter Mounce (@petemounce), Pepe Barbe (@elventear), Adam Keech (@smadam813)"
+  proxy:
+    description:
+      - proxy url used to install chocolatey and the package
+    version_added: '2.2'
+  proxy_user:
+    description:
+      - proxy user used to install chocolatey and the package
+    version_added: '2.2'
+  proxy_password:
+    description:
+      - proxy password used to install chocolatey and the package
+    version_added: '2.2'
+author: "Trond Hindenes (@trondhindenes), Peter Mounce (@petemounce), Pepe Barbe (@elventear), Adam Keech (@smadam813), Pierre Templier (@ptemplier)"
 '''
 
 # TODO:
@@ -113,4 +125,11 @@ EXAMPLES = '''
   win_chocolatey:
     name: git
     source: https://someserver/api/v2/
+
+  # Install curl using proxy
+  win_chocolatey:
+    name: curl
+    proxy: http://proxy-server:8080/
+    proxy_user: joe
+    proxy_password: p@ssw0rd
 '''


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

win_chocolatey
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

Add win_chocolatey proxy support.
Add parameters to specify proxy url, user and password to be used when installing chocolatey and when installing package.
##### WORKAROUND

```
- name:  Check if chocolatey is installed
  win_stat: path='C:/ProgramData/chocolatey'
  register: choco_install

- name: Install Chocolatey using proxy
  raw: 'Set-ExecutionPolicy -ExecutionPolicy Unrestricted ; $wc=new-object net.webclient ; $proxy = New-Object System.Net.WebProxy("{{http_proxy_host}}:{{http_proxy_port}}", $true)  ; $wc.proxy=$proxy ; iex($wc.downloadstring("https://chocolatey.org/install.ps1"))'
  when: choco_install.stat.exists == False

- name: Chocolatey set proxy
  raw: 'choco config set proxy http://{{http_proxy_host}}:{{http_proxy_port}}'

- name: install curl
  win_chocolatey:
    name: curl
```
