### PR TITLE
Remove need for translate/maketrans due to py3 differences

### DIFF
--- a/cloud/vmware/vmware_guest.py
+++ b/cloud/vmware/vmware_guest.py
@@ -161,7 +161,6 @@ except ImportError:
     pass
 
 import os
-import string
 import time
 
 from ansible.module_utils.urls import fetch_url
@@ -631,11 +630,7 @@ class PyVmomiHelper(object):
             if [x for x in pspec.keys() if x.startswith('size_') or x == 'size']:
                 # size_tb, size_gb, size_mb, size_kb, size_b ...?
                 if 'size' in pspec:
-                    # http://stackoverflow.com/a/1451407
-                    trans = string.maketrans('', '')
-                    chars = trans.translate(trans, string.digits)
-                    expected = pspec['size'].translate(trans, chars)
-                    expected = expected
+                    expected = ''.join(c for c in pspec['size'] if c.isdigit())
                     unit = pspec['size'].replace(expected, '').lower()
                     expected = int(expected)
                 else:


### PR DESCRIPTION
##### ISSUE TYPE

 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
devel 2.2
```

##### SUMMARY

* translate() has a different api for text vs byte strings
* maketrans must be imported from a different location on py2 vs py3

Since this is such a small string outside of a loop we don't have to
worry too much about speed so it's better to have a single piece of code
that works on both py2 and py3