### PR TITLE
Fix pkgng on python 3

### DIFF
--- a/packaging/os/pkgng.py
+++ b/packaging/os/pkgng.py
@@ -114,7 +114,7 @@ def query_package(module, pkgng_path, name, dir_arg):
 def pkgng_older_than(module, pkgng_path, compare_version):
 
     rc, out, err = module.run_command("%s -v" % pkgng_path)
-    version = map(lambda x: int(x), re.split(r'[\._]', out))
+    version = [int(x) for x in re.split(r'[\._]', out)]
 
     i = 0
     new_pkgng = True


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

pkgng 
##### SUMMARY

Fail with:

```
Traceback (most recent call last):
  File \"/tmp/ansible_2rsl4fg1/ansible_module_pkgng.py\", line 353, in <module>
    main()
  File \"/tmp/ansible_2rsl4fg1/ansible_module_pkgng.py\", line 330, in main
    _changed, _msg = install_packages(module, pkgng_path, pkgs, p[\"cached\"], p[\"pkgsite\"], dir_arg)
  File \"/tmp/ansible_2rsl4fg1/ansible_module_pkgng.py\", line 161, in install_packages
    old_pkgng = pkgng_older_than(module, pkgng_path, [1, 1, 4])
  File \"/tmp/ansible_2rsl4fg1/ansible_module_pkgng.py\", line 121, in pkgng_older_than
    while compare_version[i] == version[i]:
TypeError: 'map' object is not subscriptable
```
