### PR TITLE
Fix days_of_week var command typo

### DIFF
--- a/windows/win_scheduled_task.ps1
+++ b/windows/win_scheduled_task.ps1
@@ -24,7 +24,7 @@ $ErrorActionPreference = "Stop"
 
 $params = Parse-Args $args;
 
-$days_of_week = Get-AnsibleParam $params -anem "days_of_week"
+$days_of_week = Get-AnsibleParam $params -name "days_of_week"
 $enabled = Get-AnsibleParam $params -name "enabled" -default $true
 $enabled = $enabled | ConvertTo-Bool
 $description = Get-AnsibleParam $params -name "description" -default " "


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

module: win_scheduled_task
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
bug also in devel
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

Module fails when frequency=weekly due to typo in module.
Changed "-anem" to "-name".

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

before:

```
fatal: [x.x.x.x]: FAILED! => {"changed": false, "failed": true, "msg": "missing required argument: days_of_week"}
```

after:

```
changed: [x.x.x.x]
```
