### PR TITLE
Adding missing required field in doc example

### DIFF
--- a/monitoring/pagerduty.py
+++ b/monitoring/pagerduty.py
@@ -132,6 +132,7 @@ EXAMPLES='''
 # Create a 5 minute maintenance window for service FOO123, using a token
 - pagerduty: name=companyabc
              token=xxxxxxxxxxxxxx
+             requester_id=xxxxxx
              hours=0
              minutes=5
              state=running


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

 pagerduty
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 1.9.2
  configured module search path = None
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

requester_id is required when token is used. It is not shown in the example in the documentation.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
