### PR TITLE
kubernetes_templating

### DIFF
--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -193,6 +193,7 @@ class ActionModule(ActionBase):
     def get_template_source(self, filepath):
         try:
             source = self._find_needle('templates', source)
+            b_source = to_bytes(source)
             with open(b_source, 'r') as f:
                 template_data = to_text(f.read())
 

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -1,0 +1,340 @@
+# (c) 2015, Michael DeHaan <michael.dehaan@gmail.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import base64
+import datetime
+import os
+import pwd
+import time
+import json
+import requests
+import yaml
+
+from ansible import constants as C
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.plugins.action import ActionBase
+from ansible.utils.hashing import checksum_s
+from ansible.utils.boolean import boolean
+from ansible.module_utils.urls import fetch_url
+
+############################################################################
+############################################################################
+# For API coverage, this Anislbe module provides capability to operate on
+# all Kubernetes objects that support a "create" call (except for 'Events').
+# In order to obtain a valid list of Kubernetes objects, the v1 spec file
+# was referenced and the below python script was used to parse the JSON
+# spec file, extract only the objects with a description starting with
+# 'create a'. The script then iterates over all of these base objects
+# to get the endpoint URL and was used to generate the KIND_URL map.
+#
+# import json
+# from urllib2 import urlopen
+#
+# r = urlopen("https://raw.githubusercontent.com/kubernetes"
+#            "/kubernetes/master/api/swagger-spec/v1.json")
+# v1 = json.load(r)
+#
+# apis = {}
+# for a in v1['apis']:
+#     p = a['path']
+#     for o in a['operations']:
+#         if o["summary"].startswith("create a") and o["type"] != "v1.Event":
+#             apis[o["type"]] = p
+#
+# def print_kind_url_map():
+#     results = []
+#     for a in apis.keys():
+#         results.append('"%s": "%s"' % (a[3:].lower(), apis[a]))
+#     results.sort()
+#     print "KIND_URL = {"
+#     print ",\n".join(results)
+#     print "}"
+#
+# if __name__ == '__main__':
+#     print_kind_url_map()
+############################################################################
+############################################################################
+
+KIND_URL = {
+    "binding": "/api/v1/namespaces/{namespace}/bindings",
+    "endpoints": "/api/v1/namespaces/{namespace}/endpoints",
+    "limitrange": "/api/v1/namespaces/{namespace}/limitranges",
+    "namespace": "/api/v1/namespaces",
+    "node": "/api/v1/nodes",
+    "persistentvolume": "/api/v1/persistentvolumes",
+    "persistentvolumeclaim": "/api/v1/namespaces/{namespace}/persistentvolumeclaims",  # NOQA
+    "pod": "/api/v1/namespaces/{namespace}/pods",
+    "podtemplate": "/api/v1/namespaces/{namespace}/podtemplates",
+    "replicationcontroller": "/api/v1/namespaces/{namespace}/replicationcontrollers",  # NOQA
+    "resourcequota": "/api/v1/namespaces/{namespace}/resourcequotas",
+    "secret": "/api/v1/namespaces/{namespace}/secrets",
+    "service": "/api/v1/namespaces/{namespace}/services",
+    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts"
+}
+USER_AGENT = "ansible-k8s-module/0.0.1"
+
+class ActionModule(ActionBase):
+
+    def api_request(self, result, url, method="GET", headers=None, data=None, auth=None):
+        #TODO: add basic auth
+        #r = requests.get(url, auth=('user', 'pass'))
+        body = None
+        if data:
+            data = json.dumps(data)
+        if token:
+            if headers is None:
+                headers = {}
+            headers["Authorization"] = "Bearer {}".format(token)
+        if method == "GET":
+            r = requests.get(url, headers=headers, auth=auth)
+        elif method == "POST":
+            r = requests.post(url, headers=headers, data=data, auth=auth)
+        elif method == "PUT":
+            r = requests.put(url, headers=headers, data=data, auth=auth)
+        elif method == "DELETE":
+            r = requests.delete(url, headers=headers, auth=auth)
+        elif method == "PATCH":
+            r = requests.patch(url, headers=headers, data=data, auth=auth)
+        else:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg': "%s is not an proper http method" % method})
+            return -1, None
+
+        if r.status_code == -1:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg': "Failed to execute the API request: %s" % body, 'url': url, 'method':method, 'headers':headers})
+        if r.text is not None:
+            body = json.loads(r.text)
+        return r.status_code, body
+    
+    
+    def k8s_create_resource(self, result, url, data, auth):
+        status, body = self.api_request(result, url, method="POST", data=data, headers={"Content-Type": "application/json"}, auth=auth)
+        if status == 409:
+            name = data["metadata"].get("name", None)
+            status, body = self.api_request(result, url + "/" + name)
+            return False, body
+        elif status >= 400:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg':"failed to create the resource: %s" % body, 'url':url})
+        return True, body
+    
+    
+    def k8s_delete_resource(self, result, url, data, auth):
+        name = data.get('metadata', {}).get('name')
+        if name is None:
+            result['failed'] = True
+            result['msg'] = "Missing a named resource in object metadata when trying to remove a resource"
+    
+        url = url + '/' + name
+        status, body = self.api_request(result, url, method="DELETE", auth=auth)
+        if status == 404:
+            return False, "Resource name '%s' already absent" % name
+        elif status >= 400:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg':"failed to delete the resource '%s': %s" % (name, body), 'url':url})
+        return True, "Successfully deleted resource name '%s'" % name
+    
+
+    def k8s_replace_resource(self, result, url, data, auth):
+        #TODO: rather than error out, check if it already exists, and create if not
+        name = data.get('metadata', {}).get('name')
+        if name is None:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg':"Missing a named resource in object metadata when trying to replace a resource"})
+    
+        headers = {"Content-Type": "application/json"}
+        url = url + '/' + name
+        status, body = self.api_request(result, url, method="PUT", data=data, headers=headers, auth=auth)
+        if status == 409:
+            name = data["metadata"].get("name", None)
+            info, body = self.api_request(result, url + "/" + name, auth=auth)
+            return False, body
+        elif status >= 400:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg':"failed to replace the resource '%s': %s" % (name, body), 'url':url})
+        return True, body
+
+
+    def k8s_update_resource(self, result, url, data, auth):
+        name = data.get('metadata', {}).get('name')
+        if name is None:
+            result['failed'] = True
+            result['msg'] = json({'msg':"Missing a named resource in object metadata when trying to update a resource"})
+    
+        headers = {"Content-Type": "application/strategic-merge-patch+json"}
+        url = url + '/' + name
+        status, body = self.api_request(result, url, method="PATCH", data=data, headers=headers, auth=auth)
+        if status == 409:
+            name = data["metadata"].get("name", None)
+            status, body = self.api_request(result, url + "/" + name, auth=auth)
+            return False, body
+        elif status >= 400:
+            result['failed'] = True
+            result['msg'] = json.dumps({'msg':"failed to update the resource '%s': %s" % (name, body), 'url':url})
+        return True, body
+
+
+    def get_template_source(self, filepath):
+        try:
+            source = self._find_needle('templates', source)
+            with open(b_source, 'r') as f:
+                template_data = to_text(f.read())
+
+            return template_data
+
+        except AnsibleError as e:
+            result['failed'] = True
+            result['msg'] = to_native(e)
+            return None
+
+    def template(self, template_path, task_vars):
+        try:
+            template_data = self.get_template_source(template_path)
+
+            temp_vars = task_vars.copy()
+            temp_vars['template_host']     = os.uname()[1]
+            temp_vars['template_path']     = template_path
+
+            # Create a new searchpath list to assign to the templar environment's file
+            # loader, so that it knows about the other paths to find template files
+            searchpath = [self._loader._basedir, os.path.dirname(template_path)]
+            if self._task._role is not None:
+                if C.DEFAULT_ROLES_PATH:
+                    searchpath[:0] = C.DEFAULT_ROLES_PATH
+                searchpath.insert(1, self._task._role._role_path)
+
+            self._templar.environment.loader.searchpath = searchpath
+
+            old_vars = self._templar._available_variables
+            self._templar.set_available_variables(temp_vars)
+            resultant = self._templar.template(template_data, preserve_trailing_newlines=True, escape_backslashes=False, convert_data=False)
+            self._templar.set_available_variables(old_vars)
+        except Exception as e:
+            result['failed'] = True
+            result['msg'] = type(e).__name__ + ": " + str(e)
+            return None
+
+        try:
+            data = yaml.load(resultant)
+        except yaml.YAMLError, exc:
+            if hasattr(exc, 'problem_mark'):
+                mark = exc.problem_mark
+                result['failed'] = True
+                result['msg'] = "Error parsing YAML: error position: (%s:%s)" % (mark.line+1, mark.column+1)
+            else:
+                result['failed'] = True
+                result['msg'] = "Unknown error parsing YAML"
+            return None
+
+        return data
+
+
+    def run(self, tmp=None, task_vars=None):
+        ''' handler for managing the kubernetes objects '''
+        if task_vars is None:
+            task_vars = dict()
+
+        result = super(ActionModule, self).run(tmp, task_vars)
+
+        api_endpoint = self._task.args.get('api_endpoint')
+        username = self._task.args.get('username', None)
+        password = self._task.args.get('password', None)
+        global token #TODO: don't use a global. pass a header object
+        token = self._task.args.get('token')
+        insecure = self._task.args.get('insecure', False)
+        template_path = self._task.args.get('template', None)
+        inline = self._task.args.get('inline', None)
+        state  = self._task.args.get('state', None)
+
+        # check for required params
+        if api_endpoint is None:
+            result['failed'] = True
+            result['msg'] = "api_endpoint is required"
+
+        auth = None
+        if username is not None or password is not None:
+            if username is not None and password is not None:
+                auth=(username, password)
+            else:
+                result['failed'] = True
+                result['msg'] = "username and password must both be provided if either is provided"
+
+        if not isinstance(insecure, bool):
+            result['failed'] = True
+            result['msg'] = "insecure must be a valid boolean"
+
+        if state is None:
+            result['failed'] = True
+            result['msg'] = "state is required"
+
+        if template_path is not None or inline is not None:
+            if template_path is not None:
+                data = self.template(template_path, task_vars)
+            else:
+                data = inline
+        else:
+            result['failed'] = True
+            result['msg'] = "either template or inline is required"
+
+        if 'failed' in result:
+            return result
+
+        # some data massaging given that input params are valid
+        if not isinstance(data, list):
+            data = [ data ]
+
+        transport = 'https'
+        if insecure:
+            transport = 'http'
+    
+        target_endpoint = "%s://%s" % (transport, api_endpoint)
+    
+        result['changed'] = False
+        body = []
+
+        # send the specs to kubernetes
+        for item in data:
+            namespace = "default"
+            if item and 'metadata' in item:
+                namespace = item.get('metadata', {}).get('namespace', "default")
+                kind = item.get('kind', '').lower()
+                try:
+                    url = target_endpoint + KIND_URL[kind]
+                except KeyError:
+                    result['failed'] = True
+                    result['msg'] = "invalid resource kind specified in the data: '%s'" % kind
+                url = url.replace("{namespace}", namespace)
+            else:
+                url = target_endpoint
+    
+            if state == 'present':
+                item_changed, item_body = self.k8s_create_resource(result, url, item, auth)
+            elif state == 'absent':
+                item_changed, item_body = self.k8s_delete_resource(result, url, item, auth)
+            elif state == 'replace':
+                item_changed, item_body = self.k8s_replace_resource(result, url, item, auth)
+            elif state == 'update':
+                item_changed, item_body = self.k8s_update_resource(result, url, item, auth)
+    
+            result['changed'] |= item_changed
+            body.append(item_body)
+
+        return result

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -240,9 +240,10 @@ class ActionModule(ActionBase):
 
         try:
             data = yaml.load(resultant)
-        except yaml.YAMLError, exc:
-            if hasattr(exc, 'problem_mark'):
-                mark = exc.problem_mark
+        except yaml.YAMLError:
+            e = get_exception()
+            if hasattr(e, 'problem_mark'):
+                mark = e.problem_mark
                 result['failed'] = True
                 result['msg'] = "Error parsing YAML: error position: (%s:%s)" % (mark.line+1, mark.column+1)
             else:

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -14,7 +14,8 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
-from __future__ import (absolute_import, division, print_function)
+#from __future__ import (absolute_import, division, print_function)
+from __future__ import division
 __metaclass__ = type
 
 import base64

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -33,6 +33,7 @@ from ansible.plugins.action import ActionBase
 from ansible.utils.hashing import checksum_s
 from ansible.utils.boolean import boolean
 from ansible.module_utils.urls import fetch_url
+from ansible.module_utils.pycompat24 import get_exception
 
 ############################################################################
 ############################################################################
@@ -202,7 +203,8 @@ class ActionModule(ActionBase):
 
             return template_data
 
-        except AnsibleError as e:
+        except AnsibleError:
+            e = get_exception()
             result['failed'] = True
             result['msg'] = to_native(e)
             return None
@@ -229,7 +231,8 @@ class ActionModule(ActionBase):
             self._templar.set_available_variables(temp_vars)
             resultant = self._templar.template(template_data, preserve_trailing_newlines=True, escape_backslashes=False, convert_data=False)
             self._templar.set_available_variables(old_vars)
-        except Exception as e:
+        except Exception:
+            e = get_exception()
             result['failed'] = True
             result['msg'] = type(e).__name__ + ": " + str(e)
             return None

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -36,7 +36,7 @@ from ansible.module_utils.urls import fetch_url
 
 ############################################################################
 ############################################################################
-# For API coverage, this Anislbe module provides capability to operate on
+# For API coverage, this Ansible module provides capability to operate on
 # all Kubernetes objects that support a "create" call (except for 'Events').
 # In order to obtain a valid list of Kubernetes objects, the v1 spec file
 # was referenced and the below python script was used to parse the JSON

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -194,8 +194,11 @@ class ActionModule(ActionBase):
         try:
             source = self._find_needle('templates', source)
             b_source = to_bytes(source)
-            with open(b_source, 'r') as f:
+            f = open(b_source, 'r')
+            try:
                 template_data = to_text(f.read())
+            finally:
+               f.close()
 
             return template_data
 

--- a/clustering/action_plugins/kubernetes.py
+++ b/clustering/action_plugins/kubernetes.py
@@ -93,8 +93,6 @@ USER_AGENT = "ansible-k8s-module/0.0.1"
 class ActionModule(ActionBase):
 
     def api_request(self, result, url, method="GET", headers=None, data=None, auth=None):
-        #TODO: add basic auth
-        #r = requests.get(url, auth=('user', 'pass'))
         body = None
         if data:
             data = json.dumps(data)

--- a/clustering/kubernetes.py
+++ b/clustering/kubernetes.py
@@ -75,8 +75,7 @@ options:
         only be used when execuing the M('kubernetes') module local to the Kubernetes
         cluster using the insecure local port (locahost:8080 by default)."
 
-author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
-        "adapted by Joe schneider (@astropuffin) <j2@dronedeploy.com>"
+author: "Eric Johnson (@erjohnso) <erjohnso@google.com>, adapted by Joe schneider (@astropuffin) <j2@dronedeploy.com>"
 '''
 
 EXAMPLES = '''

--- a/clustering/kubernetes.py
+++ b/clustering/kubernetes.py
@@ -25,9 +25,8 @@ description:
     - This module can manage Kubernetes resources on an existing cluster using
       the Kubernetes server API. Users can specify in-line API data, or
       specify an existing Kubernetes YAML file. Currently, this module,
-        Only supports HTTP Basic Auth
+        Supports HTTP Basic Auth and Auth Tokens
         Only supports 'strategic merge' for update, http://goo.gl/fCPYxT
-        SSL certs are not working, use 'validate_certs=off' to disable
 options:
   api_endpoint:
     description:
@@ -35,25 +34,15 @@ options:
     required: true
     default: null
     aliases: ["endpoint"]
-  inline_data:
+  inline:
     description:
-      - The Kubernetes YAML data to send to the API I(endpoint). This option is
-        mutually exclusive with C('file_reference').
+      - The Kubernetes YAML data to send to the API I(endpoint).
     required: true
     default: null
-  file_reference:
+  template:
     description:
-      - Specify full path to a Kubernets YAML file to send to API I(endpoint).
-        This option is mutually exclusive with C('inline_data').
-    required: false
-    default: null
-  certificate_authority_data:
-    description:
-      - Certificate Authority data for Kubernetes server. Should be in either
-        standard PEM format or base64 encoded PEM data. Note that certificate
-        verification is broken until ansible supports a version of
-        'match_hostname' that can match the IP address against the CA data.
-    required: false
+      - The Kubernetes YAML data to send to the API I(endpoint).
+    required: true
     default: null
   state:
     description:
@@ -61,71 +50,74 @@ options:
     required: true
     default: "present"
     choices: ["present", "absent", "update", "replace"]
-  url_password:
-    description:
-      - The HTTP Basic Auth password for the API I(endpoint). This should be set
-        unless using the C('insecure') option.
-    default: null
-    aliases: ["password"]
-  url_username:
+  username:
     description:
       - The HTTP Basic Auth username for the API I(endpoint). This should be set
-        unless using the C('insecure') option.
+        unless using the C('insecure') option. If C('password') is supplied then
+        then this is required. Mutually exclusive with C('token')
     default: "admin"
     aliases: ["username"]
+  password:
+    description:
+      - The HTTP Basic Auth password for the API I(endpoint). This should be set
+        unless using the C('insecure') option. If C('username') is supplied then
+        then this is required. Mutually exclusive with C('token')
+    default: null
+    aliases: ["password"]
+  token:
+    description:
+      - the Authorization bearer token (http://kubernetes.io/docs/admin/authentication/)
+        Mutually exclusive with C('username') and C('password')
+    default: None
   insecure:
     description:
       - "Reverts the connection to using HTTP instead of HTTPS. This option should
         only be used when execuing the M('kubernetes') module local to the Kubernetes
         cluster using the insecure local port (locahost:8080 by default)."
-  validate_certs:
-    description:
-      - Enable/disable certificate validation. Note that this is set to
-        C(false) until Ansible can support IP address based certificate
-        hostname matching (exists in >= python3.5.0).
-    required: false
-    default: false
 
 author: "Eric Johnson (@erjohnso) <erjohnso@google.com>"
+        "adapted by Joe schneider (@astropuffin) <j2@dronedeploy.com>"
 '''
 
 EXAMPLES = '''
-# Create a new namespace with in-line YAML.
-- name: Create a kubernetes namespace
+# Create a kubernetes namespace from file
+- name: Create a kubernetes namespace from file
   kubernetes:
-    api_endpoint: 123.45.67.89
-    url_username: admin
-    url_password: redacted
-    inline_data:
-      kind: Namespace
-      apiVersion: v1
-      metadata:
-        name: ansible-test
-        labels:
-          label_env: production
-          label_ver: latest
-        annotations:
-          a1: value1
-          a2: value2
+    api_endpoint: kube-master.ddops.cool
+    token: redacted
+    template: ns.yml
     state: present
 
-# Create a new namespace from a YAML file.
-- name: Create a kubernetes namespace
+# Create a kubernetes namespace from template
+- name: Create a kubernetes namespace from template
   kubernetes:
-    api_endpoint: 123.45.67.89
-    url_username: admin
-    url_password: redacted
-    file_reference: /path/to/create_namespace.yaml
+    api_endpoint: kube-master.ddops.cool
+    username: admin
+    password: redacted
+    template: ns.yml.j2
     state: present
+  with_items:
+    - ansible-test
 
-# Do the same thing, but using the insecure localhost port
-- name: Create a kubernetes namespace
+# Create a kubernetes namespace from inline
+- name: Create a kubernetes namespace from inline
   kubernetes:
-    api_endpoint: 123.45.67.89
-    insecure: true
-    file_reference: /path/to/create_namespace.yaml
+    api_endpoint: kube-master.ddops.cool
+    token: redacted
+    inline:
+        kind: Namespace
+        apiVersion: v1
+        metadata:
+          name: "{{ item }}"
+          labels:
+            label_env: test
+            label_ver: latest
+          annotations:
+            a1: value1
+            a2: value2
     state: present
-
+  with_items:
+    - ansible-test
 '''
 
 RETURN = '''
@@ -150,250 +142,4 @@ api_response:
             phase: "Active"
 '''
 
-import yaml
-import base64
-
-############################################################################
-############################################################################
-# For API coverage, this Anislbe module provides capability to operate on
-# all Kubernetes objects that support a "create" call (except for 'Events').
-# In order to obtain a valid list of Kubernetes objects, the v1 spec file
-# was referenced and the below python script was used to parse the JSON
-# spec file, extract only the objects with a description starting with
-# 'create a'. The script then iterates over all of these base objects
-# to get the endpoint URL and was used to generate the KIND_URL map.
-#
-# import json
-# from urllib2 import urlopen
-#
-# r = urlopen("https://raw.githubusercontent.com/kubernetes"
-#            "/kubernetes/master/api/swagger-spec/v1.json")
-# v1 = json.load(r)
-#
-# apis = {}
-# for a in v1['apis']:
-#     p = a['path']
-#     for o in a['operations']:
-#         if o["summary"].startswith("create a") and o["type"] != "v1.Event":
-#             apis[o["type"]] = p
-#
-# def print_kind_url_map():
-#     results = []
-#     for a in apis.keys():
-#         results.append('"%s": "%s"' % (a[3:].lower(), apis[a]))
-#     results.sort()
-#     print "KIND_URL = {"
-#     print ",\n".join(results)
-#     print "}"
-#
-# if __name__ == '__main__':
-#     print_kind_url_map()
-############################################################################
-############################################################################
-
-KIND_URL = {
-    "binding": "/api/v1/namespaces/{namespace}/bindings",
-    "endpoints": "/api/v1/namespaces/{namespace}/endpoints",
-    "limitrange": "/api/v1/namespaces/{namespace}/limitranges",
-    "namespace": "/api/v1/namespaces",
-    "node": "/api/v1/nodes",
-    "persistentvolume": "/api/v1/persistentvolumes",
-    "persistentvolumeclaim": "/api/v1/namespaces/{namespace}/persistentvolumeclaims",  # NOQA
-    "pod": "/api/v1/namespaces/{namespace}/pods",
-    "podtemplate": "/api/v1/namespaces/{namespace}/podtemplates",
-    "replicationcontroller": "/api/v1/namespaces/{namespace}/replicationcontrollers",  # NOQA
-    "resourcequota": "/api/v1/namespaces/{namespace}/resourcequotas",
-    "secret": "/api/v1/namespaces/{namespace}/secrets",
-    "service": "/api/v1/namespaces/{namespace}/services",
-    "serviceaccount": "/api/v1/namespaces/{namespace}/serviceaccounts"
-}
-USER_AGENT = "ansible-k8s-module/0.0.1"
-
-
-# TODO(erjohnso): SSL Certificate validation is currently unsupported.
-# It can be made to work when the following are true:
-# - Ansible consistently uses a "match_hostname" that supports IP Address
-#   matching. This is now true in >= python3.5.0. Currently, this feature
-#   is not yet available in backports.ssl_match_hostname (still 3.4).
-# - Ansible allows passing in the self-signed CA cert that is created with
-#   a kubernetes master. The lib/ansible/module_utils/urls.py method,
-#   SSLValidationHandler.get_ca_certs() needs a way for the Kubernetes
-#   CA cert to be passed in and included in the generated bundle file.
-# When this is fixed, the following changes can be made to this module,
-# - Remove the 'return' statement in line 254 below
-# - Set 'required=true' for certificate_authority_data and ensure that
-#   ansible's SSLValidationHandler.get_ca_certs() can pick up this CA cert
-# - Set 'required=true' for the validate_certs param.
-
-def decode_cert_data(module):
-    return
-    d = module.params.get("certificate_authority_data")
-    if d and not d.startswith("-----BEGIN"):
-        module.params["certificate_authority_data"] = base64.b64decode(d)
-
-
-def api_request(module, url, method="GET", headers=None, data=None):
-    body = None
-    if data:
-        data = json.dumps(data)
-    response, info = fetch_url(module, url, method=method, headers=headers, data=data)
-    if int(info['status']) == -1:
-        module.fail_json(msg="Failed to execute the API request: %s" % info['msg'], url=url, method=method, headers=headers)
-    if response is not None:
-        body = json.loads(response.read())
-    return info, body
-
-
-def k8s_create_resource(module, url, data):
-    info, body = api_request(module, url, method="POST", data=data, headers={"Content-Type": "application/json"})
-    if info['status'] == 409:
-        name = data["metadata"].get("name", None)
-        info, body = api_request(module, url + "/" + name)
-        return False, body
-    elif info['status'] >= 400:
-        module.fail_json(msg="failed to create the resource: %s" % info['msg'], url=url)
-    return True, body
-
-
-def k8s_delete_resource(module, url, data):
-    name = data.get('metadata', {}).get('name')
-    if name is None:
-        module.fail_json(msg="Missing a named resource in object metadata when trying to remove a resource")
-
-    url = url + '/' + name
-    info, body = api_request(module, url, method="DELETE")
-    if info['status'] == 404:
-        return False, "Resource name '%s' already absent" % name
-    elif info['status'] >= 400:
-        module.fail_json(msg="failed to delete the resource '%s': %s" % (name, info['msg']), url=url)
-    return True, "Successfully deleted resource name '%s'" % name
-
-
-def k8s_replace_resource(module, url, data):
-    name = data.get('metadata', {}).get('name')
-    if name is None:
-        module.fail_json(msg="Missing a named resource in object metadata when trying to replace a resource")
-
-    headers = {"Content-Type": "application/json"}
-    url = url + '/' + name
-    info, body = api_request(module, url, method="PUT", data=data, headers=headers)
-    if info['status'] == 409:
-        name = data["metadata"].get("name", None)
-        info, body = api_request(module, url + "/" + name)
-        return False, body
-    elif info['status'] >= 400:
-        module.fail_json(msg="failed to replace the resource '%s': %s" % (name, info['msg']), url=url)
-    return True, body
-
-
-def k8s_update_resource(module, url, data):
-    name = data.get('metadata', {}).get('name')
-    if name is None:
-        module.fail_json(msg="Missing a named resource in object metadata when trying to update a resource")
-
-    headers = {"Content-Type": "application/strategic-merge-patch+json"}
-    url = url + '/' + name
-    info, body = api_request(module, url, method="PATCH", data=data, headers=headers)
-    if info['status'] == 409:
-        name = data["metadata"].get("name", None)
-        info, body = api_request(module, url + "/" + name)
-        return False, body
-    elif info['status'] >= 400:
-        module.fail_json(msg="failed to update the resource '%s': %s" % (name, info['msg']), url=url)
-    return True, body
-
-
-def main():
-    module = AnsibleModule(
-        argument_spec=dict(
-            http_agent=dict(default=USER_AGENT),
-
-            url_username=dict(default="admin", aliases=["username"]),
-            url_password=dict(default="", no_log=True, aliases=["password"]),
-            force_basic_auth=dict(default="yes"),
-            validate_certs=dict(default=False, type='bool'),
-            certificate_authority_data=dict(required=False),
-            insecure=dict(default=False, type='bool'),
-            api_endpoint=dict(required=True),
-            file_reference=dict(required=False),
-            inline_data=dict(required=False),
-            state=dict(default="present", choices=["present", "absent", "update", "replace"])
-        ),
-        mutually_exclusive = (('file_reference', 'inline_data'),
-                              ('url_username', 'insecure'),
-                              ('url_password', 'insecure')),
-        required_one_of = (('file_reference', 'inline_data'),),
-    )
-
-    decode_cert_data(module)
-
-    api_endpoint = module.params.get('api_endpoint')
-    state = module.params.get('state')
-    insecure = module.params.get('insecure')
-    inline_data = module.params.get('inline_data')
-    file_reference = module.params.get('file_reference')
-
-    if inline_data:
-        if not isinstance(inline_data, dict) and not isinstance(inline_data, list):
-            data = yaml.load(inline_data)
-        else:
-            data = inline_data
-    else:
-        try:
-            f = open(file_reference, "r")
-            data = [x for x in yaml.load_all(f)]
-            f.close()
-            if not data:
-                module.fail_json(msg="No valid data could be found.")
-        except:
-            module.fail_json(msg="The file '%s' was not found or contained invalid YAML/JSON data" % file_reference)
-
-    # set the transport type and build the target endpoint url
-    transport = 'https'
-    if insecure:
-        transport = 'http'
-
-    target_endpoint = "%s://%s" % (transport, api_endpoint)
-
-    body = []
-    changed = False
-
-    # make sure the data is a list
-    if not isinstance(data, list):
-        data = [ data ]
-
-    for item in data:
-        namespace = "default"
-        if item and 'metadata' in item:
-            namespace = item.get('metadata', {}).get('namespace', "default")
-            kind = item.get('kind', '').lower()
-            try:
-                url = target_endpoint + KIND_URL[kind]
-            except KeyError:
-                module.fail_json(msg="invalid resource kind specified in the data: '%s'" % kind)
-            url = url.replace("{namespace}", namespace)
-        else:
-            url = target_endpoint
-
-        if state == 'present':
-            item_changed, item_body = k8s_create_resource(module, url, item)
-        elif state == 'absent':
-            item_changed, item_body = k8s_delete_resource(module, url, item)
-        elif state == 'replace':
-            item_changed, item_body = k8s_replace_resource(module, url, item)
-        elif state == 'update':
-            item_changed, item_body = k8s_update_resource(module, url, item)
-
-        changed |= item_changed
-        body.append(item_body)
-
-    module.exit_json(changed=changed, api_response=body)
-
-
-# import module snippets
-from ansible.module_utils.basic import *    # NOQA
-from ansible.module_utils.urls import *     # NOQA
-
-
-if __name__ == '__main__':
-    main()
+#This module is implemented as an action plugin

--- a/clustering/kubernetes.py
+++ b/clustering/kubernetes.py
@@ -83,7 +83,7 @@ EXAMPLES = '''
 # Create a kubernetes namespace from file
 - name: Create a kubernetes namespace from file
   kubernetes:
-    api_endpoint: kube-master.ddops.cool
+    api_endpoint: example.com
     token: redacted
     template: ns.yml
     state: present
@@ -91,7 +91,7 @@ EXAMPLES = '''
 # Create a kubernetes namespace from template
 - name: Create a kubernetes namespace from template
   kubernetes:
-    api_endpoint: kube-master.ddops.cool
+    api_endpoint: example.com
     username: admin
     password: redacted
     template: ns.yml.j2
@@ -102,7 +102,7 @@ EXAMPLES = '''
 # Create a kubernetes namespace from inline
 - name: Create a kubernetes namespace from inline
   kubernetes:
-    api_endpoint: kube-master.ddops.cool
+    api_endpoint: example.com
     token: redacted
     inline:
         kind: Namespace


### PR DESCRIPTION
##### ISSUE TYPE
- New Module Pull Request
##### COMPONENT NAME

kubernetes
##### ANSIBLE VERSION

Tested a slightly tweaked implementation using the below version, but updated to be compatible with devel.

```
ansible 2.0.0.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

Features:
- template files (with variables)
- relative paths (so it can reference ansible directories rather than abs paths)
- token authentication
- removes code that explicitly doesn't work (code clean up)

Almost all of the templating code was copied from the template action plugin. However, that plugin has substantially more code that handles file writing to a remote host, which this plugin doesn't need at all. As a result, I've probably imported more things than I need to. In the future a more generic "grab from file template" action plugin should be written, as this module/plugin doesn't need any special logic beyond what is already offered.

running the examples:

```
> ansible-p  ansible-playbook kubernetes.yml -vvv
No config file found; using defaults
 [WARNING]: provided hosts list is empty, only localhost is available

1 plays in kubernetes.yml

PLAY [Kube ns test] ************************************************************

TASK [testing : Create a kubernetes namespace from file] ***********************
task path: /Users/j2/work/src/github.com/dronedeploy/kube_deploy/roles/testing/tasks/main.yml:3
ok: [localhost] => {"changed": false, "invocation": {"module_args": {"api_endpoint": "redacted", "state": "present", "template": "ns.yml", "token": "redacted"}, "module_name": "kubernetes"}}

TASK [testing : Create a kubernetes namespace from template] *******************
task path: /Users/j2/work/src/github.com/dronedeploy/kube_deploy/roles/testing/tasks/main.yml:10
ok: [localhost] => (item=ansible-test) => {"changed": false, "invocation": {"module_args": {"api_endpoint": "kube-master.ddops.cool", "state": "present", "template": "ns.yml.j2", "token": "redacted"}, "module_name": "kubernetes"}, "item": "ansible-test"}

TASK [testing : Create a kubernetes namespace from inline] *********************
task path: /Users/j2/work/src/github.com/dronedeploy/kube_deploy/roles/testing/tasks/main.yml:19
ok: [localhost] => {"changed": false, "invocation": {"module_args": {"api_endpoint": "redacted", "inline": {"apiVersion": "v1", "kind": "Namespace", "metadata": {"annotations": {"a1": "value1", "a2": "value2"}, "labels": {"label_env": "test", "label_ver": "latest"}, "name": "ansible-test"}}, "state": "present", "token": "redacted"}, "module_name": "kubernetes"}}

TASK [testing : Create a kubernetes namespace from inline with variable] *******
task path: /Users/j2/work/src/github.com/dronedeploy/kube_deploy/roles/testing/tasks/main.yml:36
ok: [localhost] => (item=ansible-test) => {"changed": false, "invocation": {"module_args": {"api_endpoint": "redacted", "inline": {"apiVersion": "v1", "kind": "Namespace", "metadata": {"annotations": {"a1": "value1", "a2": "value2"}, "labels": {"label_env": "test", "label_ver": "latest"}, "name": "ansible-test"}}, "state": "present", "token": "redacted"}, "module_name": "kubernetes"}, "item": "ansible-test"}

PLAY RECAP *********************************************************************
localhost                  : ok=4    changed=0    unreachable=0    failed=0   

```

Note: I couldn't figure out where to put the action plugin code. I don't think this is the right spot for it. Please let me know where it goes and I'll update the PR.
