### PR TITLE
zypper.py: Check if result isn't None and then run the for loop

### DIFF
--- a/packaging/os/zypper.py
+++ b/packaging/os/zypper.py
@@ -267,15 +267,16 @@ def get_cmd(m, subcommand):
 def set_diff(m, retvals, result):
     # TODO: if there is only one package, set before/after to version numbers
     packages = {'installed': [], 'removed': [], 'upgraded': []}
-    for p in result:
-        group = result[p]['group']
-        if group == 'to-upgrade':
-            versions = ' (' + result[p]['oldversion'] + ' => ' + result[p]['version'] + ')'
-            packages['upgraded'].append(p + versions)
-        elif group == 'to-install':
-            packages['installed'].append(p)
-        elif group == 'to-remove':
-            packages['removed'].append(p)
+    if result:
+        for p in result:
+            group = result[p]['group']
+            if group == 'to-upgrade':
+                versions = ' (' + result[p]['oldversion'] + ' => ' + result[p]['version'] + ')'
+                packages['upgraded'].append(p + versions)
+            elif group == 'to-install':
+                packages['installed'].append(p)
+            elif group == 'to-remove':
+                packages['removed'].append(p)
 
     output = ''
     for state in packages:


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

zypper.py
##### ANSIBLE VERSION

```
ansible 2.3.0 (devel 6be09ee866) last updated 2016/10/12 09:49:08 (GMT +200)
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

The return variable is None when no changes are made, but the for loop in set_diff doesn't verify this.

Fixes #3142 

Before:

```
srv1| FAILED! => {
    "changed": false,
    "failed": true,
    "module_stderr": "Shared connection to srv1 closed.\r\n",
    "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_z_2rNm/ansible_module_zypper.py\", line 449, in <module>\r\n    main()\r\n  File \"/tmp/ansible_z_2rNm/ansible_module_zypper.py\", line 434, in main\r\n    set_diff(module, retvals, packages_changed)\r\n  File \"/tmp/ansible_z_2rNm/ansible_module_zypper.py\", line 269, in set_diff\r\n    for p in result:\r\nTypeError: 'NoneType' object is not iterable\r\n",
    "msg": "MODULE FAILURE"
}
```

After:

```

srv1 | SUCCESS => {
    "changed": null,
    "name": [
        "w3m"
    ],
    "rc": 0,
    "state": "absent",
    "update_cache": false
}

```
