### PR TITLE
Fixed wrong variable name in the let's encrypt doc

### DIFF
--- a/web_infrastructure/letsencrypt.py
+++ b/web_infrastructure/letsencrypt.py
@@ -122,8 +122,8 @@ EXAMPLES = '''
 # for example:
 #
 # - copy:
-#     dest: /var/www/html/{{ sample_com_http_challenge['challenge_data']['sample.com']['http-01']['resource'] }}
-#     content: "{{ sample_com_http_challenge['challenge_data']['sample.com']['http-01']['resource_value'] }}"
+#     dest: /var/www/html/{{ sample_com_challenge['challenge_data']['sample.com']['http-01']['resource'] }}
+#     content: "{{ sample_com_challenge['challenge_data']['sample.com']['http-01']['resource_value'] }}"
 #     when: sample_com_challenge|changed
 
 - letsencrypt:


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
letsencrypt

##### SUMMARY
Fixed wrong variable name in the let's encrypt doc
It could lead to unwanted error when dummy-paste to try this module.

