### PR TITLE
Do not leak root passwd solaris zone

### DIFF
--- a/system/solaris_zone.py
+++ b/system/solaris_zone.py
@@ -417,7 +417,7 @@ def main():
         argument_spec       = dict(
             name            = dict(required=True),
             state           = dict(default='present', choices=['running', 'started', 'present', 'installed', 'stopped', 'absent', 'configured', 'detached', 'attached']),
-            path            = dict(defalt=None),
+            path            = dict(default=None),
             sparse          = dict(default=False, type='bool'),
             root_password   = dict(default=None, no_log=True),
             timeout         = dict(default=600, type='int'),

--- a/system/solaris_zone.py
+++ b/system/solaris_zone.py
@@ -419,7 +419,7 @@ def main():
             state           = dict(default='present', choices=['running', 'started', 'present', 'installed', 'stopped', 'absent', 'configured', 'detached', 'attached']),
             path            = dict(defalt=None),
             sparse          = dict(default=False, type='bool'),
-            root_password   = dict(default=None),
+            root_password   = dict(default=None, no_log=True),
             timeout         = dict(default=600, type='int'),
             config          = dict(default=''),
             create_options  = dict(default=''),


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

solaris_zone
##### SUMMARY

Do set the root password as 'no_log', so this doesn't leak in log, etc. Also fix a small typo in variable name.
