### PR TITLE
Add support to the `make` module for targets with options

### DIFF
--- a/system/make.py
+++ b/system/make.py
@@ -59,6 +59,11 @@ EXAMPLES = '''
     params:
       NUM_THREADS: 4
       BACKEND: lapack
+
+# Skip building a file as part of a target
+- make:
+    chdir: /home/ubuntu/cool-project
+    target: 'all -o somefile'
 '''
 
 # TODO: Disabled the RETURN as it was breaking docs building. Someone needs to
@@ -106,13 +111,14 @@ def main():
     )
     # Build up the invocation of `make` we are going to use
     make_path = module.get_bin_path('make', True)
-    make_target = module.params['target']
+    make_target = module.params['target'].split()
     if module.params['params'] is not None:
         make_parameters = [k + '=' + str(v) for k, v in module.params['params'].iteritems()]
     else:
         make_parameters = []
 
-    base_command = [make_path, make_target]
+    base_command = [make_path]
+    base_command.extend(make_target)
     base_command.extend(make_parameters)
 
     # Check if the target is already up to date


### PR DESCRIPTION
##### ISSUE TYPE
- Feature Pull Request
##### COMPONENT NAME

`make`
##### ANSIBLE VERSION

```
$ ansible --version
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

In order to run a `make` target with options, we need to not
assume that the target that is passed in to the module is to
be interpreted as one command-line argument. This allows us
to support targets with options like:
  $ make some-target -o some-file

Where the `some-target` target skips rebuilding `some-file`
even if the file is old. Currently, the implementation would
attempt to run the `some-target -o some-file` target, which
does not exist.

`make` does not allow for targets with spaces in their names,
so we should be safe to break up the command-line arguments
like this and not risk mutilating a valid target name.

Signed-off-by: Steve Kuznetsov skuznets@redhat.com
###### BEFORE

```
TASK [make : execute make target(s) "test -o build" in the origin-web-console repository] ***
failed: [openshiftdevel] (item=test -o build) => {
    "cmd": "/bin/make 'test -o build'", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "chdir": "/data/src/github.com/openshift/origin-web-console", 
            "params": null, 
            "target": "test -o build"
        }, 
        "module_name": "make"
    }, 
    "item": "test -o build", 
    "msg": "make: *** No rule to make target 'test -o build'.  Stop.", 
    "rc": 2, 
    "stderr": "make: *** No rule to make target 'test -o build'.  Stop.\n", 
    "stdout": "", 
    "stdout_lines": []
}
```
###### AFTER

```
TASK [make : execute make target(s) "test -o build" in the origin-web-console repository] ***
failed: [openshiftdevel] (item=test -o build) => {
    "cmd": "/bin/make test -o build", 
    "failed": true, 
    "invocation": {
        "module_args": {
            "chdir": "/data/src/github.com/openshift/origin-web-console", 
            "params": null, 
            "target": "test -o build"
        }, 
        "module_name": "make"
    }, 
    "item": "test -o build", 
    "msg": "<snip>make: *** [test] Error 3", 
    "rc": 2, 
    "stderr": "<snip>make: *** [test] Error 3\n", 
    "stdout": "<snip>Makefile:45: recipe for target 'test' failed\n", 
    "stdout_lines": [
        <snip>
        "Makefile:45: recipe for target 'test' failed"
    ]
}
```

(example after has a failed `make` target, but it runs correctly, just that example failed in the middle of the run)

@LinusU @gregdek 
