### PR TITLE
ovirt_vms: wait for VM to be created for states stopped/suspended

### DIFF
--- a/cloud/ovirt/ovirt_vms.py
+++ b/cloud/ovirt/ovirt_vms.py
@@ -761,6 +761,7 @@ def main():
                     )
         elif state == 'stopped':
             vms_module.create(
+                result_state=otypes.VmStatus.DOWN if vm is None else None,
                 clone=module.params['clone'],
                 clone_permissions=module.params['clone_permissions'],
             )
@@ -781,6 +782,7 @@ def main():
                 )
         elif state == 'suspended':
             vms_module.create(
+                result_state=otypes.VmStatus.DOWN if vm is None else None,
                 clone=module.params['clone'],
                 clone_permissions=module.params['clone_permissions'],
             )


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

ovirt_vms
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
2.2
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This patch add wait for creation of VM in case state is stopped or suspended and VM didn't existed before. The VM can be in image_locked state, so we need to wait for VM to be in DOWN state.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```
