### PR TITLE
Update to Create-example in docs

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -111,12 +111,12 @@ options:
 '''
 
 EXAMPLES = '''
-# Create a metric monitor
+# Create a service check monitor
 datadog_monitor:
-  type: "metric alert"
+  type: "service check"
   name: "Test monitor"
   state: "present"
-  query: "datadog.agent.up".over("host:host1").last(2).count_by_status()"
+  query: "'datadog.agent.up'.over('host:host1').last(2).count_by_status()"
   message: "Host [[host.name]] with IP [[host.ip]] is failing to report to datadog."
   api_key: "9775a026f1ca7d1c6c5af9d94d9595a4"
   app_key: "87ce4a24b5553d2e482ea8a8500e71b8ad4554ff"


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

 monitoring/datadog_monitor.py
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.1.0
```
##### SUMMARY

I realized that the example in the documentation was of the type "service check" rather than a "metric alert" when I was trying to create and run a task based on it. And I found that the quotes in the current query example was unbalanced. 

So balanced the quotes and changed the type of the example.
