### PR TITLE
Fix compatibility when map is actually imap.

### DIFF
--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -211,7 +211,7 @@ class HAProxy(object):
         """
         data = self.execute('show stat', 200, False).lstrip('# ')
         r = csv.DictReader(data.splitlines())
-        return map(lambda d: d['pxname'], filter(lambda d: d['svname'] == 'BACKEND', r))
+        return tuple(map(lambda d: d['pxname'], filter(lambda d: d['svname'] == 'BACKEND', r)))
 
 
     def execute_for_backends(self, cmd, pxname, svname, wait_for_status = None):
@@ -244,7 +244,7 @@ class HAProxy(object):
         """
         data = self.execute('show stat', 200, False).lstrip('# ')
         r = csv.DictReader(data.splitlines())
-        state = map(lambda d: { 'status': d['status'], 'weight': d['weight'] }, filter(lambda d: (pxname is None or d['pxname'] == pxname) and d['svname'] == svname, r))
+        state = tuple(map(lambda d: { 'status': d['status'], 'weight': d['weight'] }, filter(lambda d: (pxname is None or d['pxname'] == pxname) and d['svname'] == svname, r)))
         return state or None
 
 


### PR DESCRIPTION
##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME
haproxy

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

2 functions return `map(some_stuff)` but those do not work when `map` is actually `imap`.

While I still have no idea why or how the `map` call is being swapped out while still running in python 2.7, this change will fix the following error, as well as improve py3 compatiblity:

Before:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: Value of unknown type: <type 'itertools.imap'>, <itertools.imap object at 0x7fdb35c4b110>, pysys.version_info(major=2, minor=7, micro=12, releaselevel='final', serial=0); from {'changed': True, 'command': ['get weight servers/server8888; enable server servers/server8888; set weight servers/server8888 0'], 'state_after': <itertools.imap object at 0x7fdb35c4b110>, 'invocation': {'module_args': {'shutdown_sessions': False, 'socket': '/var/run/haproxy/admin.sock', 'weight': '0', 'wait_interval': 5, 'wait_retries': 25, 'state': 'enabled', 'fail_on_not_found': False, 'host': 'server8888', 'wait': False, 'backend': 'servers'}}, 'output': ['0 (initial 1)'], 'state_before': <itertools.imap object at 0x7fdb35bd9fd0>}[state_after]
fatal: [server0.staging.internal.encircleapp.com]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_z7IB5b/ansible_module_haproxy.py\", line 350, in <module>\n    main()\n  File \"/tmp/ansible_z7IB5b/ansible_module_haproxy.py\", line 345, in main\n    ansible_haproxy.act()\n  File \"/tmp/ansible_z7IB5b/ansible_module_haproxy.py\", line 317, in act\n    self.module.exit_json(**self.command_results)\n  File \"/tmp/ansible_z7IB5b/ansible_modlib.zip/ansible/module_utils/basic.py\", line 1799, in exit_json\n  File \"/tmp/ansible_z7IB5b/ansible_modlib.zip/ansible/module_utils/basic.py\", line 388, in remove_values\n  File \"/tmp/ansible_z7IB5b/ansible_modlib.zip/ansible/module_utils/basic.py\", line 388, in <genexpr>\n  File \"/tmp/ansible_z7IB5b/ansible_modlib.zip/ansible/module_utils/basic.py\", line 399, in remove_values\nTypeError: Value of unknown type: <type 'itertools.imap'>, <itertools.imap object at 0x7fdb35c4b110>, pysys.version_info(major=2, minor=7, micro=12, releaselevel='final', serial=0); from {'changed': True, 'command': ['get weight servers/server8888; enable server servers/server8888; set weight servers/server8888 0'], 'state_after': <itertools.imap object at 0x7fdb35c4b110>, 'invocation': {'module_args': {'shutdown_sessions': False, 'socket': '/var/run/haproxy/admin.sock', 'weight': '0', 'wait_interval': 5, 'wait_retries': 25, 'state': 'enabled', 'fail_on_not_found': False, 'host': 'server8888', 'wait': False, 'backend': 'servers'}}, 'output': ['0 (initial 1)'], 'state_before': <itertools.imap object at 0x7fdb35bd9fd0>}[state_after]\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

After
```
TASK [Drain HTTP connections from webserver] ***********************************
ok: [server0.-------]
```