### PR TITLE
blockinfile: Fixes #1926 by comparing a marker to a whole line

### DIFF
--- a/files/blockinfile.py
+++ b/files/blockinfile.py
@@ -258,9 +258,9 @@ def main():
 
     n0 = n1 = None
     for i, line in enumerate(lines):
-        if line.startswith(marker0):
+        if line == marker0:
             n0 = i
-        if line.startswith(marker1):
+        if line == marker1:
             n1 = i
 
     if None in (n0, n1):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
blockinfile

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 333f6d447b) last updated 2016/11/02 10:58:53 (GMT +900)
  lib/ansible/modules/core: (detached HEAD d2106f1c92) last updated 2016/11/02 10:59:08 (GMT +900)
  lib/ansible/modules/extras: (detached HEAD 9a01d01f78) last updated 2016/11/02 10:59:13 (GMT +900)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Compare a marker to a whole line after stripping them based on a [comment](https://github.com/ansible/ansible-modules-extras/issues/1926#issuecomment-203070573) by @mavit.
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->
Fixes #1926 

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```