### PR TITLE
a10 - Use docs_fragments

### DIFF
--- a/network/a10/a10_server.py
+++ b/network/a10/a10_server.py
@@ -29,37 +29,22 @@ short_description: Manage A10 Networks AX/SoftAX/Thunder/vThunder devices
 description:
     - Manage slb server objects on A10 Networks devices via aXAPI
 author: "Mischa Peters (@mischapeters)"
-notes:
-    - Requires A10 Networks aXAPI 2.1
+extends_documentation_fragment: a10
 options:
-  host:
-    description:
-      - hostname or ip of your A10 Networks device
-    required: true
-  username:
-    description:
-      - admin account of your A10 Networks device
-    required: true
-    aliases: ['user', 'admin']
-  password:
-    description:
-      - admin password of your A10 Networks device
-    required: true
-    aliases: ['pass', 'pwd']
   server_name:
     description:
-      - slb server name
+      - SLB server name.
     required: true
     aliases: ['server']
   server_ip:
     description:
-      - slb server IP address
+      - SLB server IP address.
     required: false
     default: null
     aliases: ['ip', 'address']
   server_status:
     description:
-      - slb virtual server status
+      - SLB virtual server status.
     required: false
     default: enabled
     aliases: ['status']
@@ -74,28 +59,10 @@ options:
     default: null
   state:
     description:
-      - create, update or remove slb server
+      - Create, update or remove slb server.
     required: false
     default: present
     choices: ['present', 'absent']
-  write_config:
-    description:
-      - If C(yes), any changes will cause a write of the running configuration
-        to non-volatile memory. This will save I(all) configuration changes,
-        including those that may have been made manually or through other modules,
-        so care should be taken when specifying C(yes).
-    required: false
-    version_added: 2.2
-    default: "no"
-    choices: ["yes", "no"]
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled devices using self-signed certificates.
-    required: false
-    version_added: 2.2
-    default: 'yes'
-    choices: ['yes', 'no']
 
 '''
 

--- a/network/a10/a10_service_group.py
+++ b/network/a10/a10_service_group.py
@@ -30,47 +30,25 @@ description:
     - Manage slb service-group objects on A10 Networks devices via aXAPI
 author: "Mischa Peters (@mischapeters)"
 notes:
-    - Requires A10 Networks aXAPI 2.1
     - When a server doesn't exist and is added to the service-group the server will be created
+extends_documentation_fragment: a10
 options:
-  host:
-    description:
-      - hostname or ip of your A10 Networks device
-    required: true
-    default: null
-    aliases: []
-    choices: []
-  username:
-    description:
-      - admin account of your A10 Networks device
-    required: true
-    default: null
-    aliases: ['user', 'admin']
-    choices: []
-  password:
-    description:
-      - admin password of your A10 Networks device
-    required: true
-    default: null
-    aliases: ['pass', 'pwd']
-    choices: []
   service_group:
     description:
-      - slb service-group name
+      - SLB service-group name.
     required: true
     default: null
     aliases: ['service', 'pool', 'group']
-    choices: []
   service_group_protocol:
     description:
-      - slb service-group protocol
+      - SLB service-group protocol.
     required: false
     default: tcp
     aliases: ['proto', 'protocol']
     choices: ['tcp', 'udp']
   service_group_method:
     description:
-      - slb service-group loadbalancing method
+      - SLB service-group loadbalancing method.
     required: false
     default: round-robin
     aliases: ['method']
@@ -82,24 +60,6 @@ options:
         specify the C(status:). See the examples below for details.
     required: false
     default: null
-    aliases: []
-    choices: []
-  write_config:
-    description:
-      - If C(yes), any changes will cause a write of the running configuration
-        to non-volatile memory. This will save I(all) configuration changes,
-        including those that may have been made manually or through other modules,
-        so care should be taken when specifying C(yes).
-    required: false
-    default: "no"
-    choices: ["yes", "no"]
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled devices using self-signed certificates.
-    required: false
-    default: 'yes'
-    choices: ['yes', 'no']
 
 '''
 

--- a/network/a10/a10_virtual_server.py
+++ b/network/a10/a10_virtual_server.py
@@ -29,48 +29,23 @@ short_description: Manage A10 Networks devices' virtual servers
 description:
     - Manage slb virtual server objects on A10 Networks devices via aXAPI
 author: "Mischa Peters (@mischapeters)"
-notes:
-    - Requires A10 Networks aXAPI 2.1
-requirements: []
+extends_documentation_fragment: a10
 options:
-  host:
-    description:
-      - hostname or ip of your A10 Networks device
-    required: true
-    default: null
-    aliases: []
-    choices: []
-  username:
-    description:
-      - admin account of your A10 Networks device
-    required: true
-    default: null
-    aliases: ['user', 'admin']
-    choices: []
-  password:
-    description:
-      - admin password of your A10 Networks device
-    required: true
-    default: null
-    aliases: ['pass', 'pwd']
-    choices: []
   virtual_server:
     description:
-      - slb virtual server name
+      - SLB virtual server name.
     required: true
     default: null
     aliases: ['vip', 'virtual']
-    choices: []
   virtual_server_ip:
     description:
-      - slb virtual server ip address
+      - SLB virtual server IP address.
     required: false
     default: null
     aliases: ['ip', 'address']
-    choices: []
   virtual_server_status:
     description:
-      - slb virtual server status
+      - SLB virtual server status.
     required: false
     default: enable
     aliases: ['status']
@@ -82,22 +57,6 @@ options:
         specify the C(service_group:) as well as the C(status:). See the examples
         below for details. This parameter is required when C(state) is C(present).
     required: false
-  write_config:
-    description:
-      - If C(yes), any changes will cause a write of the running configuration
-        to non-volatile memory. This will save I(all) configuration changes,
-        including those that may have been made manually or through other modules,
-        so care should be taken when specifying C(yes).
-    required: false
-    default: "no"
-    choices: ["yes", "no"]
-  validate_certs:
-    description:
-      - If C(no), SSL certificates will not be validated. This should only be used
-        on personally controlled devices using self-signed certificates.
-    required: false
-    default: 'yes'
-    choices: ['yes', 'no']
 
 '''
 


### PR DESCRIPTION
##### ISSUE TYPE
- Docs Pull Request
##### COMPONENT NAME

a10_*
##### ANSIBLE VERSION

```
ansible-playbook 2.3.0 (a10_docs_fragment b1bd63c2ca) last updated 2016/10/24 12:53:57 (GMT +100)
  lib/ansible/modules/core:  not found - use git submodule update --init lib/ansible/modules/core
  lib/ansible/modules/extras: (devel 6b0a204e74) last updated 2016/10/24 11:43:03 (GMT +100)
```
##### SUMMARY

Remove duplicated documentation (common options defined in module_utils/a10.py).
Also tidy up formatting.

Fill fail CI till `module_docs_fragments/a10.py` is updated, see https://github.com/ansible/ansible/pull/18163

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ansible/ansible-modules-extras/3281)

<!-- Reviewable:end -->
