### PR TITLE
Make nmcli pass py3 sanity check

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -395,6 +395,9 @@ try:
 except ImportError:
     pass
 
+from ansible.module_utils.basic import AnsibleModule
+
+
 class Nmcli(object):
     """
     This is the generic nmcli manipulation class that is subclassed based on platform.
@@ -490,7 +493,7 @@ class Nmcli(object):
             for setting in secrets:
                 for key in secrets[setting]:
                     config[setting_name][key]=secrets[setting][key]
-        except Exception, e:
+        except Exception as e:
             pass
 
     def dict_to_string(self, d):
@@ -1079,8 +1082,5 @@ def main():
         result['stderr']=err
 
     module.exit_json(**result)
-
-# import module snippets
-from ansible.module_utils.basic import *
 
 main()

--- a/test/utils/shippable/sanity-skip-python24.txt
+++ b/test/utils/shippable/sanity-skip-python24.txt
@@ -13,3 +13,4 @@
 /univention/
 /web_infrastructure/letsencrypt.py
 /infrastructure/foreman/
+/network/nmcli.py

--- a/test/utils/shippable/sanity-skip-python3.txt
+++ b/test/utils/shippable/sanity-skip-python3.txt
@@ -50,4 +50,3 @@
 /network/cloudflare_dns.py
 /network/f5/bigip_gtm_virtual_server.py
 /network/f5/bigip_gtm_wide_ip.py
-/network/nmcli.py


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

nmcli
##### SUMMARY

Cleanup include, do not use '*' for future refactoring.

Since nmcli is not present on EL5, we can safely use python
2.6 syntax only.
