### PR TITLE
ecs_taskdefinition: Added CPU and Memory conversion to int. 

### DIFF
--- a/cloud/amazon/ecs_taskdefinition.py
+++ b/cloud/amazon/ecs_taskdefinition.py
@@ -196,6 +196,14 @@ def main():
     if module.params['state'] == 'present':
         if 'containers' not in module.params or not module.params['containers']:
             module.fail_json(msg="To use task definitions, a list of containers must be specified")
+        else: 
+            for container in module.params['containers']:
+                if not "cpu" in container or container['cpu'] is None:
+                    module.fail_json(msg="To use containers, cpu must be specified")
+                if not "memory" or container['memory'] is None:
+                    module.fail_json(msg="To use containers, memory must be specified")
+                container['cpu'] = int(container['cpu'])
+                container['memory'] = int(container['memory'])
 
         if 'family' not in module.params or not module.params['family']:
             module.fail_json(msg="To use task definitions, a family must be specified")


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ecs_taskdefinition

##### ANSIBLE VERSION
```
ansible 2.3.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Make CPU and Mem templatable to be able to use them like 
```
 memory: "{{item.mem}}"
 cpu: "{{item.cpu}}"
```

This mimics #1715 (thanks @nikhilo), rebased on the new ecs_taskdefinition.py