### PR TITLE
Make irules module idempotent

### DIFF
--- a/network/f5/bigip_irule.py
+++ b/network/f5/bigip_irule.py
@@ -202,7 +202,7 @@ class BigIpiRule(object):
             )
 
         if hasattr(r, 'apiAnonymous'):
-            p['content'] = str(r.apiAnonymous)
+            p['content'] = str(r.apiAnonymous.strip())
         p['name'] = name
         return p
 
@@ -246,14 +246,10 @@ class BigIpiRule(object):
             )
 
     def present(self):
-        changed = False
-
         if self.exists():
-            changed = self.update()
+            return self.update()
         else:
-            changed = self.create()
-
-        return changed
+            return self.create()
 
     def update(self):
         params = dict()
@@ -267,6 +263,7 @@ class BigIpiRule(object):
         module = self.params['module']
 
         if content is not None:
+            content = content.strip()
             if 'content' in current:
                 if content != current['content']:
                     params['apiAnonymous'] = content
@@ -318,7 +315,7 @@ class BigIpiRule(object):
             return True
 
         if content is not None:
-            params['apiAnonymous'] = content
+            params['apiAnonymous'] = content.strip()
 
         params['name'] = name
         params['partition'] = partition


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

network/f5/bigip_irule.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```
##### SUMMARY

The irules module was failing to strip whitespace that is, for some
reason, automatically inserted by BIG-IP. This patch adds necessary
strips
