### PR TITLE
Corrects the required SDK version

### DIFF
--- a/network/f5/bigip_ssl_certificate.py
+++ b/network/f5/bigip_ssl_certificate.py
@@ -88,7 +88,7 @@ notes:
     tmsh or these modules.
 extends_documentation_fragment: f5
 requirements:
-    - f5-sdk >= 1.3.1
+    - f5-sdk >= 1.5.0
     - BigIP >= v12
 author:
     - Kevin Coming (@waffie1)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

network/f5/bigip_ssl_certificate.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.2.0
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

The SDK version that was mentioned originally was incorrect
