### PR TITLE
gcdataproc module PR: Interact with Google Dataproc API

### DIFF
--- a/cloud/google/gcdataproc.py
+++ b/cloud/google/gcdataproc.py
@@ -1,0 +1,392 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2016 Cambridge Semantics Inc.
+#
+# This file is part of Ansible.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+DOCUMENTATION = '''
+---
+module: gcdataproc
+short_description: Module for Google Cloud Dataproc clusters.
+description:
+  - Creates or destroys Google Cloud Dataproc clusters on Google Cloud.
+version_added: "2.3"
+author: "John Baublitz @jbaublitz"
+requirements:
+  - "python >= 2.6"
+  - "google-api-python-client >= 1.5.4"
+  - "oauth2client >= 3.0.0"
+options:
+notes:
+'''
+
+EXAMPLES = '''
+# Create an A record.
+- gcdns_record:
+    record: 'www1.example.com'
+    zone: 'example.com'
+    type: A
+    value: '1.2.3.4'
+
+# Update an existing record.
+- gcdns_record:
+    record: 'www1.example.com'
+    zone: 'example.com'
+    type: A
+    overwrite: true
+    value: '5.6.7.8'
+
+# Remove an A record.
+- gcdns_record:
+    record: 'www1.example.com'
+    zone_id: 'example-com'
+    state: absent
+    type: A
+    value: '5.6.7.8'
+
+# Create a CNAME record.
+- gcdns_record:
+    record: 'www.example.com'
+    zone_id: 'example-com'
+    type: CNAME
+    value: 'www.example.com.'    # Note the trailing dot
+
+# Create an MX record with a custom TTL.
+- gcdns_record:
+    record: 'example.com'
+    zone: 'example.com'
+    type: MX
+    ttl: 3600
+    value: '10 mail.example.com.'    # Note the trailing dot
+
+# Create multiple A records with the same name.
+- gcdns_record:
+    record: 'api.example.com'
+    zone_id: 'example-com'
+    type: A
+    record_data:
+      - '192.0.2.23'
+      - '10.4.5.6'
+      - '198.51.100.5'
+      - '203.0.113.10'
+
+# Change the value of an existing record with multiple record_data.
+- gcdns_record:
+    record: 'api.example.com'
+    zone: 'example.com'
+    type: A
+    overwrite: true
+    record_data:           # WARNING: All values in a record will be replaced
+      - '192.0.2.23'
+      - '192.0.2.42'    # The changed record
+      - '198.51.100.5'
+      - '203.0.113.10'
+
+# Safely remove a multi-line record.
+- gcdns_record:
+    record: 'api.example.com'
+    zone_id: 'example-com'
+    state: absent
+    type: A
+    record_data:           # NOTE: All of the values must match exactly
+      - '192.0.2.23'
+      - '192.0.2.42'
+      - '198.51.100.5'
+      - '203.0.113.10'
+
+# Unconditionally remove a record.
+- gcdns_record:
+    record: 'api.example.com'
+    zone_id: 'example-com'
+    state: absent
+    overwrite: true   # overwrite is true, so no values are needed
+    type: A
+
+# Create an AAAA record
+- gcdns_record:
+    record: 'www1.example.com'
+    zone: 'example.com'
+    type: AAAA
+    value: 'fd00:db8::1'
+
+# Create a PTR record
+- gcdns_record:
+    record: '10.5.168.192.in-addr.arpa'
+    zone: '5.168.192.in-addr.arpa'
+    type: PTR
+    value: 'api.example.com.'    # Note the trailing dot.
+
+# Create an NS record
+- gcdns_record:
+    record: 'subdomain.example.com'
+    zone: 'example.com'
+    type: NS
+    ttl: 21600
+    record_data:
+      - 'ns-cloud-d1.googledomains.com.'    # Note the trailing dots on values
+      - 'ns-cloud-d2.googledomains.com.'
+      - 'ns-cloud-d3.googledomains.com.'
+      - 'ns-cloud-d4.googledomains.com.'
+
+# Create a TXT record
+- gcdns_record:
+    record: 'example.com'
+    zone_id: 'example-com'
+    type: TXT
+    record_data:
+      - '"v=spf1 include:_spf.google.com -all"'   # A single-string TXT value
+      - '"hello " "world"'    # A multi-string TXT value
+'''
+
+RETURN = '''
+overwrite:
+    description: Whether to the module was allowed to overwrite the record
+    returned: success
+    type: boolean
+    sample: True
+record:
+    description: Fully-qualified domain name of the resource record
+    returned: success
+    type: string
+    sample: mail.example.com.
+state:
+    description: Whether the record is present or absent
+    returned: success
+    type: string
+    sample: present
+ttl:
+    description: The time-to-live of the resource record
+    returned: success
+    type: int
+    sample: 300
+type:
+    description: The type of the resource record
+    returned: success
+    type: string
+    sample: A
+record_data:
+    description: The resource record values
+    returned: success
+    type: list
+    sample: ['5.6.7.8', '9.10.11.12']
+zone:
+    description: The dns name of the zone
+    returned: success
+    type: string
+    sample: example.com.
+zone_id:
+    description: The Google Cloud DNS ID of the zone
+    returned: success
+    type: string
+    sample: example-com
+'''
+
+import os
+import time
+
+try:
+    from oauth2client.service_account import ServiceAccountCredentials
+    from apiclient.discovery import build
+    from googleapiclient.errors import HttpError
+    HAS_GOOGLE_API_LIB = True
+except ImportError:
+    HAS_GOOGLE_API_LIB = False
+
+def google_auth(module, cred_path):
+    scopes = ['https://www.googleapis.com/auth/cloud-platform']
+    credentials = None
+    try:
+        credentials = ServiceAccountCredentials.from_json_keyfile_name(
+                          cred_path,
+                          scopes=scopes
+                      )
+    except Exception as e:
+        module.fail_json(msg=e, changed=False)
+
+    return credentials
+
+def generate_resource_uri(project, *args):
+    google_base_uri = \
+            'https://www.googleapis.com/compute/v1/projects/%s/' % project
+    return google_base_uri + '/'.join(args)
+
+def populate_request_body(module, name, project, region, zone):
+    image_version = module.params.get('image_version')
+    bucket = module.params.get('bucket')
+    network = module.params.get('network')
+    subnetwork = module.params.get('subnetwork')
+    tags = module.params.get('tags')
+    service_account_scopes = module.params.get('service_account_scopes')
+    metadata = module.params.get('metadata')
+    init_actions = module.params.get('init_actions')
+    master_config = module.params.get('master_config')
+    worker_config = module.params.get('worker_config')
+    second_worker_config = module.params.get('second_worker_config')
+
+    body = {
+        'clusterName': name,
+        'projectId': project,
+        'config': {
+            'gceClusterConfig': {
+                'zoneUri': generate_resource_uri(
+                    project,
+                    'zones',
+                    zone
+                )
+            }
+        }
+    }
+
+    if image_version:
+        body['config']['softwareConfig'] = {}
+        body['config']['softwareConfig']['imageVersion'] = image_version
+    if bucket:
+        body['config']['configBucket'] = bucket
+    if tags:
+        body['config']['gceClusterConfig']['tags'] = tags.split(',')
+    if network:
+        body['config']['gceClusterConfig']['networkUri'] = \
+            generate_resource_uri(
+                project,
+                'regions',   
+                region,
+                network
+            )
+    if subnetwork:
+        body['config']['gceClusterConfig']['subnetworkUri'] = \
+            generate_resource_uri(
+                project,
+                'regions',
+                region,
+                subnetwork
+            )
+    if service_account_scopes:
+        body['config']['gceConfigCluster']['serviceAccountScopes'] = \
+            ['https://www.googleapis.com/auth/' + scope \
+             for scope in service_account_scopes]
+    if metadata:
+        body['config']['gceConfigCluster']['metadata'] = metadata
+    if init_actions:
+        body['config']['initializationActions'] = init_actions
+    if master_config:
+        body['config']['masterConfig'] = master_config
+    if worker_config:
+        body['config']['workerConfig'] = worker_config
+    if second_worker_config:
+        body['config']['secondaryWorkerConfig'] = second_worker_config
+
+    return body
+
+def main():
+    module = AnsibleModule(
+        argument_spec = dict(
+            name = dict(required=True),
+            state = dict(default='present'),
+            network = dict(),
+            subnetwork = dict(),
+            region = dict(default='us-central1'),
+            zone = dict(default='us-central1-a'),
+            sync = dict(type='bool', default=True),
+            poll_interval = dict(type='int', default=1),
+            image_version = dict(),
+            service_account_scopes = dict(type='list'),
+            metadata = dict(type='dict'),
+            init_actions = dict(type='list'),
+            master_config = dict(type='dict'),
+            worker_config = dict(type='dict'),
+            second_worker_config = dict(type='dict'),
+            bucket = dict()
+        ),
+        mutually_exclusive = [
+            ('network', 'subnetwork')
+        ]
+    )
+
+    if not HAS_GOOGLE_API_LIB:
+        module.fail_json(msg="Please install google-api-python-client library")
+
+    name = module.params.get('name')
+    state = module.params.get('state')
+    region = module.params.get('region')
+    zone = module.params.get('zone')
+    sync = module.params.get('sync')
+    poll_interval = module.params.get('poll_interval')
+
+    if not zone.startswith(region):
+        module.fail_json(msg="Region %s must contain zone %s" % (region, zone))
+
+    gce_email = os.environ.get('GCE_EMAIL', None)
+    gce_project = os.environ.get('GCE_PROJECT', None)
+    gce_credentials = os.environ.get('GCE_CREDENTIALS_FILE_PATH', None)
+    if not gce_email or not gce_project or not gce_credentials:
+        module.fail_json(msg="Please define Google auth environment " \
+                             "variables GCE_EMAIL, GCE_PROJECT and " \
+                             "GCE_CREDENTIALS_FILE_PATH",
+                             changed=False)
+
+    credentials = google_auth(module, gce_credentials)
+    dataproc = build('dataproc', 'v1', credentials=credentials)
+    json = {}
+    changed = False
+    if state in ['present', 'active']:
+        try:
+            json = dataproc.projects().regions().clusters() \
+                   .get(projectId=gce_project,
+                        region='global',
+                        clusterName=name).execute()
+        except HttpError:
+            body = populate_request_body(module, name, gce_project, region, zone)
+            json = dataproc.projects().regions().clusters() \
+                    .create(projectId=gce_project,
+                            region='global',
+                            body=body
+                    ).execute()
+            if sync:
+                while 'status' not in json or \
+                        json['status']['state'] != 'RUNNING':
+                    json = dataproc.projects().regions().clusters() \
+                           .get(projectId=gce_project,
+                                region='global',
+                                clusterName=name).execute();
+                    time.sleep(poll_interval)
+            changed = True
+        except Exception as e:
+            module.fail_json(changed=changed, msg=str(e))
+    elif state in ['absent', 'deleted']:
+        try:
+            json = dataproc.projects().regions().clusters() \
+                   .get(projectId=gce_project,
+                        region='global',
+                        clusterName=name).execute()
+        except HttpError as e:
+            pass
+        except Exception as e:
+            module.fail_json(changed=changed, msg=str(e))
+        else:
+            json = dataproc.projects().regions().clusters() \
+                   .delete(projectId=gce_project,
+                           region='global',
+                           clusterName=name
+                   ).execute()
+            changed = True
+
+    module.exit_json(changed=changed, **json)
+
+# import module snippets
+from ansible.module_utils.basic import *
+if __name__ == '__main__':
+    main()

--- a/cloud/google/gcdataproc.py
+++ b/cloud/google/gcdataproc.py
@@ -110,9 +110,44 @@ notes:
 '''
 
 EXAMPLES = '''
+# Creating a dataproc cluster with default paramters
+- gcdataproc:
+    name: test
+
+# Creating a dataproc cluster with defaults, fire and forget
+- gcdataproc:
+    name: test
+    sync: false
 '''
 
 RETURN = '''
+name:
+  description:
+    - The server-assigned name, which is only unique within the same service that originally returns it. If
+      you use the default HTTP mapping, the name should have the format of operations/some/unique/name.
+metadata:
+  description:
+    - Service-specific metadata associated with the operation. It typically contains progress information
+      and common metadata such as create time. Some services might not provide such metadata. Any method
+      that returns a long-running operation should document the metadata type, if any.
+      An object containing fields of an arbitrary type. An additional field "@type" contains a URI
+      identifying the type. Example: { "id": 1234, "@type": "types.example.com/standard/id" }.
+done:
+  description:
+    - If the value is false, it means the operation is still in progress. If true, the operation is completed,
+      and either error or response is available.
+error:
+  description:
+    - The error result of the operation in case of failure. 
+response:
+  description:
+    - The normal response of the operation in case of success. If the original method returns no data on
+      success, such as Delete, the response is google.protobuf.Empty. If the original method is standard
+      Get/Create/Update, the response should be the resource. For other methods, the response should have
+      the type XxxResponse, where Xxx is the original method name. For example, if the original method
+      name is TakeSnapshot(), the inferred response type is TakeSnapshotResponse.
+      An object containing fields of an arbitrary type. An additional field "@type" contains a URI
+      identifying the type. Example: { "id": 1234, "@type": "types.example.com/standard/id" }.
 '''
 
 import os

--- a/cloud/google/gcdataproc.py
+++ b/cloud/google/gcdataproc.py
@@ -24,7 +24,7 @@ module: gcdataproc
 short_description: Module for Google Cloud Dataproc clusters.
 description:
   - Creates or destroys Google Cloud Dataproc clusters on Google Cloud.
-    For more information on Dataproc, see: https://cloud.google.com/dataproc/.
+    For more information on Dataproc, see "https://cloud.google.com/dataproc/".
 version_added: "2.3"
 author: "John Baublitz @jbaublitz"
 requirements:

--- a/cloud/google/gcdataproc.py
+++ b/cloud/google/gcdataproc.py
@@ -72,37 +72,37 @@ options:
       - Cluster software image version.
   service_account_scopes:
     description:
-      - See https://developers.google.com/identity/protocols/googlescopes#dataprocv1
+      - See "https://developers.google.com/identity/protocols/googlescopes#dataprocv1"
         for more information on OAuth2 scopes available for dataproc.
   metadata:
     description:
       - Unvalidated dict of metadata passed to dataproc clusters on creation.
-        See https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#gceclusterconfig
+        See "https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#gceclusterconfig"
         and the metadata field in this object for more information.
   init_actions:
     description:
       - Unvalidated list of initialization actions passed to dataproc clusters on creation.
-        Each object in the list is defined by the following object:
-        https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#nodeinitializationaction.
+        Each object in the list is defined by the following object -
+        "https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#nodeinitializationaction".
   master_config:
     description:
       - Unvalidated dict specifying the master configuration for the cluster.
-        https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#instancegroupconfig.
+        "https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#instancegroupconfig".
   worker_config:
     description:
       - Unvalidated dict specifying the master configuration for the cluster.
-        https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#instancegroupconfig.
+        "https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#instancegroupconfig".
   second_worker_config:
     description:
       - Unvalidated dict specifying the master configuration for the cluster.
-        https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#instancegroupconfig.
+        "https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#instancegroupconfig".
   bucket:
     description:
       - A Google Cloud Storage staging bucket used for sharing generated SSH keys and config. If you do not
         specify a staging bucket, Cloud Dataproc will determine an appropriate Cloud Storage location
         (US, ASIA, or EU) for your cluster's staging bucket according to the Google Compute Engine zone where
         your cluster is deployed, and then it will create and manage this project-level, per-location bucket for you.
-        (from https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#clusterconfig)
+        (from "https://cloud.google.com/dataproc/docs/reference/rest/v1/projects.regions.clusters#clusterconfig")
 notes:
   - Because this module deals directly with a highly variable JSON REST API, much of the input is unvalidated.
     Check the documentation for Google Cloud for defaults on the cloud side. If input is improperly formatted,
@@ -131,7 +131,7 @@ metadata:
       and common metadata such as create time. Some services might not provide such metadata. Any method
       that returns a long-running operation should document the metadata type, if any.
       An object containing fields of an arbitrary type. An additional field "@type" contains a URI
-      identifying the type. Example: { "id": 1234, "@type": "types.example.com/standard/id" }.
+      identifying the type.
 done:
   description:
     - If the value is false, it means the operation is still in progress. If true, the operation is completed,
@@ -147,7 +147,7 @@ response:
       the type XxxResponse, where Xxx is the original method name. For example, if the original method
       name is TakeSnapshot(), the inferred response type is TakeSnapshotResponse.
       An object containing fields of an arbitrary type. An additional field "@type" contains a URI
-      identifying the type. Example: { "id": 1234, "@type": "types.example.com/standard/id" }.
+      identifying the type.
 '''
 
 import os


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- New Module Pull Request
##### COMPONENT NAME

<!--- Name of the plugin/module/task -->

gcdataproc
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible-playbook 2.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

This module uses `google-api-python-client` to make requests as opposed to `libcloud` as `libcloud` did not support the Dataproc API at the time of writing this module. The module requires a slightly different profile of information given the switch from `libcloud` to `google-api-python-client` and the nature of the Dataproc API compared to Compute for example.

I have removed the explicit parameters (but can add them back in if this seems more like a bug than a simplification) corresponding to  `GCE_EMAIL`, `GCE_PROJECT`, and `GCE_CREDENTIALS_FILE_PATH` environment variables that are supported in the other modules.

Another note is that the `google-api-python-client` calls are asynchronous to Dataproc. I have a very ugly poll-sleep interface for synchronous calls and would be open to hearing suggestions as I am unsure whether other Google APIs support event based calls or if `libcloud` simply emulates synchronous calls in a way similar to what I do (from what I saw of the code, it seems to support the latter).

The last noteworthy design decision was to pass unvalidated data into the Google API. This is a decision I saw in parameters like `metadata` in the `gce` module and some of these parameters are so highly variable that this seems like a better task for the user in the playbooks to pick and choose based on the documentation which parts of the object to pass in as not all are required for the API. I also think that the number of parameters would be a bit excessive without this structure and not easily represented within the ansible framework.

TODOS:
1. I need to work more on documentation and welcome suggestions. One issue that I just saw is that the Google docs and the return values from the `google-api-python-client` call do not seem to match. I need to look into this and fix the documentation there.
2. I only support the creation and destruction of clusters currently. Is anyone interested in the other components of the Dataproc API for this module? One warning is that I am unsure of the ability we will have to make this idempotent.
3. Cluster destruction does not currently support synchronous operations.

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
***********************************
PARSED OUTPUT
{
    "changed": true, 
    "clusterName": "test", 
    "clusterUuid": "7cf1ff27-4c9a-465e-8106-f646739eced3", 
    "config": {
        "configBucket": "dataproc-2433fc45-780c-44a7-a05b-2aa6fa077e39-us", 
        "gceClusterConfig": {
            "networkUri": "https://www.googleapis.com/compute/v1/projects/[PROJECT]/global/networks/default", 
            "serviceAccountScopes": [
                "https://www.googleapis.com/auth/bigquery", 
                "https://www.googleapis.com/auth/bigtable.admin.table", 
                "https://www.googleapis.com/auth/bigtable.data", 
                "https://www.googleapis.com/auth/cloud.useraccounts.readonly", 
                "https://www.googleapis.com/auth/devstorage.full_control", 
                "https://www.googleapis.com/auth/devstorage.read_write", 
                "https://www.googleapis.com/auth/logging.write"
            ], 
            "zoneUri": "https://www.googleapis.com/compute/v1/projects/[PROJECT]/zones/us-central1-a"
        }, 
        "masterConfig": {
            "diskConfig": {
                "bootDiskSizeGb": 500
            }, 
            "imageUri": "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-1-1-20161017-161942", 
            "instanceNames": [
                "test-m"
            ], 
            "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/[PROJECT]/zones/us-central1-a/machineTypes/n1-standard-4", 
            "numInstances": 1
        }, 
        "softwareConfig": {
            "imageVersion": "1.1.8", 
            "properties": {
                "distcp:mapreduce.map.java.opts": "-Xmx2457m", 
                "distcp:mapreduce.map.memory.mb": "3072", 
                "distcp:mapreduce.reduce.java.opts": "-Xmx4915m", 
                "distcp:mapreduce.reduce.memory.mb": "6144", 
                "mapred:mapreduce.map.cpu.vcores": "1", 
                "mapred:mapreduce.map.java.opts": "-Xmx2457m", 
                "mapred:mapreduce.map.memory.mb": "3072", 
                "mapred:mapreduce.reduce.cpu.vcores": "2", 
                "mapred:mapreduce.reduce.java.opts": "-Xmx4915m", 
                "mapred:mapreduce.reduce.memory.mb": "6144", 
                "mapred:yarn.app.mapreduce.am.command-opts": "-Xmx4915m", 
                "mapred:yarn.app.mapreduce.am.resource.cpu-vcores": "2", 
                "mapred:yarn.app.mapreduce.am.resource.mb": "6144", 
                "spark:spark.driver.maxResultSize": "1920m", 
                "spark:spark.driver.memory": "3840m", 
                "spark:spark.executor.cores": "2", 
                "spark:spark.executor.memory": "5586m", 
                "spark:spark.yarn.am.memory": "5586m", 
                "spark:spark.yarn.am.memoryOverhead": "558", 
                "spark:spark.yarn.executor.memoryOverhead": "558", 
                "yarn:yarn.nodemanager.resource.memory-mb": "12288", 
                "yarn:yarn.scheduler.maximum-allocation-mb": "12288", 
                "yarn:yarn.scheduler.minimum-allocation-mb": "1024"
            }
        }, 
        "workerConfig": {
            "diskConfig": {
                "bootDiskSizeGb": 500
            }, 
            "imageUri": "https://www.googleapis.com/compute/v1/projects/cloud-dataproc/global/images/dataproc-1-1-20161017-161942", 
            "instanceNames": [
                "test-w-0", 
                "test-w-1"
            ], 
            "machineTypeUri": "https://www.googleapis.com/compute/v1/projects/[PROJECT]/zones/us-central1-a/machineTypes/n1-standard-4", 
            "numInstances": 2
        }
    }, 
    "invocation": {
        "module_args": {
            "bucket": null, 
            "image_version": null, 
            "init_actions": null, 
            "master_config": null, 
            "metadata": null, 
            "name": "test", 
            "network": null, 
            "poll_interval": 1, 
            "region": "us-central1", 
            "second_worker_config": null, 
            "service_account_scopes": null, 
            "state": "present", 
            "subnetwork": null, 
            "sync": true, 
            "worker_config": null, 
            "zone": "us-central1-a"
        }
    }, 
    "metrics": {}, 
    "projectId": [PROJECT], 
    "status": {
        "state": "RUNNING", 
        "stateStartTime": "2016-10-25T19:06:32.545Z"
    }, 
    "statusHistory": [
        {
            "state": "CREATING", 
            "stateStartTime": "2016-10-25T19:04:36.149Z"
        }
    ]
}
```

/cc @ryansb @supertom 
