### PR TITLE
maven_artifact: Operation fails because status != 200 when using a maven repo with a file URL

### DIFF
--- a/packaging/language/maven_artifact.py
+++ b/packaging/language/maven_artifact.py
@@ -257,7 +257,7 @@ class MavenDownloader:
         self.module.params['http_agent'] = self.module.params.get('user_agent', None)
 
         response, info = fetch_url(self.module, url_to_use, timeout=req_timeout)
-        if info['status'] != 200:
+        if info['status'] != 200 or info['msg'][:2] != 'OK':
             raise ValueError(failmsg + " because of " + info['msg'] + "for URL " + url_to_use)
         else:
             return f(response)


### PR DESCRIPTION
##### ISSUE TYPE

<!--- Pick one below and delete the rest: -->
- Bugfix Pull Request
##### COMPONENT NAME

maven_artifact
##### ANSIBLE VERSION

<!--- Paste verbatim output from “ansible --version” between quotes below -->

```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```
##### SUMMARY

<!--- Describe the change, including rationale and design decisions -->

When using a file: url with maven_artifact plugin **info['status']** is **None** causing plugin execution to fail even if file was copied successfully.

e.g. 

```
- maven_artifact: group_id=com.example artifact_id=foo version=1.2.3.4 dest=foo/pom.xml extension=pom repository_url=file:/bar/baz
```

yields output 

```
Failed to download maven-metadata.xml because of OK (1234 bytes)for URL file:/bar/baz/com/example/foo/maven-metadata.xml
```

While **info['status']** is **None** in this case, **info['msg']** contains **OK (### bytes)** when a file transfer is successful with this method, so if **info['msg'][:2] == 'OK'** then this indicates a successful operation.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

_Edited for formatting/grammar_
