### PR TITLE
Fixes #3380 - ec2_elb_facts errors with no names input

### DIFF
--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -205,11 +205,12 @@ class ElbInformation(object):
             self.module.fail_json(msg = "%s: %s" % (err.error_code, err.error_message))
 
         if all_elbs:
-            for existing_lb in all_elbs:
-                if self.names and existing_lb.name in self.names:
-                    elb_array.append(existing_lb)
-                else:
-                    elb_array.append(existing_lb)
+            if self.names:
+                for existing_lb in all_elbs:
+                    if existing_lb.name in self.names:
+                        elb_array.append(existing_lb)
+            else:
+                elb_array = all_elbs
                     
         return list(map(self._get_elb_info, elb_array))
 

--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -214,7 +214,7 @@ class ElbInformation(object):
 def main():
     argument_spec = ec2_argument_spec()
     argument_spec.update(dict(
-            names={'default': None, 'type': 'list'}
+            names={'default': [], 'type': 'list'}
         )
     )
     module = AnsibleModule(argument_spec=argument_spec)

--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -206,10 +206,12 @@ class ElbInformation(object):
 
         if all_elbs:
             for existing_lb in all_elbs:
-                if existing_lb.name in self.names:
-                    elb_array.append(self._get_elb_info(existing_lb))
-
-        return elb_array
+                if self.names and existing_lb.name in self.names:
+                    elb_array.append(existing_lb)
+                else:
+                    elb_array.append(existing_lb)
+                    
+        return list(map(self._get_elb_info, elb_array))
 
 def main():
     argument_spec = ec2_argument_spec()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
 - ec2_elb_facts

##### ANSIBLE VERSION
```
ansible --version
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Fixes #3380 

Instead of using a None, use an empty list as the default. This allows us to continue to use python truthy functions to determine if the user has specified a set of load balancers to operate on.

```
# Before

TASK [deploy_elb_deregister : Gather elb facts] ********************************
fatal: [10.90.30.119]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 10.90.30.119 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_49PnSI/ansible_module_ec2_elb_facts.py\", line 245, in <module>\r\n    main()\r\n  File \"/tmp/ansible_49PnSI/ansible_module_ec2_elb_facts.py\", line 237, in main\r\n    elbs=elb_information.list_elbs())\r\n  File \"/tmp/ansible_49PnSI/ansible_module_ec2_elb_facts.py\", line 209, in list_elbs\r\n    if existing_lb.name in self.names:\r\nTypeError: argument of type 'NoneType' is not iterable\r\n", "msg": "MODULE FAILURE"}

# After
TASK [deploy_elb_deregister : Gather elb facts] ********************************
ok: [10.50.20.169]
```
