### PR TITLE
openvswitch_bridge: add fake bridge support

### DIFF
--- a/network/openvswitch_bridge.py
+++ b/network/openvswitch_bridge.py
@@ -47,7 +47,7 @@ options:
         required: false
         default: None
         description:
-            - The VLAN id of the fake bridge to manage
+            - The VLAN id of the fake bridge to manage (must be between 0 and 4095)
     state:
         required: false
         default: "present"
@@ -101,8 +101,11 @@ class OVSBridge(object):
         self.timeout = module.params['timeout']
         self.fail_mode = module.params['fail_mode']
 
-        if self.parent and not self.vlan:
+        if self.parent and self.vlan is None:
             self.module.fail_json(msg='VLAN id must be set when parent is defined')
+
+        if self.vlan < 0 or self.vlan > 4095:
+            self.module.fail_json(msg='Invalid VLAN ID (must be between 0 and 4095)')
 
     def _vsctl(self, command):
         '''Run ovs-vsctl command'''

--- a/network/openvswitch_bridge.py
+++ b/network/openvswitch_bridge.py
@@ -35,7 +35,19 @@ options:
     bridge:
         required: true
         description:
-            - Name of bridge to manage
+            - Name of bridge or fake bridge to manage
+    parent:
+        version_added: 2.2
+        required: false
+        default: None
+        description:
+            - Bridge parent of the fake bridge to manage
+    vlan:
+        version_added: 2.2
+        required: false
+        default: None
+        description:
+            - The VLAN id of the fake bridge to manage
     state:
         required: false
         default: "present"
@@ -67,6 +79,9 @@ EXAMPLES = '''
 # Create a bridge named br-int
 - openvswitch_bridge: bridge=br-int state=present
 
+# Create a fake bridge named br-int within br-parent on the VLAN 405
+- openvswitch_bridge: bridge=br-int parent=br-parent vlan=405 state=present
+
 # Create an integration bridge
 - openvswitch_bridge: bridge=br-int state=present fail_mode=secure
   args:
@@ -80,9 +95,14 @@ class OVSBridge(object):
     def __init__(self, module):
         self.module = module
         self.bridge = module.params['bridge']
+        self.parent = module.params['parent']
+        self.vlan = module.params['vlan']
         self.state = module.params['state']
         self.timeout = module.params['timeout']
         self.fail_mode = module.params['fail_mode']
+
+        if self.parent and not self.vlan:
+            self.module.fail_json(msg='VLAN id must be set when parent is defined')
 
     def _vsctl(self, command):
         '''Run ovs-vsctl command'''
@@ -100,7 +120,11 @@ class OVSBridge(object):
 
     def add(self):
         '''Create the bridge'''
-        rtc, _, err = self._vsctl(['add-br', self.bridge])
+        if self.parent and self.vlan: # Add fake bridge
+            rtc, _, err = self._vsctl(['add-br', self.bridge, self.parent, self.vlan])
+        else:
+            rtc, _, err = self._vsctl(['add-br', self.bridge])
+
         if rtc != 0:
             self.module.fail_json(msg=err)
         if self.fail_mode:
@@ -247,6 +271,8 @@ def main():
     module = AnsibleModule(
         argument_spec={
             'bridge': {'required': True},
+            'parent': {'default': None},
+            'vlan': {'default': None, 'type': 'int'},
             'state': {'default': 'present', 'choices': ['present', 'absent']},
             'timeout': {'default': 5, 'type': 'int'},
             'external_ids': {'default': None, 'type': 'dict'},


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

openvswitch_bridge
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Add fake bridge support as mentioned in ovs-vsctl(8).

> ```
>          [--may-exist] add-br bridge parent vlan
> 
>           Creates a ``fake bridge'' named bridge within the existing  Open
>           vSwitch  bridge  parent,  which  must already exist and must not
>           itself be a fake bridge.  The new fake bridge will be on  802.1Q
>           VLAN  vlan,  which  must  be  an  integer  between  0  and 4095.
>           Initially bridge will have no ports (other than bridge itself).
> 
>           Without --may-exist, attempting to create a bridge  that  exists
>           is  an  error.   With  --may-exist, this command does nothing if
>           bridge already exists as a VLAN bridge under parent for vlan.
> ```
