### PR TITLE
Add a 'deployment' resource URI to available Kubernetes resources kinds (implements #2487)

### DIFF
--- a/clustering/kubernetes.py
+++ b/clustering/kubernetes.py
@@ -205,7 +205,9 @@ KIND_URL = {
     "resourcequota": "/api/v1/namespaces/{namespace}/resourcequotas",
     "secret": "/api/v1/namespaces/{namespace}/secrets",
     "service": "/api/v1/namespaces/{namespace}/services",
-    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts"
+    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts",
+
+    "deployment": "/apis/extensions/v1beta1/namespaces/{namespace}/deployments"
 }
 USER_AGENT = "ansible-k8s-module/0.0.1"
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

clustering/kubernetes
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Here we suggest a simple addition that brings support for `deployment` K8S resources, as requested in Feature Idea #2487.
See also the K8S Reference API for these resources: [Extensions API Operations › create a Deployment](http://kubernetes.io/docs/api-reference/extensions/v1beta1/operations/#_create_a_deployment).
