### PR TITLE
Remove reference to ansible-validate-modules

### DIFF
--- a/GUIDELINES.md
+++ b/GUIDELINES.md
@@ -64,7 +64,6 @@ If you'd like to step down as a maintainer, please submit a PR to the maintainer
 
 ## Useful tools
 * https://ansible.sivel.net/pr/byfile.html -- a full list of all open Pull Requests, organized by file. 
-* https://github.com/sivel/ansible-testing -- these are the tests that run on Shippable against all PRs for extras modules, so it's a good idea to run these tests locally first.
 
 ## Other Resources
 


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Feature Pull Request
- New Module Pull Request
- Bugfix Pull Request
- Docs Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```

```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```

```

ansible-validate-modules is now in ansible/ansible

During 2.3 we will be merge the modules into ansible/ansible so this file will go away.

The new testing documentation will refer to `ansible-test` which will wrap up the unit, integration, and ansible-validate-modules. So no need to document here.
