### PR TITLE
Allow STS assume role

### DIFF
--- a/cloud/amazon/cloudtrail.py
+++ b/cloud/amazon/cloudtrail.py
@@ -53,28 +53,9 @@ options:
     default: false
     choices: ["true", "false"]
 
-  aws_secret_key:
-    description:
-      - AWS secret key. If not set then the value of the AWS_SECRET_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_secret_key', 'secret_key' ]
-    version_added: "1.5"
-  aws_access_key:
-    description:
-      - AWS access key. If not set then the value of the AWS_ACCESS_KEY environment variable is used.
-    required: false
-    default: null
-    aliases: [ 'ec2_access_key', 'access_key' ]
-    version_added: "1.5"
-  region:
-    description:
-      - The AWS region to use. If not specified then the value of the EC2_REGION environment variable, if any, is used.
-    required: false
-    aliases: ['aws_region', 'ec2_region']
-    version_added: "1.5"
-
-extends_documentation_fragment: aws
+extends_documentation_fragment:
+  - aws
+  - ec2
 """
 
 EXAMPLES = """
@@ -165,9 +146,7 @@ def main():
     if not HAS_BOTO:
       module.fail_json(msg='boto is required.')
 
-    ec2_url, access_key, secret_key, region = get_ec2_creds(module)
-    aws_connect_params = dict(aws_access_key_id=access_key,
-                              aws_secret_access_key=secret_key)
+    region, ec2_url, aws_connect_params = get_aws_connection_info(module)
 
     if not region:
         module.fail_json(msg="Region must be specified as a parameter, in EC2_REGION or AWS_REGION environment variables or in boto configuration file")


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

AWS CloudTrail module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.0.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

EC2 credentials (session token) are not passed to boto. This causes connection problems when using STS assume role

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: {u'message': u'The security token included in the request is invalid.', u'__type': u'UnrecognizedClientException'}

```
