### PR TITLE
Remove gce from the blacklist for python 3 tests, forgot in #3179

### DIFF
--- a/test/utils/shippable/sanity-skip-python3.txt
+++ b/test/utils/shippable/sanity-skip-python3.txt
@@ -31,8 +31,6 @@
 /cloud/centurylink/clc_aa_policy.py
 /cloud/centurylink/clc_group.py
 /cloud/centurylink/clc_publicip.py
-/cloud/google/gce_img.py
-/cloud/google/gce_tag.py
 /cloud/misc/proxmox.py
 /cloud/misc/proxmox_template.py
 /cloud/misc/virt_net.py


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

gce 
