### PR TITLE
Fix issue with multiple pages of results in ec2_lc_find

### DIFF
--- a/cloud/amazon/ec2_lc_find.py
+++ b/cloud/amazon/ec2_lc_find.py
@@ -162,31 +162,32 @@ def find_launch_configs(client, module):
         }
     )
 
+    results = []
+
     for response in response_iterator:
         response['LaunchConfigurations'] = filter(lambda lc: re.compile(name_regex).match(lc['LaunchConfigurationName']),
                                                   response['LaunchConfigurations'])
 
-    results = []
-    for lc in response['LaunchConfigurations']:
-        data = {
-            'name': lc['LaunchConfigurationName'],
-            'arn': lc['LaunchConfigurationARN'],
-            'created_time': lc['CreatedTime'],
-            'user_data': lc['UserData'],
-            'instance_type': lc['InstanceType'],
-            'image_id': lc['ImageId'],
-            'ebs_optimized': lc['EbsOptimized'],
-            'instance_monitoring': lc['InstanceMonitoring'],
-            'classic_link_vpc_security_groups': lc['ClassicLinkVPCSecurityGroups'],
-            'block_device_mappings': lc['BlockDeviceMappings'],
-            'keyname': lc['KeyName'],
-            'security_groups': lc['SecurityGroups'],
-            'kernel_id': lc['KernelId'],
-            'ram_disk_id': lc['RamdiskId'],
-            'associate_public_address': lc['AssociatePublicIpAddress'],
-        }
+        for lc in response['LaunchConfigurations']:
+            data = {
+                'name': lc['LaunchConfigurationName'],
+                'arn': lc['LaunchConfigurationARN'],
+                'created_time': lc['CreatedTime'],
+                'user_data': lc['UserData'],
+                'instance_type': lc['InstanceType'],
+                'image_id': lc['ImageId'],
+                'ebs_optimized': lc['EbsOptimized'],
+                'instance_monitoring': lc['InstanceMonitoring'],
+                'classic_link_vpc_security_groups': lc['ClassicLinkVPCSecurityGroups'],
+                'block_device_mappings': lc['BlockDeviceMappings'],
+                'keyname': lc['KeyName'],
+                'security_groups': lc['SecurityGroups'],
+                'kernel_id': lc['KernelId'],
+                'ram_disk_id': lc['RamdiskId'],
+                'associate_public_address': lc['AssociatePublicIpAddress'],
+            }
 
-        results.append(data)
+            results.append(data)
 
     results.sort(key=lambda e: e['name'], reverse=(sort_order == 'descending'))
 


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ec2_lc_find
##### ANSIBLE VERSION

```
ansible 2.2+
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

The `response_iterator` responsible for paging through multiple pages of response details for current launch configurations didn't assign response data appropriately, leading to missing launch configurations when multiple pages were present.

This fixes the logic by simply adding the data into the `results` _while_ iterating through the response pages.
