### PR TITLE
Improve verbosity and avoids erroneously succeeding

### DIFF
--- a/packaging/language/pear.py
+++ b/packaging/language/pear.py
@@ -149,8 +149,11 @@ def install_packages(module, state, packages):
         cmd = "pear %s %s" % (command, package)
         rc, stdout, stderr = module.run_command(cmd, check_rc=False)
 
-        if rc != 0:
-            module.fail_json(msg="failed to install %s" % (package))
+        # verify that the package is actually installed
+        # as pear exit value is unreliable
+        installed, updated = query_package(module, package)
+        if rc != 0 or not installed or (state == 'latest' and not updated):
+            module.fail_json(msg="failed to install %s: %s" % (package, stdout))
 
         install_c += 1
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

pear module
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /home/jonathan/.ansible.cfg
  configured module search path = ['/home/jonathan/dev/ansible/modules']
```
##### SUMMARY

Fixes #3053

This adds verification that packages are really installed to avoid succeeding when package installation failed (instead of just relying on pear exit value which is often 0 even in case of failure), and this adds pear stdout output to the error message to make the cause more explicit.
