### PR TITLE
Adding dc to consul_kv

### DIFF
--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -84,6 +84,11 @@ options:
             the ModifyIndex of that key.
         required: false
         default: None
+    dc:
+        description:
+          - used to connect to a specific consul datacenter
+        required: false
+        default: None
     flags:
         description:
           - opaque integer value that can be passed when setting a value.
@@ -242,6 +247,7 @@ def remove_value(module):
 
 def get_consul_api(module, token=None):
     return consul.Consul(host=module.params.get('host'),
+                         dc=module.params.get('dc'),
                          port=module.params.get('port'),
                          scheme=module.params.get('scheme'),
                          verify=module.params.get('validate_certs'),
@@ -259,6 +265,7 @@ def main():
         flags=dict(required=False),
         key=dict(required=True),
         host=dict(default='localhost'),
+        dc=dict(required=False),
         scheme=dict(required=False, default='http'),
         validate_certs=dict(required=False, default=True),
         port=dict(default=8500, type='int'),


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

consul_kv
##### ANSIBLE VERSION

```
ansible 2.1.2.0
  config file =
  configured module search path = Default w/o overrides
```
##### SUMMARY

Consul supports having multiple data centers.  The Python Consul class takes the datacenter (dc) as a parameter but the consul_kv module does not support this property.    I simply added "dc" as a property that gets passed through to the Python Consul class.

I am unsure what command output you are looking for.
