### PR TITLE
blockinfile: Add a newline at EOF when the file is newly created

### DIFF
--- a/files/blockinfile.py
+++ b/files/blockinfile.py
@@ -285,7 +285,7 @@ def main():
 
     if lines:
         result = '\n'.join(lines)
-        if original and original.endswith('\n'):
+        if original is None or original.endswith('\n'):
             result += '\n'
     else:
         result = ''


### PR DESCRIPTION
##### ISSUE TYPE

 Bugfix Pull Request
##### COMPONENT NAME

blockinfile
##### ANSIBLE VERSION

devel
##### SUMMARY

With `create: yes`, blockinfile creates a file without a newline at EOF, which is commonly unexpected as reported in #2687.  This PR fixes that behavior.

For newly created dest files, it puts a newline at EOF:

```
$ rm -f otuput.txt
$ ansible localhost, -m blockinfile -a 'dest=output.txt marker={mark} block=X create=yes'
 [WARNING]: provided hosts list is empty, only localhost is available

localhost | SUCCESS => {
    "changed": true, 
    "msg": "File created"
}
$ hexdump -C output.txt 
00000000  42 45 47 49 4e 0a 58 0a  45 4e 44 0a              |BEGIN.X.END.|
0000000c
```

For existing dest files, it preserves newline existence at EOF:

```
$ >output.txt 
$ ansible localhost, -m blockinfile -a 'dest=output.txt marker={mark} block=X create=yes'
 [WARNING]: provided hosts list is empty, only localhost is available

localhost | SUCCESS => {
    "changed": true, 
    "msg": "Block inserted"
}
$ hexdump -C output.txt 
00000000  42 45 47 49 4e 0a 58 0a  45 4e 44                 |BEGIN.X.END|
0000000b
```
