### PR TITLE
S3 bucket vers cond fix

### DIFF
--- a/cloud/amazon/s3_bucket.py
+++ b/cloud/amazon/s3_bucket.py
@@ -173,7 +173,7 @@ def _create_or_update_bucket(connection, module, location):
                     versioning_status = bucket.get_versioning_status()
                 except S3ResponseError as e:
                     module.fail_json(msg=e.message)
-            elif not versioning and versioning_status['Versioning'] != "Enabled":
+            elif not versioning and versioning_status['Versioning'] == "Enabled":
                 try:
                     bucket.configure_versioning(versioning)
                     changed = True

--- a/cloud/amazon/s3_bucket.py
+++ b/cloud/amazon/s3_bucket.py
@@ -164,8 +164,8 @@ def _create_or_update_bucket(connection, module, location):
 
     # Versioning
     versioning_status = bucket.get_versioning_status()
-    if versioning_status:
-        if versioning is not None:
+    if versioning is not None:
+        if versioning_status:
             if versioning and versioning_status['Versioning'] != "Enabled":
                 try:
                     bucket.configure_versioning(versioning)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
s3_bucket.py

##### ANSIBLE VERSION
```
ansible 2.3.0
```
(current devel branch)

##### SUMMARY
The first commit changes the order in which conditionals are evaluated. Before the response from Amazon was checked first and our own parameter afterwards.

However, the parameter the user entered is already locally available, so why not start from there? If our user has no interest in changing a setting then why should we care about its status in the cloud?

The second commit changes the conditional which evaluates whether we should perform a change on the versioning attribute of an S3 bucket. Before the parameter the user set had no effect on the versioning status of the bucket since the second variable in the conditional was identical for both execution paths.

This commit fixes the second conditional so that two seperate execution paths are possible.

```
(The module kept returning a 'changed' status before this fix. Otherwise there is no relevant output.)
```
