### PR TITLE
Make the 'make' module run on python 3

### DIFF
--- a/system/make.py
+++ b/system/make.py
@@ -65,6 +65,9 @@ EXAMPLES = '''
 # fix this
 RETURN = '''# '''
 
+from ansible.module_utils.six import iteritems
+from ansible.module_utils.basic import AnsibleModule
+
 
 def run_command(command, module, check_rc=True):
     """
@@ -90,9 +93,9 @@ def sanitize_output(output):
     :return: sanitized output
     """
     if output is None:
-        return b('')
+        return ''
     else:
-        return output.rstrip(b("\r\n"))
+        return output.rstrip("\r\n")
 
 
 def main():
@@ -108,7 +111,7 @@ def main():
     make_path = module.get_bin_path('make', True)
     make_target = module.params['target']
     if module.params['params'] is not None:
-        make_parameters = [k + '=' + str(v) for k, v in module.params['params'].iteritems()]
+        make_parameters = [k + '=' + str(v) for k, v in iteritems(module.params['params'])]
     else:
         make_parameters = []
 
@@ -146,8 +149,6 @@ def main():
         chdir=module.params['chdir']
     )
 
-
-from ansible.module_utils.basic import *
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
make
##### SUMMARY
Traceback:

    Traceback (most recent call last):
      File \"/tmp/ansible_d28_6uwl/ansible_module_make.py\", line 153, in <module>
        main()
      File \"/tmp/ansible_d28_6uwl/ansible_module_make.py\", line 119, in main
        rc, out, err = run_command(base_command + ['--question'], module, check_rc=False)
      File \"/tmp/ansible_d28_6uwl/ansible_module_make.py\", line 79, in run_command
        return rc, sanitize_output(out), sanitize_output(err)
      File \"/tmp/ansible_d28_6uwl/ansible_module_make.py\", line 95, in sanitize_output
        return output.rstrip(b(\"\\r\\n\"))
    TypeError: rstrip arg must be None or str

There is also a six.iteritems issue, fixed using six.