### PR TITLE
Make xenserver_facts compile on python 3

### DIFF
--- a/cloud/xenserver_facts.py
+++ b/cloud/xenserver_facts.py
@@ -170,7 +170,7 @@ def main():
     obj = XenServerFacts()
     try:
         session = get_xenapi_session()
-    except XenAPI.Failure, e:
+    except XenAPI.Failure as e:
         module.fail_json(msg='%s' % e)
 
     data = {

--- a/test/utils/shippable/sanity-skip-python3.txt
+++ b/test/utils/shippable/sanity-skip-python3.txt
@@ -41,7 +41,6 @@
 /cloud/profitbricks/profitbricks.py
 /cloud/profitbricks/profitbricks_volume.py
 /cloud/rackspace/rax_clb_ssl.py
-/cloud/xenserver_facts.py
 /clustering/consul.py
 /clustering/consul_acl.py
 /clustering/consul_kv.py


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

xenserver_facts
##### SUMMARY

Since the xenapi is not needed on python 2.4, we can use the
regular exception handling code
