### PR TITLE
Added return code option to documentation

### DIFF
--- a/windows/win_package.py
+++ b/windows/win_package.py
@@ -73,6 +73,8 @@ options:
   expected_return_code:
     description:
       - If the package exits with a different return code than 0, this can be used to set a comma-separated list of allowed return codes.
+    default: null
+    required: false
 '''
 
 EXAMPLES = '''

--- a/windows/win_package.py
+++ b/windows/win_package.py
@@ -71,7 +71,6 @@ options:
     default: null
     required: false
   expected_return_code:
-    version_added: "1.7"
     description:
       - If the package exits with a different return code than 0, this can be used to set a comma-separated list of allowed return codes.
 '''

--- a/windows/win_package.py
+++ b/windows/win_package.py
@@ -71,6 +71,7 @@ options:
     default: null
     required: false
   expected_return_code:
+    version_added: "2.3"
     description:
       - If the package exits with a different return code than 0, this can be used to set a comma-separated list of allowed return codes.
 '''

--- a/windows/win_package.py
+++ b/windows/win_package.py
@@ -70,6 +70,9 @@ options:
       - Password of an account with access to the package if its located on a file share. Only needed if the winrm user doesn't have access to the package. Also specify user_name for this to function properly.
     default: null
     required: false
+  expected_return_code:
+    description:
+      - If the package exits with a different return code than 0, this can be used to set a comma-separated list of allowed return codes.
 '''
 
 EXAMPLES = '''
@@ -91,5 +94,10 @@ EXAMPLES = '''
     path: "https://download.microsoft.com/download/A/F/0/AF0071F3-B198-4A35-AA90-C68D103BDCCF/rdcman.msi"
     product_id: "{0240359E-6A4C-4884-9E94-B397A02D893C}"
     state: absent
+- name: install a package that may return 1301
+  win_package:
+    path: "somepath.exe"
+    product_id: "{0240359E-6A4C-4884-9E94-B397A02D893C}"
+    expected_return_code: "0,1301"
 '''
 

--- a/windows/win_package.py
+++ b/windows/win_package.py
@@ -71,7 +71,7 @@ options:
     default: null
     required: false
   expected_return_code:
-    version_added: "2.3"
+    version_added: "1.7"
     description:
       - If the package exits with a different return code than 0, this can be used to set a comma-separated list of allowed return codes.
 '''


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

win_package
##### ANSIBLE VERSION

```
2.2.0
```
##### SUMMARY

Fixes #3067

In cases where the package returns a different exitcode than 0, the expected_return_code param can be used to specify a comma-separated list of valid return codes. This was already built into the module but not documented (which this PR fixes)
