### PR TITLE
Add subnet associations info to ec2_vpc_route_table_facts

### DIFF
--- a/cloud/amazon/ec2_vpc_route_table_facts.py
+++ b/cloud/amazon/ec2_vpc_route_table_facts.py
@@ -62,20 +62,26 @@ try:
 except ImportError:
     HAS_BOTO = False
 
+
 def get_route_table_info(route_table):
 
     # Add any routes to array
     routes = []
+    associations = []
     for route in route_table.routes:
         routes.append(route.__dict__)
+    for association in route_table.associations:
+        associations.append(association.__dict__)
 
-    route_table_info = { 'id': route_table.id,
-                         'routes': routes,
-                         'tags': route_table.tags,
-                         'vpc_id': route_table.vpc_id
-                       }
+    route_table_info = {'id': route_table.id,
+                        'routes': routes,
+                        'associations': associations,
+                        'tags': route_table.tags,
+                        'vpc_id': route_table.vpc_id
+                        }
 
     return route_table_info
+
 
 def list_ec2_vpc_route_tables(connection, module):
 
@@ -97,7 +103,7 @@ def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(
         dict(
-            filters = dict(default=None, type='dict')
+            filters=dict(default=None, type='dict')
         )
     )
 


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

ec2_vpc_route_table_facts
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Currently, the ec2_vpc_route_table_facts module does not include any information about route table associations even though this information is returned by the `get_all_route_tables` boto call. This information is extremely useful when reasoning about subnet/route table interactions. This PR rectifies that problem by just including a dict for each association in the exact same fashion as how the routes are returned to the user.

Also, I re-formatted the modules code to make it PEP8 compliant as defined by PyLint.

The main purpose of this PR is to add the subnet associations to the
dict returned by ec2_vpc_route_table_facts. This commit also
re-formats code to make it PEP8 compliant.
