### PR TITLE
Fix itertools.imap TypeError in haproxy module

### DIFF
--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -244,7 +244,7 @@ class HAProxy(object):
         """
         data = self.execute('show stat', 200, False).lstrip('# ')
         r = csv.DictReader(data.splitlines())
-        state = map(lambda d: { 'status': d['status'], 'weight': d['weight'] }, filter(lambda d: (pxname is None or d['pxname'] == pxname) and d['svname'] == svname, r))
+        state = list(map(lambda d: { 'status': d['status'], 'weight': d['weight'] }, filter(lambda d: (pxname is None or d['pxname'] == pxname) and d['svname'] == svname, r)))
         return state or None
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
haproxy module

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
Bugfix proposal for issue https://github.com/ansible/ansible-modules-extras/issues/3377.

Relates to https://github.com/ansible/ansible-modules-extras/issues/3377
