### PR TITLE
Port ovirt to python 3

### DIFF
--- a/cloud/misc/ovirt.py
+++ b/cloud/misc/ovirt.py
@@ -461,7 +461,7 @@ def main():
     #initialize connection
     try:
         c = conn(url+"/api", user, password)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg='%s' % e)
 
     if state == 'present':
@@ -469,14 +469,14 @@ def main():
             if resource_type == 'template':
                 try:
                     create_vm_template(c, vmname, image, zone)
-                except Exception, e:
+                except Exception as e:
                     module.fail_json(msg='%s' % e)
                 module.exit_json(changed=True, msg="deployed VM %s from template %s"  % (vmname,image))
             elif resource_type == 'new':
                 # FIXME: refactor, use keyword args.
                 try:
                     create_vm(c, vmtype, vmname, zone, vmdisk_size, vmcpus, vmnic, vmnetwork, vmmem, vmdisk_alloc, sdomain, vmcores, vmos, vmdisk_int)
-                except Exception, e:
+                except Exception as e:
                     module.fail_json(msg='%s' % e)
                 module.exit_json(changed=True, msg="deployed VM %s from scratch"  % vmname)
             else:

--- a/test/utils/shippable/sanity-skip-python3.txt
+++ b/test/utils/shippable/sanity-skip-python3.txt
@@ -33,7 +33,6 @@
 /cloud/centurylink/clc_publicip.py
 /cloud/google/gce_img.py
 /cloud/google/gce_tag.py
-/cloud/misc/ovirt.py
 /cloud/misc/proxmox.py
 /cloud/misc/proxmox_template.py
 /cloud/misc/virt_net.py


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

ovirt
##### SUMMARY

Since ovirt sdk is not running on python 2.4, we can use python 2.6
syntax directly for exceptions.
