### PR TITLE
Change azure default deployment mode to incremental

### DIFF
--- a/cloud/azure/azure_rm_deployment.py
+++ b/cloud/azure/azure_rm_deployment.py
@@ -42,7 +42,7 @@ options:
       - In incremental mode, resources are deployed without deleting existing resources that are not included in the template. 
         In complete mode resources are deployed and existing resources in the resource group not included in the template are deleted.
     required: false
-    default: complete
+    default: incremental
     choices:
         - complete
         - incremental

--- a/cloud/azure/azure_rm_deployment.py
+++ b/cloud/azure/azure_rm_deployment.py
@@ -405,7 +405,7 @@ class AzureRMDeploymentManager(AzureRMModuleBase):
             template_link=dict(type='str', default=None),
             parameters_link=dict(type='str', default=None),
             location=dict(type='str', default="westus"),
-            deployment_mode=dict(type='str', default='complete', choices=['complete', 'incremental']),
+            deployment_mode=dict(type='str', default='incremental', choices=['complete', 'incremental']),
             deployment_name=dict(type='str', default="ansible-arm"),
             wait_for_deployment_completion=dict(type='bool', default=True),
             wait_for_deployment_polling_period=dict(type='int', default=10)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

azure-rm-deployment
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0 and devel as of 372828d
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

COMPLETE deployment mode by default is too dangerous. No one expects to see its cluster being fully destroyed when the default deployment mode in Azure-cli is INCREMENTAL.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
