### PR TITLE
Fixes #1717 maven_artifact cannot download SBT published snapshot …

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -216,6 +216,9 @@ class MavenDownloader:
             xml = self._request(self.base + path, "Failed to download maven-metadata.xml", lambda r: etree.parse(r))
             timestamp = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")[0]
             buildNumber = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
+            for snapshotArtifact in xml.xpath("/metadata/versioning/snapshotVersions/snapshotVersion"):
+                if snapshotArtifact.xpath("classifier/text()")[0] == artifact.classifier and snapshotArtifact.xpath("extension/text()")[0] == artifact.extension:
+                    return self._uri_for_artifact(artifact, snapshotArtifact.xpath("value/text()")[0])
             return self._uri_for_artifact(artifact, artifact.version.replace("SNAPSHOT", timestamp + "-" + buildNumber))
 
         return self._uri_for_artifact(artifact, artifact.version)

--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -217,7 +217,7 @@ class MavenDownloader:
             timestamp = xml.xpath("/metadata/versioning/snapshot/timestamp/text()")[0]
             buildNumber = xml.xpath("/metadata/versioning/snapshot/buildNumber/text()")[0]
             for snapshotArtifact in xml.xpath("/metadata/versioning/snapshotVersions/snapshotVersion"):
-                if snapshotArtifact.xpath("classifier/text()")[0] == artifact.classifier and snapshotArtifact.xpath("extension/text()")[0] == artifact.extension:
+                if len(snapshotArtifact.xpath("classifier/text()")) > 0 and snapshotArtifact.xpath("classifier/text()")[0] == artifact.classifier and len(snapshotArtifact.xpath("extension/text()")) > 0 and snapshotArtifact.xpath("extension/text()")[0] == artifact.extension:
                     return self._uri_for_artifact(artifact, snapshotArtifact.xpath("value/text()")[0])
             return self._uri_for_artifact(artifact, artifact.version.replace("SNAPSHOT", timestamp + "-" + buildNumber))
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

maven_artifact
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file = /home/michalklempa/.ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Fixing https://github.com/ansible/ansible-modules-extras/issues/1717
When there is an artifact published as SNAPSHOT with different extension / classifiers combinations
published with different buildNumber in maven repository, maven_artifact is unable to download
some of them, since maven_artifact constructs URL for artifact download using string
catenation of artifact-version-snapshottimestamp-buildnumber-classifer.extension and in
`maven-metadata.xml` such artifact maybe does not exist. Maven_artifact should search
`maven-metadata.xml` for precise `version-snapshottimestmap-buildnumber` name for
desired extension / classifier combination. Maven itself does it this way and can handle such situations (which maybe created by buggy upload by another tools, sbt for example).
