### PR TITLE
Correction for spelling of 'azure_rm_deployment' in example

### DIFF
--- a/cloud/azure/azure_rm_deployment.py
+++ b/cloud/azure/azure_rm_deployment.py
@@ -190,7 +190,7 @@ EXAMPLES = '''
 
 # Create or update a template deployment based on an inline template and parameters
 - name: Create Azure Deploy
-  azure_rm_deploy:
+  azure_rm_deployment:
     state: present
     subscription_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     resource_group_name: dev-ops-cle


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

azure_rm_deployment
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides

```
##### SUMMARY

Documentation fix to allow example to work
