### PR TITLE
zfs: Don't set property on empty values. i.e. when set to None.

### DIFF
--- a/system/zfs.py
+++ b/system/zfs.py
@@ -184,7 +184,7 @@ class Zfs(object):
     def set_properties_if_changed(self):
         current_properties = self.get_current_properties()
         for prop, value in self.properties.iteritems():
-            if current_properties.get(prop, None) != value:
+            if value != '' and current_properties.get(prop, None) != value:
                 self.set_property(prop, value)
 
     def get_current_properties(self):


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

zfs
##### ANSIBLE VERSION

```
ansible 2.1.1.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

When setting a ZFS property in ansible to None (i.e. you're using a loop to set options on several ZFS mounts), ZFS will error with `missing value in property=value argument`.
This patch allows setting a property to None to effectively have it ignored, and not error.
