### PR TITLE
Fixes broken documentation in two modules

### DIFF
--- a/network/f5/bigip_device_sshd.py
+++ b/network/f5/bigip_device_sshd.py
@@ -118,12 +118,12 @@ EXAMPLES = '''
 
 RETURN = '''
 allow:
-    description: |
+    description: >
         Specifies, if you have enabled SSH access, the IP address or address
         range for other systems that can use SSH to communicate with this
         system.
     returned: changed
-    type: list
+    type: string
     sample: "192.0.2.*"
 banner:
     description: Whether the banner is enabled or not.
@@ -131,14 +131,14 @@ banner:
     type: string
     sample: "true"
 banner_text:
-    description: |
+    description: >
         Specifies the text included on the pre-login banner that
         displays when a user attempts to login to the system using SSH.
     returned: changed and success
     type: string
     sample: "This is a corporate device. Connecting to it without..."
 inactivity_timeout:
-    description: |
+    description: >
         The number of seconds before inactivity causes an SSH.
         session to log out
     returned: changed

--- a/network/f5/bigip_routedomain.py
+++ b/network/f5/bigip_routedomain.py
@@ -46,12 +46,13 @@ options:
       - The unique identifying integer representing the route domain.
     required: true
   parent:
-    description: |
+    description:
       Specifies the route domain the system searches when it cannot
       find a route in the configured domain.
+    required: false
   routing_protocol:
     description:
-      -  Dynamic routing protocols for the system to use in the route domain.
+      - Dynamic routing protocols for the system to use in the route domain.
     choices:
       - BFD
       - BGP


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Docs Pull Request
##### COMPONENT NAME

network/f5/bigip_device_sshd
network/f5/bigip_routedomain
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides

```
##### SUMMARY

The modules listed in this PR were using YAML that resulted in
blockquote tages being inserted into the generated RestructedText.

This PR fixes that so that the documentation once again looks correct

If possible, this should be cherry-picked back to 2.2.0 before release
