### PR TITLE
s3_bucket: initialize Versioning attribute when undefined

### DIFF
--- a/cloud/amazon/s3_bucket.py
+++ b/cloud/amazon/s3_bucket.py
@@ -168,6 +168,12 @@ def _create_or_update_bucket(connection, module, location):
 
     # Versioning
     versioning_status = bucket.get_versioning_status()
+
+    # versioning_status dictionary is empty upon bucket creation
+    # so default the Versioning attribute to "Disabled"
+    if versioning_status == dict():
+        versioning_status = dict(Versioning="Disabled")
+
     if versioning_status:
         if versioning is not None:
             if versioning and versioning_status['Versioning'] != "Enabled":


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_bucket.py

##### ANSIBLE VERSION
```
ansible 2.3.0
```
(current devel branch)

##### SUMMARY
The versioning attribute was not set for new S3 buckets even if you explicitly set the versioning boolean to true ('yes').

This is a regression from an earlier incarnation of the module (in ansible-2.1.1.0). However, that version of the module was unusable due to broken json parsing of the bucket policy.

The current version of the module on the devel branch was broken because the response from Amazon resulted in an empty dictionary. While this module assumed the 'Versioning' attribute was at least present (it checks whether its value != "Enabled").

My suggested fix is to initialize the 'Versioning' attribute to "Disabled" in case the dictionary is empty. This way the rest of the module functions as it should.

```
Relevant output is absent because the module did not fail. Instead versioning was simply not set on newly created S3 buckets.
```