### PR TITLE
Make zabbix modules compile on python 3

### DIFF
--- a/monitoring/zabbix_group.py
+++ b/monitoring/zabbix_group.py
@@ -136,7 +136,7 @@ class HostGroup(object):
                     except Already_Exists:
                         return group_add_list
             return group_add_list
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to create host group(s): %s" % e)
 
     # delete host group(s)
@@ -145,7 +145,7 @@ class HostGroup(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.hostgroup.delete(group_ids)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to delete host group(s), Exception: %s" % e)
 
     # get group ids by name
@@ -192,7 +192,7 @@ def main():
     try:
         zbx = ZabbixAPI(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
     hostGroup = HostGroup(module, zbx)

--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -216,7 +216,7 @@ class Host(object):
             host_list = self._zapi.host.create(parameters)
             if len(host_list) >= 1:
                 return host_list['hostids'][0]
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to create host %s: %s" % (host_name, e))
 
     def update_host(self, host_name, group_ids, status, host_id, interfaces, exist_interface_list, proxy_id):
@@ -253,7 +253,7 @@ class Host(object):
                     remove_interface_ids.append(interface_id)
                 if len(remove_interface_ids) > 0:
                     self._zapi.hostinterface.delete(remove_interface_ids)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to update host %s: %s" % (host_name, e))
 
     def delete_host(self, host_id, host_name):
@@ -261,7 +261,7 @@ class Host(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.host.delete([host_id])
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to delete host %s: %s" % (host_name, e))
 
     # get host by host name
@@ -385,7 +385,7 @@ class Host(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.host.update(request_str)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to link template to host: %s" % e)
 
     # Update the host inventory_mode
@@ -408,7 +408,7 @@ class Host(object):
             if self._module.check_mode:
                 self._module.exit_json(changed=True)
             self._zapi.host.update(request_str)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to set inventory_mode to host: %s" % e)
 
 def main():
@@ -460,7 +460,7 @@ def main():
     try:
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
     host = Host(module, zbx)

--- a/monitoring/zabbix_hostmacro.py
+++ b/monitoring/zabbix_hostmacro.py
@@ -129,7 +129,7 @@ class HostMacro(object):
             else:
                 host_id = host_list[0]['hostid']
                 return host_id
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to get the host %s id: %s." % (host_name, e))
 
     # get host macro
@@ -140,7 +140,7 @@ class HostMacro(object):
             if len(host_macro_list) > 0:
                 return host_macro_list[0]
             return None
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to get host macro %s: %s" % (macro_name, e))
 
     # create host macro
@@ -150,7 +150,7 @@ class HostMacro(object):
                 self._module.exit_json(changed=True)
             self._zapi.usermacro.create({'hostid': host_id, 'macro': '{$' + macro_name + '}', 'value': macro_value})
             self._module.exit_json(changed=True, result="Successfully added host macro %s " % macro_name)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to create host macro %s: %s" % (macro_name, e))
 
     # update host macro
@@ -163,7 +163,7 @@ class HostMacro(object):
                 self._module.exit_json(changed=True)
             self._zapi.usermacro.update({'hostmacroid': host_macro_id, 'value': macro_value})
             self._module.exit_json(changed=True, result="Successfully updated host macro %s " % macro_name)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to updated host macro %s: %s" % (macro_name, e))
 
     # delete host macro
@@ -174,7 +174,7 @@ class HostMacro(object):
                 self._module.exit_json(changed=True)
             self._zapi.usermacro.delete([host_macro_id])
             self._module.exit_json(changed=True, result="Successfully deleted host macro %s " % macro_name)
-        except Exception, e:
+        except Exception as e:
             self._module.fail_json(msg="Failed to delete host macro %s: %s" % (macro_name, e))
 
 def main():
@@ -213,7 +213,7 @@ def main():
     try:
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
     host_macro_class_obj = HostMacro(module, zbx)

--- a/monitoring/zabbix_screen.py
+++ b/monitoring/zabbix_screen.py
@@ -354,7 +354,7 @@ def main():
     try:
         zbx = ZabbixAPIExtends(server_url, timeout=timeout, user=http_login_user, passwd=http_login_password)
         zbx.login(login_user, login_password)
-    except Exception, e:
+    except Exception as e:
         module.fail_json(msg="Failed to connect to Zabbix server: %s" % e)
 
     screen = Screen(module, zbx)

--- a/test/utils/shippable/sanity-skip-python3.txt
+++ b/test/utils/shippable/sanity-skip-python3.txt
@@ -56,10 +56,6 @@
 /monitoring/datadog_monitor.py
 /monitoring/rollbar_deployment.py
 /monitoring/stackdriver.py
-/monitoring/zabbix_group.py
-/monitoring/zabbix_host.py
-/monitoring/zabbix_hostmacro.py
-/monitoring/zabbix_screen.py
 /network/citrix/netscaler.py
 /network/cloudflare_dns.py
 /network/dnsimple.py


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

zabbix*
##### SUMMARY

Since the module is not compatible with python 2.4, we
do not need to use the get_exception trick
