### PR TITLE
Specify the correct argument type

### DIFF
--- a/web_infrastructure/jira.py
+++ b/web_infrastructure/jira.py
@@ -311,7 +311,7 @@ def main():
             comment=dict(),
             status=dict(),
             assignee=dict(),
-            fields=dict(default={})
+            fields=dict(default={}, type='dict')
         ),
         supports_check_mode=False
     )


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
jira module

##### ANSIBLE VERSION
Fix validated on:
```
ansible 2.1.2.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
See #2600 for more detail, but the `fields` parameter was being loaded as a string instead of a dictionary, causing the code to break.

(Example copied from #2600)
```
- hosts: xxxx

  tasks:
  - name: (JIRA) Sample ansible issue
    jira: description=something issuetype=Bug operation=create password=XXXX project=xxx summary=test uri=https://hostname.com username=XXX
```

By default, all arguments are considered strings, but the module code expects the `fields` parameter to be a proper Python dictionary.

Fixes #2600