### PR TITLE
logentries: Fix `le rm` invocation to correctly unfollow log files with `state=absent`

### DIFF
--- a/monitoring/logentries.py
+++ b/monitoring/logentries.py
@@ -52,6 +52,9 @@ EXAMPLES = '''
 - logentries: path=/var/log/nginx/error.log state=absent
 '''
 
+import platform
+import os.path
+
 def query_log_status(module, le_path, path, state="present"):
     """ Returns whether a log is followed or not. """
 
@@ -91,7 +94,7 @@ def follow_log(module, le_path, logs, name=None, logtype=None):
 
     module.exit_json(changed=False, msg="logs(s) already followed")
 
-def unfollow_log(module, le_path, logs):
+def unfollow_log(module, le_path, logs, name=None):
     """ Unfollows one or more logs if followed. """
 
     removed_count = 0
@@ -104,7 +107,8 @@ def unfollow_log(module, le_path, logs):
 
         if module.check_mode:
             module.exit_json(changed=True)
-        rc, out, err = module.run_command([le_path, 'rm', log])
+        le_entity = 'hosts/%s/%s' % (platform.node(), name or os.path.basename(log))
+        rc, out, err = module.run_command([le_path, 'rm', le_entity])
 
         if query_log_status(module, le_path, log):
             module.fail_json(msg="failed to remove '%s': %s" % (log, err.strip()))
@@ -139,7 +143,7 @@ def main():
         follow_log(module, le_path, logs, name=p['name'], logtype=p['logtype'])
 
     elif p["state"] in ["absent", "unfollowed"]:
-        unfollow_log(module, le_path, logs)
+        unfollow_log(module, le_path, logs, name=p['name'])
 
 # import module snippets
 from ansible.module_utils.basic import *


### PR DESCRIPTION
##### ISSUE TYPE
- Bugfix Pull Request
##### COMPONENT NAME

`logentries` module
##### ANSIBLE VERSION

```
ansible 1.9.3
  configured module search path = None
```
##### SUMMARY

The `logentries` module fails to correctly unfollow logs. The `le` command it issues is `le rm <logfile-path>`, but that only results in an error message:

```
failed: [<hostname>] => (item={'path': '/var/log/diskutil.log', 'state': 'absent', 'name': 'Diskutil'}) => {"failed": true, "item": {"name": "Diskutil", "path": "/var/log/diskutil.log", "state": "absent"}}
msg: failed to remove '/var/log/diskutil.log': Error: Resource var not found.
```

The play in the playbook is:

```
- name: logentries
  hosts: all
  sudo: yes
  roles:
    - role: logentries
      logentries_logs:
        - …
        - name: "Diskutil"
          path: "/var/log/diskutil.log"
          state: absent
```

The relevant task is:

```
- name: Follow logs
  logentries: path={{ item.path }} state={{ item.state | default('present') }}
  with_items: logentries_logs
```

According to https://docs.logentries.com/docs/linux-agent and https://github.com/logentries/le/issues/66, the correct argument to pass to `le rm` is not the log file's file system path but a virtual path composed of 1. the prefix `hosts/`, 2. the fully qualified name of the host, and 3. the symbolic name of the log file specified during the initial `follow` action (defaulting to the base name of the log file path), e.g., `hosts/<hostname>/diskutil.log`.

Fixes #3307
