### PR TITLE
add a set of modules pertaining to various benchmarking and validatio…

### DIFF
--- a/benchmarks/fio.py
+++ b/benchmarks/fio.py
@@ -1,0 +1,317 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: fio
+short_description: Execute the fio benchmark
+description:
+ - Use this module to run the FlexibleI/O benchmark
+ - https://github.com/axboe/fio
+version_added: "2.1"
+options:
+  chdir:
+    description:
+     - change working directory
+    required: false
+    default: null
+  bs:
+    description:
+     - block size
+    required: true
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: false
+  executable:
+    description:
+     - path to fio executable if running from source
+    required: false
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: false
+  direct:
+    description:
+     - If true, use non-buffered I/O
+    required: False
+  iodepth:
+    description:
+     - Number of I/O units to keep in flight against file
+    required: False
+  ioengine:
+    description:
+     - Defined how the job issues I/O
+    required: False
+  name:
+    description:
+     - Used as Job Name and to specify start of a new job.
+    required: True
+  numjobs:
+    description:
+     - Number of threads/processes performing the same workload
+    required: False
+    default: 1
+  rw:
+    description:
+     - Type of I/O pattern to perform
+    required: True
+  size:
+    description:
+     - Total size of I/O for job. Can give specific size or percentage of drive
+    required: True
+  offset:
+    description:
+     - Offset in the file to start I/O. Data before the offset will not be touched.
+    required: False
+  sync:
+    description:
+     - Use synchronous I/O for buffered writes.
+    required: False
+  time_based:
+    description:
+     - Run jobs (even if repeated) until specified time is reached.
+    required: False
+  ramp_time:
+    description:
+     - Time to run specified workload before start of logging.
+    required: False
+  runtime:
+    description:
+     - Total time to run specified workload.
+    required: False
+  rwmixread:
+    description:
+     - Percentage of mixed workload that should be reads.
+    required: False
+  rwmixwrite:
+    description:
+     - Percentage of mixed workload that should be writes.
+    required: False
+  output_format:
+    description:
+     - Format in which the job results should be displayed.
+    required: False
+  group_reporting:
+    description:
+     - If set, display per-group reports instead of per-job when numjobs is specified.
+    required: True
+requirements:
+ - fio
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run fio read job in 4k blocks up to 512M
+- fio: name=read rw=read bs=4k size=512M
+
+# Run fio read job in 4k blocks up to 512M and output to /tmp/fio.out
+- fio: name=read rw=read bs=4k size=512M dest=/tmp/fio.out
+
+# Run fio readwrite job in 4k blocks up to 512M using libaio engine with iodepth of 1
+- fio: name=rw rw=rw bs=4k size=512M ioengine=libaio iodepth=1'
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/usr/bin/fio --name=..."
+'''
+
+import os
+import re
+import tempfile
+
+
+def benchmark(module, result, bin, params):
+
+    name        = params['name']
+    bs          = params['bs']
+    dest        = params['dest']
+    direct      = params['direct']
+    iodepth     = params['iodepth']
+    ioengine    = params['ioengine']
+    numjobs     = params['numjobs']
+    rw          = params['rw']
+    size        = params['size']
+    offset      = params['offset']
+    sync        = params['sync']
+    time_based  = params['time_based']
+    ramp_time   = params['ramp_time']
+    runtime    = params['runtime']
+    rwmixread   = params['rwmixread']
+    rwmixwrite  = params['rwmixwrite']
+    output_format   = params['output_format']
+    group_reporting = params['group_reporting']
+
+    benchmark_command = None
+
+    if dest:
+        benchmark_command = "{} --name={} --bs={} " \
+                            "--rw={} --size={} --output={}"\
+            .format(bin, name, bs, rw, size, dest)
+    else:
+        benchmark_command = "{} --name={} --bs={} " \
+                            "--rw={} --size={}"\
+            .format(bin, name, bs, rw, size)
+
+    if direct: benchmark_command += " --direct=1"
+    if iodepth: benchmark_command += " --iodepth={}".format(iodepth)
+    if ioengine: benchmark_command += " --ioengine={}".format(ioengine)
+    if numjobs: benchmark_command += " --numjobs={}".format(numjobs)
+    if offset: benchmark_command += " --offset={}".format(offset)
+    if output_format: benchmark_command += " --output_format={}".format(output_format)
+    if sync: benchmark_command += " --sync=1"
+    if ramp_time: benchmark_command += " --ramp_time={}".format(ramp_time)
+    if runtime: benchmark_command += " --runtime={}".format(runtime)
+    if rwmixread: benchmark_command += " --rwmixread={}".format(rwmixread)
+    if rwmixwrite: benchmark_command += " --rwmixwrite={}".format(rwmixwrite)
+    if time_based: benchmark_command += " --time_based"
+    if group_reporting: benchmark_command += " --group_reporting"
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['exec_cmd']  = benchmark_command
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+
+def parse(module, result, params):
+    # Doesn't need one, since fio output has both original and JSON formats
+    pass
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            bs=dict(required=True,
+                    type='str'),
+            chdir=dict(required=False,
+                       type='str'),
+            dest=dict(required=False,
+                      type='str',
+                      default=None),
+            direct=dict(required=False,
+                        type='int',
+                        default=1,
+                        choices=[0, 1]),
+            executable=dict(required=False,
+                            type='str'),
+            name=dict(required=True,
+                      type='str'),
+            rw=dict(required=True,
+                    type='str',
+                    choices=['read', 'write', 'randread', 'randwrite',
+                             'rw', 'readwrite', 'randrw']),
+            size=dict(required=True,
+                      type='str'),
+            state=dict(type='str',
+                       default="benchmark",
+                       choices=['benchmark', 'parse']),
+            timeout=dict(required=False,
+                         type='int'),
+            group_reporting=dict(required=False,
+                                 type='bool',
+                                 default=False),
+            iodepth=dict(required=False,
+                         type='int'),
+            ioengine=dict(required=False,
+                          type='str',
+                          choices=['sync', 'psync', 'vsync', 'libaio',
+                                   'posixaio', 'solarisaio', 'windowsaio',
+                                   'mmap', 'splice', 'syslet-rw', 'sg',
+                                   'null', 'net', 'netsplice', 'cpuio',
+                                   'guasi', 'rdma', 'external', 'falloc',
+                                   'e4defrag']),
+            numjobs=dict(required=False,
+                         type='int',
+                         default=1),
+            offset=dict(required=False,
+                        type='int'),
+            output_format=dict(required=False,
+                               type='str',
+                               choices=['terse', 'json', 'json+', 'normal']),
+            sync=dict(required=False,
+                      type='bool',
+                      default=False),
+            time_based=dict(required=False,
+                            type='bool',
+                            default=False),
+            ramp_time=dict(required=False,
+                           type='int'),
+            runtime=dict(required=False,
+                         type='int'),
+            rwmixread=dict(required=False,
+                           type='int'),
+            rwmixwrite=dict(required=False,
+                            type='int'),
+
+        ),
+        supports_check_mode=False
+    )
+
+    benchmark_bin = None
+    result = {'changed': False}
+
+    if module.params['state'] == 'benchmark':
+        missing_params = list()
+        for param in ['name', 'rw', 'bs', 'size']:
+            if not module.params[param]:
+                missing_params.append(param)
+        if len(missing_params) > 0:
+            module.fail_json(msg="missing required arguments: {}".format(missing_params))
+        if module.params['executable']:
+            benchmark_bin = module.get_bin_path('fio', True, [module.params['executable']])
+        else:
+            benchmark_bin = module.get_bin_path('fio', True, ['/usr/bin/local'])
+
+        benchmark(module, result, benchmark_bin, module.params)
+        
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/iperf.py
+++ b/benchmarks/iperf.py
@@ -1,0 +1,292 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: iperf
+short_description: Execute the iPerf3 benchmark
+description:
+ - Use this module to run the iPerf3 benchmark
+ - http://software.es.net/iperf/
+version_added: "2.1"
+options:
+  chdir:
+    description:
+     - change working directory
+    required: False
+    default: null
+  mode:
+    description:
+     - Determines if target is acting as server or client
+    required: True
+  bind:
+    description:
+     - Address of interface to bind to
+    required: False
+  executable:
+    description:
+     - path to iperf3 executable if running from source
+    required: False
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: False
+  interval:
+    description:
+     - Number of seconds to pause between each bandwidth report.
+    required: False
+  port:
+    description:
+     - Set the port to listen on
+    required: False
+    default: 5201
+  udp:
+    description:
+     - use UDP instead of TCP
+    required: False
+  server:
+    description:
+     - hostname or ip address of the iperf server to connect to
+    required: True
+  verbose:
+    description:
+     - give more detailed output
+    required: False
+  timeout:
+    description:
+     - Total time to run iperf3 for.
+    required: False
+requirements:
+ - iperf3
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Start server daemon on target host
+- iperf: mode=server
+
+# Run iperf3 tcp on target host as client
+- iperf: mode=client server=ubuntu_14
+
+# Run iperf3 udp on target host as client with verbose
+- iperf: mode=client server=target1 udp=True verbose=True
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/usr/bin/iperf3 -s"
+'''
+
+import os
+import re
+import tempfile
+
+
+def benchmark(module, result, bin, params):
+
+    mode        = params['mode']
+    timeout     = params['timeout']
+    bind        = params['bind']
+    dest        = params['dest']
+    interval    = params['interval']
+    port        = params['port']
+    udp         = params['udp']
+    server      = params['server']
+    verbose     = params['verbose']
+    parallel_threads    = params['parallel_threads']
+    tcp_window_size     = params['tcp_window_size']
+    output_format       = params['output_format']
+
+
+    benchmark_command = None
+
+    if mode == 'server':
+        benchmark_command = "{} -s -D" \
+            .format(bin)
+    else:
+        benchmark_command = "{} -c {} -t {}"\
+            .format(bin, server, timeout)
+
+        if udp:
+            benchmark_command += " --udp"
+        if output_format:
+            benchmark_command += " --json"
+        if dest:
+            benchmark_command += " --logfile {}".format(dest)
+        if parallel_threads:
+            benchmark_command += " --parallel {}".format(parallel_threads)
+        if tcp_window_size:
+            benchmark_command += " --window {}".format(tcp_window_size)
+
+    if interval:
+        benchmark_command += " --interval {}".format(interval)
+    if port:
+        benchmark_command += " --port {}".format(port)
+    if bind:
+        benchmark_command += " --bind {}".format(bind)
+    if verbose:
+        benchmark_command += " --verbose"
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['exec_cmd']  = benchmark_command
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+def parse(module, result, params):
+
+    dest        = params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    result_file = open(dest, 'r')
+    data = result_file.readlines()
+    result_file.close()
+
+    json_result = dict()
+
+    for line in data:
+        if "hogs" in line:
+            match = re.search('(\d+)\s+cpu,\s+(\d+)\s+io,\s+(\d+)\s+vm,\s+(\d+)\s+hdd', line)
+            if match:
+                json_result['cpu_hogs'] = match.group(1)
+                json_result['io_hogs'] = match.group(2)
+                json_result['vm_hogs'] = match.group(3)
+                json_result['hdd_hogs'] = match.group(4)
+        elif "successful" in line:
+            match = re.search('completed\s+in\s+(\d+)', line)
+            if match:
+                json_result['completion_time'] = match.group(1)
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}: {}".format(dest, line))
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            chdir=dict(required=False,
+                       type='str'),
+            mode=dict(required=False,
+                      type='str',
+                      default="client",
+                      choices=['server', 'client']),
+            bind=dict(type='str',
+                      required=False),
+            dest=dict(required=False,
+                      type='str',
+                      default=None),
+            executable=dict(required=False,
+                            type='str'),
+            format=dict(required=False,
+                        type='str',
+                        default='k',
+                        choices=['k', 'm', 'K', 'M']),
+            interval=dict(required=False,
+                          type='int'),
+            port=dict(required=False,
+                      type=int),
+            state=dict(type='str',
+                       default="benchmark",
+                       choices=['benchmark', 'parse']),
+            server=dict(type='str',
+                        required=False),
+            output_format=dict(type='str',
+                               required=False,
+                               choices=['standard', 'json']),
+            timeout=dict(required=False,
+                         type='int',
+                         default=10),
+            udp=dict(required=False,
+                     type='bool',
+                     default=False),
+            verbose=dict(required=False,
+                         type='bool',
+                         default=False),
+            tcp_window_size=dict(required=False,
+                                 type='str'),
+            parallel_threads=dict(required=False,
+                          type='int'),
+        ),
+        supports_check_mode=False
+    )
+
+    iperf_bin = None
+    result = {'changed': False, 'bench_config': dict()}
+
+    if module.params['state'] == 'parse':
+        if not module.params['dest']:
+            module.fail_json(msg='dest= is required for state=parse')
+        parse(module, result, module.params)
+
+    if module.params['state'] == 'benchmark':
+        missing_params = list()
+
+        if module.params['mode'] == 'client':
+            for param in ['server']:
+                if not module.params[param]:
+                    missing_params.append(param)
+        if len(missing_params) > 0:
+            module.fail_json(msg="missing required arguments: {}".format(missing_params))
+        if module.params['executable']:
+            iperf_bin = module.params['executable']
+        else:
+            iperf_bin = module.get_bin_path('iperf3', True, ['/usr/bin/local'])
+
+        benchmark(module, result, iperf_bin, module.params)
+
+    for param in ['timeout', 'udp']:
+        result['bench_config'][param] = module.params[param]
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/mprime.py
+++ b/benchmarks/mprime.py
@@ -1,0 +1,212 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: mprime
+short_description: Execute the mPrime torture benchmark
+description:
+ - Use this module to run the mPrime benchmark
+ - http://www.mersenne.org/download/
+version_added: "2.1"
+options:
+  chdir:
+    description:
+     - change working directory
+    required: false
+    default: null
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: false
+  executable:
+    description:
+     - path to mprime executable if running from source
+    required: false
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: false
+  timeout:
+    description:
+     - Total time to run mprime for.
+    required: true
+  unit:
+    description:
+     - Unit of time for timeout(s = seconds, m = minutes, h = hours, d = day)
+    required: false
+    default: s
+requirements:
+ - mprime
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run mprime for 60 seconds
+- mprime: timeout=60 unit=s
+
+# Run mprime for 60 seconds output results to /tmp/mprime.out
+- mprime: timeout=60 unit=s dest=/tmp/mprime.out
+
+# Parse mprime result from file
+- mprime: state=parse dest=/tmp/mprime.out
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/path/to/mprime ..."
+'''
+
+import os
+import re
+import tempfile
+
+
+def benchmark(module, result, bin, params):
+
+    timeout     = params['timeout']
+    unit        = params['unit']
+    dest        = params['dest']
+
+    benchmark_command = None
+
+    if dest:
+        benchmark_command = "timeout --preserve-status -s SIGINT {1}{2} {0} -t > {3}"\
+            .format(bin, timeout, unit, dest)
+    else:
+        benchmark_command = "timeout --preserve-status -s SIGINT {1}{2} {0} -t"\
+            .format(bin, timeout, unit)
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['exec_cmd']  = benchmark_command
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+def parse(module, result, params):
+
+    dest        = params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    result_file = open(dest, 'r')
+    data = result_file.read()
+    result_file.close()
+
+    json_result = dict()
+
+    regex = re.compile('\w* completed (\d*) .*? - (\d*) \w*, (\d*) \w*')
+    data = re.findall(regex, data)
+
+    json_result['total_tests'] = 0
+    json_result['total_errors'] = 0
+    json_result['total_warnings'] = 0
+
+    for tup in data:
+        json_result['total_tests'] += int(tup[0])
+        json_result['total_errors'] += int(tup[1])
+        json_result['total_warnings'] += int(tup[2])
+
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}".format(dest))
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            chdir=dict(required=False,
+                       type='str'),
+            dest=dict(required=False,
+                      type='str',
+                      default=None),
+            executable=dict(required=False,
+                            type='str'),
+            state=dict(type='str',
+                       default="benchmark",
+                       choices=['benchmark', 'parse']),
+            timeout=dict(required=False,
+                         type='int'),
+            unit=dict(required=False,
+                      type='str',
+                      default='s',
+                      choices=['s', 'm', 'h', 'd']),
+
+        ),
+        supports_check_mode=False
+    )
+
+    benchmark_bin = None
+    result = {'changed': False}
+
+    if module.params['state'] == 'parse':
+        if not module.params['dest']:
+            module.fail_json(msg='dest= is required for state=parse')
+        parse(module, result, module.params)
+
+    if module.params['state'] == 'benchmark':
+        missing_params = list()
+        for param in ['timeout']:
+            if not module.params[param]:
+                missing_params.append(param)
+        if len(missing_params) > 0:
+            module.fail_json(msg="missing required arguments: {}".format(missing_params))
+        if module.params['executable']:
+            benchmark_bin = module.get_bin_path('mprime', True, [module.params['executable']])
+        else:
+            benchmark_bin = module.get_bin_path('mprime', True, ['/usr/bin/local'])
+
+        benchmark(module, result, benchmark_bin, module.params)
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/multichase.py
+++ b/benchmarks/multichase.py
@@ -1,0 +1,260 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+# Kwanho Ryu <Kwanho.Ryu@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: multichase
+short_description: Execute the Multichase benchmark
+description:
+ - Use this module to run the Multichase benchmark
+options:
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: False
+  state:
+    description:
+     - specify whether to run benchmark or parse output
+    required: False
+    default: benchmark
+    choices: ["benchmark", "parse"]
+  benchmark:
+    description:
+     - benchmark to run
+    required: False
+    choices: ["multichase", "pingpong", "fairness"]
+    default: multichase
+  memory:
+    description:
+     - used only for multichase, size of array that a pointer chase will be performed through
+    required: False
+  stride:
+    description:
+     - used only for multichase, size of stride that a pointer chase will be run with
+    required: False
+  threads:
+    description:
+     - used only for multichase, number of threads that we run the benchmark on
+    required: False
+  samples:
+    description:
+     - used only for multichase, number of 0.5 second samples
+    required: False
+  dest:
+    description:
+     - absolute path of file to write stdout to or where the output file to be parsed is
+    required: False
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: False
+requirements:
+ - multichase
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+        "Kwanho Ryu <Kwanho.Ryu@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run multichase that will perform a pointer chase through an array size of 200000 bytes
+  with a stride size of 128 bytes on 1 thread where the number of 0.5 second samples is 3
+  and write stdout to the absolute path specified in dest option.
+- multichase:
+    state: benchmark
+    benchmark: multichase
+    executable: /tmp/test/
+    memory: 200000
+    stride: 128
+    threads: 1
+    samples: 3
+    dest: /tmp/test/multichase.out
+
+# parse the output file stored in the path given in dest
+- multichase:
+    state: parse
+    dest: /tmp/test/multichase.out
+
+# Schedule fairness benchmark to execute in 10 minutes
+- multichase:
+    state: benchmark
+    benchmark: fairness
+    executable: /tmp/test/
+    dest: /tmp/test/fairness.out
+    delay: 10
+
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/path/to/multichase ..."
+'''
+
+
+import os
+import re
+import tempfile
+from commands import *
+import fcntl, struct, sys
+
+
+def benchmark(module, result, bin, params):
+
+    benchmark   = params['benchmark']
+    memory      = params['memory']
+    stride      = params['stride']
+    threads     = params['threads']
+    samples     = params['samples']
+    dest        = params['dest']
+
+    # Changing directory to the one containing executable benchmark
+    [path, bin] = bin.rsplit('/', 1)
+    os.chdir(path)
+
+    benchmark_command = "./{}".format(benchmark)
+
+    if benchmark == "multichase":
+        if memory:
+            benchmark_command += " -m {}".format(memory)
+        if stride:
+            benchmark_command += " -s {}".format(stride)
+        if threads:
+            benchmark_command += " -t {}".format(threads)
+        if samples:
+            benchmark_command += " -n {}".format(samples)
+        benchmark_command += " -v"
+    elif benchmark == "pingpong":
+        benchmark_command += " -u"
+
+    if dest:
+        benchmark_command += " > {}".format(dest)
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['exec_cmd']  = benchmark_command
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+# Parse only supports multichase benchmark
+def parse(module, result, params):
+    dest	= params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    f = open(dest, 'r')
+
+    json_result = dict()
+
+    counter = 0
+    prev_line = ""
+    curr_line = ""
+    while True:
+        prev_line = curr_line
+        curr_line = f.readline()
+        counter += 1
+        if not curr_line:
+            break
+    json_result["Best Latency Time"]=prev_line
+
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}".format(dest))
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            chdir=dict(required=False,
+                       default=None,
+                       type='str'),
+            state=dict(required=False,
+                       choices=['benchmark', 'parse'],
+                       default="benchmark",
+                       type='str'),
+            benchmark=dict(required=False,
+                           choices=['multichase', 'pingpong', 'fairness'],
+                           default='multichase',
+                           type='str'),
+            executable=dict(required=False,
+                            type='str'),
+            memory=dict(required=False,
+                        type='str'),
+            stride=dict(required=False,
+                        type='str'),
+            threads=dict(required=False,
+                         type='str'),
+            samples=dict(required=False,
+                         type='str'),
+            dest=dict(required=False,
+                      type='str'),
+        ),
+        supports_check_mode=False
+    )
+
+    benchmark_bin = None
+    result = {'changed': False}
+
+    if module.params['state'] == 'parse':
+       if not module.params['dest']:
+           module.fail_json(msg='dest= is required for state=parse')
+       parse(module, result, module.params)
+
+    if module.params['state'] == 'benchmark':
+        if module.params['executable']:
+            benchmark_bin = module.get_bin_path(module.params['benchmark'], True, [module.params['executable']])
+        else:
+            benchmark_bin = module.get_bin_path(module.params['benchmark'], True, ['/usr/bin/local'])
+
+        benchmark(module, result, benchmark_bin, module.params)
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/passmark.py
+++ b/benchmarks/passmark.py
@@ -1,0 +1,224 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: passmark
+short_description: Execute the Passmark BurnInTest
+description:
+ - Use this module to run the Passmark BIT benchmark
+ - http://www.passmark.com/products/bitlinux.htm
+version_added: "2.1"
+options:
+  chdir:
+    description:
+     - change working directory
+    required: false
+    default: null
+  cfg:
+    description:
+     - path to passmark burnintest cfg file
+    required: true
+  executable:
+    description:
+     - path to passmark burnintest executable if running from source
+    required: false
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: false
+requirements:
+ - passmark burnintest
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run Passmark BIT with the config.bitcfg file and write output to result.log
+- passmark:
+    cfg: /path/to/config.bitcfg
+    executable: /path/to/bit_cmd_line_x64
+    dest: /path/to/result.log
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/path/to/passmark ..."
+'''
+
+import os
+import re
+import tempfile
+
+
+def benchmark(module, result, benchmark_bin, params):
+
+    cfg         = params['cfg']
+    chdir       = params['chdir']
+    dest        = params['dest']
+
+
+    if chdir:
+        try:
+            os.chdir(chdir)
+            benchmark_bin = './bit_cmd_line_x64'
+        except OSError as e:
+            module.fail_json(msg=str(e))
+
+    benchmark_command = None
+
+    if dest:
+        benchmark_command = "{} -C {} > {}"\
+            .format(benchmark_bin, cfg, dest)
+    else:
+        benchmark_command = "{} -C {}"\
+            .format(benchmark_bin, cfg)
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['exec_cmd']  = benchmark_command
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+def parse(module, result, params):
+
+    dest        = params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    result_file = open(dest, 'r')
+    data = result_file.readlines()
+    result_file.close()
+
+    json_result = dict()
+    json_result['errors'] = list()
+
+    reached = False
+    serious = False
+    errors = 0
+
+    regex = re.compile('(\w+)')
+
+    def pass_or_fail(dat):
+        return "PASS" if "PASS" in dat else "FAIL"
+
+    for line in data:
+        if "RESULT SUMMARY" in line:
+            reached = True
+        if "SERIOUS ERROR SUMMARY" in line:
+            serious = True
+            reached = False
+        if reached and "CPU" in line:
+            splitted = re.findall(regex, line)
+            json_result['cpu'] = (pass_or_fail(splitted))
+        if reached and "Memory" in line:
+            splitted = re.findall(regex, line)
+            json_result['memory'] = (pass_or_fail(splitted))
+        if reached and "Disk" in line:
+            splitted = re.findall(regex, line)
+            json_result['disk'] = (pass_or_fail(splitted))
+        if reached and "Network" in line:
+            splitted = re.findall(regex, line)
+            json_result['network'] = (pass_or_fail(splitted))
+        if serious and "SERIOUS:" in line:
+            errors += 1
+            json_result['errors'].append(line)
+
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}".format(dest))
+    json_result['total_errors'] = errors
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            chdir=dict(required=False,
+                       type='str'),
+            cfg=dict(required=False,
+                     type='str'),
+            dest=dict(required=False,
+                      type='str',
+                      default=None),
+            executable=dict(required=False,
+                            type='str'),
+            state=dict(type='str',
+                       default="benchmark",
+                       choices=['benchmark', 'parse']),
+        ),
+        supports_check_mode=False
+    )
+
+    benchmark_bin = None
+    result = {'changed': False}
+
+    if module.params['state'] == 'parse':
+        if not module.params['dest']:
+            module.fail_json(msg='dest= is required for state=parse')
+        parse(module, result, module.params)
+
+    if module.params['state'] == 'benchmark':
+        missing_params = list()
+        for param in ['cfg']:
+            if not module.params[param]:
+                missing_params.append(param)
+        if len(missing_params) > 0:
+            module.fail_json(msg="missing required arguments: {}".format(missing_params))
+        if module.params['executable']:
+            benchmark_bin = module.get_bin_path('bit_cmd_line_x64', False, [module.params['executable']])
+        else: 
+            benchmark_bin = module.get_bin_path('bit_cmd_line_x64', False, ['/usr/bin/local'])
+
+        benchmark(module, result, benchmark_bin, module.params)
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/scimark2.py
+++ b/benchmarks/scimark2.py
@@ -1,0 +1,204 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+# Shanthini Velan <Shanthini.Velan@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: scimark2
+short_description: Execute the Scimark 2.0 benchmark
+description:
+ - Use this module to run the Scimark 2.0 benchmark
+ - http://math.nist.gov/scimark2
+version_added: "2.1"
+options:
+  chdir:
+    description:
+     - change working directory
+    required: false
+    default: null
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: false
+  executable:
+    description:
+     - path to scimark2 executable if running from source
+    required: true
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: false
+  state:
+    description:
+     - specify whether to run benchmark or parse output
+    required: false
+requirements:
+ - scimark2
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run scimark2 executable located at /home/scimark
+- scimark: executable=/home/scimark
+
+# Run scimark2 executable located at /home/scimark and output results to /tmp/scimark2.out
+- scimark2: executable=/home/scimark dest=/tmp/scimark2.out
+
+# Schedule scimark2 to execute in 10 minutes
+- scimark2: executable=/home/scimark delay=10
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/path/to/scimark2 ..."
+'''
+
+import os
+import re
+import tempfile
+
+
+def benchmark(module, result, bin, params):
+
+    dest        = params['dest']
+
+    # Changing directory to the one containing executable benchmark
+    os.chdir(params['executable'])
+
+    benchmark_command = None
+
+    if dest:
+        benchmark_command = "{} > {}"\
+            .format(bin, dest)
+    else:
+        benchmark_command = "{} "\
+            .format(bin)
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+def parse(module, result, params):
+
+    dest        = params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    result_file = open(dest, 'r')
+    data = result_file.readlines()
+    result_file.close()
+
+    json_result = dict()
+
+    for line in data:
+        if "Mflops" in line:
+            match = re.search('Mflops:\s+(\d+)', line)
+            if match:
+                if "FFT" in line:
+                    json_result['FFT'] = match.group(1)
+                elif "SOR" in line:
+                    json_result['SOR'] = match.group(1)
+                elif "MonteCarlo" in line:
+                    json_result['MonteCarlo'] = match.group(1)
+                elif "Sparse"in line:
+                    json_result['Sparse_Matrix_Mult'] = match.group(1)
+                elif "LU" in line:
+                    json_result['Dense_LU'] = match.group(1)
+        elif "Composite" in line:
+            match = re.search('Score:\s+(\d+)', line)
+            if match:
+                json_result['composite_score'] = match.group(1)
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}: {}".format(dest, line))
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            chdir=dict(required=False,
+                       type='str'),
+            delay=dict(required=False,
+                       type='int'),
+            dest=dict(required=False,
+                      type='str',
+                      default=None),
+            executable=dict(required=False,
+                            type='str'),
+            state=dict(type='str',
+                       default="benchmark",
+                       choices=['benchmark', 'parse']),
+
+        ),
+        supports_check_mode=False
+    )
+
+    result = {'changed': False}
+    benchmark_bin=None
+
+    if module.params['state'] == 'parse':
+        if not module.params['dest']:
+            module.fail_json(msg='dest= is required for state=parse')
+        parse(module, result, module.params)
+    
+    if module.params['state'] == 'benchmark':
+        if not module.params['executable']:
+            module.fail_json(msg='executable= is required for state=benchmark')
+            benchmark(module, result, benchmark_bin, module.params)
+        else:
+            benchmark_bin = module.get_bin_path('scimark2', True, [module.params['executable']])
+            benchmark(module, result, benchmark_bin, module.params)
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/stress.py
+++ b/benchmarks/stress.py
@@ -1,0 +1,214 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: stress
+short_description: Execute the Stress benchmark
+description:
+ - Use this module to run the Stress benchmark
+ - https://people.seas.harvard.edu/~apw/stress/
+version_added: "2.1"
+options:
+  chdir:
+    description:
+     - change working directory
+    required: false
+    default: null
+  cpu:
+    description:
+     - number of cpus to stress
+    required: true
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: false
+  executable:
+    description:
+     - path to stress executable if running from source
+    required: false
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: false
+  timeout:
+    description:
+     - Total time to run stress for.
+    required: True
+requirements:
+ - stress
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run stress for 10 seconds on 1 cpu
+- stress: timeout=10 cpu=1
+
+# Run stress for 10 seconds on 1 cpu and output results to /tmp/stress.out
+- stress: timeout=10 cpu=1 dest=/tmp/stress.out
+
+# Schedule stress to execute in 10 minutes
+- stress: timeout=10 cpu=1 dest=/tmp/stress.out delay=10
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/path/to/stress ..."
+'''
+
+import os
+import re
+import tempfile
+
+
+def benchmark(module, result, bin, params):
+
+    cpu         = params['cpu']
+    timeout     = params['timeout']
+    dest        = params['dest']
+
+    benchmark_command = None
+
+    if dest:
+        benchmark_command = "{} --cpu {} --timeout {} > {}"\
+            .format(bin, cpu, timeout, dest)
+    else:
+        benchmark_command = "{} --cpu {} --timeout {}"\
+            .format(bin, cpu, timeout)
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed']   = True
+    result['exec_cmd']  = benchmark_command
+    result['stdout']    = out.rstrip("\r\n")
+    result['stderr']    = err.rstrip("\r\n")
+    result['rc']        = rc
+
+def parse(module, result, params):
+
+    dest        = params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    result_file = open(dest, 'r')
+    data = result_file.readlines()
+    result_file.close()
+
+    json_result = dict()
+
+    for line in data:
+        if "hogs" in line:
+            match = re.search('(\d+)\s+cpu,\s+(\d+)\s+io,\s+(\d+)\s+vm,\s+(\d+)\s+hdd', line)
+            if match:
+                json_result['cpu_hogs'] = match.group(1)
+                json_result['io_hogs'] = match.group(2)
+                json_result['vm_hogs'] = match.group(3)
+                json_result['hdd_hogs'] = match.group(4)
+        elif "successful" in line:
+            match = re.search('completed\s+in\s+(\d+)', line)
+            if match:
+                json_result['completion_time'] = match.group(1)
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}: {}".format(dest, line))
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+
+    module = AnsibleModule(
+        argument_spec = dict(
+            chdir=dict(required=False,
+                       type='str'),
+            cpu=dict(required=False,
+                     type='int'),
+            delay=dict(required=False,
+                       type='int'),
+            dest=dict(required=False,
+                      type='str',
+                      default=None),
+            executable=dict(required=False,
+                            type='str'),
+            state=dict(type='str',
+                       default="benchmark",
+                       choices=['benchmark', 'parse']),
+            timeout=dict(required=False,
+                         type='int'),
+
+        ),
+        supports_check_mode=False
+    )
+
+    stress_bin = None
+    result = {'changed': False, 'bench_config': dict()}
+
+    if module.params['state'] == 'parse':
+        if not module.params['dest']:
+            module.fail_json(msg='dest= is required for state=parse')
+        parse(module, result, module.params)
+
+    if module.params['state'] == 'benchmark':
+        missing_params = list()
+        for param in ['timeout', 'cpu']:
+            if not module.params[param]:
+                missing_params.append(param)
+        if len(missing_params) > 0:
+            module.fail_json(msg="missing required arguments: {}".format(missing_params))
+        if module.params['executable']:
+            stress_bin = module.params['executable']
+        else:
+            stress_bin = module.get_bin_path('stress', True, ['/usr/bin/local'])
+
+        benchmark(module, result, stress_bin, module.params)
+
+    for param in ['timeout', 'cpu']:
+        result['bench_config'][param] = module.params[param]
+
+    module.exit_json(**result)
+
+# import module snippets
+from ansible.module_utils.basic import *
+main()

--- a/benchmarks/unixbench.py
+++ b/benchmarks/unixbench.py
@@ -1,0 +1,213 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2016, Hugh Ma <Hugh.Ma@flextronics.com>
+# Kwanho Ryu <Kwanho.Ryu@flextronics.com>
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: unixbench
+short_description: Execute the Unixbench benchmark
+description:
+ - Use this module to run the Unixbench benchmark
+options:
+  delay:
+    description:
+     - piggybacks off the at module as a action plugin to run benchmark at a schedule time
+    required: False
+  state:
+    description:
+     - specify whether to run benchmark or parse output
+    required: False
+  executable:
+    description:
+     - path to unixbench executable if running from source 
+    required: False
+  count:
+    description:
+     - number of copies of each test in parallel
+    required: True
+  dest:
+    description:
+     - absolute path of file to write stdout to
+    required: False
+requirements:
+ - unixbench
+author: "Hugh Ma <Hugh.Ma@flextronics.com>"
+        "Kwanho Ryu <Kwanho.Ryu@flextronics.com>"
+'''
+
+EXAMPLES = '''
+# Run unixbench in the given absolute path with count 1 and write stdout to the dest.
+- unixbench:
+    state: benchmark
+    executable: /tmp/test/byte-unixbench-master/UnixBench/
+    count: 1
+    dest: /tmp/test/ansible_Unixbench.out
+
+# Schedule parsing the file in the given path to execute in 10 minutes
+    state: parse
+    dest: /tmp/test/ansible_Unixbench.out
+    delay: 10
+'''
+
+RETURN = '''
+changed:
+  description: response to whether or not the benchmark completed successfully
+  returned: always
+  type: boolean
+  sample: true
+
+stdout:
+  description: the set of responses from the commands
+  returned: always
+  type: list
+  sample: ['...', '...']
+
+stdout_lines:
+  description: the value of stdout split into a list
+  returned: always
+  type: list
+  sample: [['...', '...'], ['...'], ['...']]
+
+exec_cmd:
+  description: Exact command executed to launch the benchmark with parameters
+  returned: success
+  type: string
+  sample: "/path/to/unixbench ..."
+'''
+
+import os
+import re
+import tempfile
+from commands import *
+import fcntl, struct, sys
+
+
+def benchmark(module, result, bin, params):
+
+    count   = params['count']
+    dest    = params['dest']
+
+    # Changing directory to the one containing executable benchmark
+    [path, bin] = bin.rsplit('/', 1)
+    os.chdir(path)
+
+    if dest:
+        benchmark_command = "./{} -c {} > {}".format(bin, count, dest)
+    else:
+        benchmark_command = "./{} -c {}".format(bin, count)
+
+    rc, out, err = module.run_command(benchmark_command,
+                                      use_unsafe_shell=True,
+                                      check_rc=True)
+
+    if dest:
+        out += "; Output located on targeted hosts at: {}".format(dest)
+
+    result['changed'] 	= True
+    result['exec_cmd']  = benchmark_command
+    result['stdout'] 	= out.rstrip("\r\n")
+    result['stderr'] 	= err.rstrip("\r\n")
+    result['rc'] 	= rc
+
+
+def parse(module, result, params):
+    dest = params['dest']
+
+    if not os.path.exists(dest):
+        module.fail_json(msg="{} does not exist".format(dest))
+
+    result_file = open(dest, 'r')
+    data = result_file.read()
+    data = data.strip()
+    data = data.splitlines()
+    result_file.close()
+
+    json_result = dict()
+
+    for line in data:
+        if 'BASELINE' in line:
+            idx = data.index(line)
+    data = data[(idx + 1):]
+    data = [x for x in data if '========' not in x]
+
+    json_result = dict()
+    for x in data:
+        rez = x.split(' ')
+        rez = filter(None, rez)
+        index = rez.pop()
+        if 'Index Score' not in x:
+            rez.pop()
+            rez.pop()
+        json_result[' '.join(rez)] = index
+
+    if not json_result:
+        module.fail_json(msg="Invalid result file at {}: {}".format(dest, line))
+
+    result['changed'] = True
+    result['results'] = json.dumps(json_result)
+
+
+def main():
+    module = AnsibleModule(
+        argument_spec=dict(
+            chdir=dict(required=False,
+                       default=None,
+                       type='str'),
+            state=dict(required=False,
+                       choices=['benchmark', 'parse'],
+                       default="benchmark",
+                       type='str'),
+            executable=dict(required=False,
+                            type='str'),
+            count=dict(required=True,
+                       type='str'),
+            dest=dict(required=False,
+                      type='str'),
+        ),
+        supports_check_mode=False
+    )
+
+    benchmark_bin = None
+    result = {'changed': False}
+
+    if module.params['state'] == 'parse':
+        if not module.params['dest']:
+            module.fail_json(msg='dest= is required for state=parse')
+        parse(module, result, module.params)
+
+    if module.params['state'] == 'benchmark':
+        missing_params = list()
+        for param in ['count']:
+            if not module.params[param]:
+                missing_params.append(param)
+        if len(missing_params) > 0:
+            module.fail_json(msg="missing required arguments: {}".format(missing_params))
+        if module.params['executable']:
+            benchmark_bin = module.get_bin_path('Run', True, [module.params['executable']])
+        else:
+            benchmark_bin = module.get_bin_path('Run', True, ['/usr/bin/local'])
+
+        benchmark(module, result, benchmark_bin, module.params)
+
+    module.exit_json(**result)
+
+
+# import module snippets
+from ansible.module_utils.basic import *
+
+main()


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

benchmarks modules: 
- fio
- iperf
- mprime
- multichase
- passmark
- scimark2
- stress
- unixbench
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Benchmarking is a field which automation is often sought after. By wrapping these benchmark tools (more to come) as Ansible modules, it enables people to quickly launch benchmarks remotely and at scale. Each benchmark module is formatted with essentially the same boilerplate with specific changes to just the parsing and execution portions. As much of the code is kept the same as possible as to allow adding new benchmarks to be quick and painless. 

…n tools
