### PR TITLE
Changed parameter ordering in create_connection_bond

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -709,6 +709,9 @@ class Nmcli(object):
             cmd.append(self.ifname)
         elif self.conn_name is not None:
             cmd.append(self.conn_name)
+        if self.mode is not None:
+            cmd.append('mode')
+            cmd.append(self.mode)
         if self.ip4 is not None:
             cmd.append('ip4')
             cmd.append(self.ip4)
@@ -724,9 +727,6 @@ class Nmcli(object):
         if self.autoconnect is not None:
             cmd.append('autoconnect')
             cmd.append(self.bool_to_string(self.autoconnect))
-        if self.mode is not None:
-            cmd.append('mode')
-            cmd.append(self.mode)
         if self.miimon is not None:
             cmd.append('miimon')
             cmd.append(self.miimon)


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-modules-extra/nmcli

##### ANSIBLE VERSION
```
ansible 2.2.0
  config file = /etc/ansible/code/ansible.cfg
  configured module search path = ['modules']

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
On RHEL7 systems the nmcli mode parameter must be present before the ip address parameter.
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
TASK [try nmcli add bond - conn_name only & ip4 gw4 mode] **********************
task path: /etc/ansible/code/playbooks/network_config_add.yml:15
Using module file /usr/lib/python2.7/site-packages/ansible/modules/extras/network/nmcli.py
<localhost > ESTABLISH SSH CONNECTION FOR USER: root
<localhost > SSH: EXEC ssh -vvv -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60 -o TCPKeepAlive=yes -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/%h-%r localhost '/bin/sh -c '"'"'/usr/bin/python && sleep 0'"'"''
failed: [localhost] (item={u'conn_name': u'bond0', u'mode': u'active-backup', u'ip4': u'10.20.8.209/24', u'gw4': u'10.20.8.1'}) => {
    "failed": true,
    "invocation": {
        "module_args": {
            "ageingtime": "300",
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": null,
            "conn_name": "bond0",
            "dns4": null,
            "dns6": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": "15",
            "gw4": "10.20.8.1",
            "gw6": null,
            "hellotime": "2",
            "ifname": null,
            "ingress": null,
            "ip4": "10.20.8.209/24",
            "ip6": null,
            "mac": null,
            "master": null,
            "maxage": "20",
            "miimon": null,
            "mode": "active-backup",
            "mtu": null,
            "priority": "128",
            "slavepriority": "32",
            "state": "present",
            "stp": "yes",
            "type": "bond",
            "updelay": null,
            "vlandev": null,
            "vlanid": null
        },
        "module_name": "nmcli"
    },
    "item": {
        "conn_name": "bond0",
        "gw4": "10.20.8.1",
        "ip4": "10.20.8.209/24",
        "mode": "active-backup"
    },
    "msg": "Error: Unexpected argument 'mode'\n",
    "name": "bond0",
    "rc": 2
}
```

After:
```
TASK [try nmcli add bond - conn_name only & ip4 gw4 mode] **********************
task path: /etc/ansible/code/playbooks/network_config_add.yml:15
Using module file /etc/ansible/code/modules/nmcli.py
<localhost > ESTABLISH SSH CONNECTION FOR USER: root
<localhost > SSH: EXEC ssh -vvv -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=60 -o TCPKeepAlive=yes -o KbdInteractiveAuthentication=no -o PreferredAuthentications=gssapi-with-mic,gssapi-keyex,hostbased,publickey -o PasswordAuthentication=no -o User=root -o ConnectTimeout=10 -o ControlPath=/root/.ansible/cp/%h-%r localhost '/bin/sh -c '"'"'/usr/bin/python && sleep 0'"'"''
changed: [localhost ] => (item={u'conn_name': u'bond0', u'mode': u'active-backup', u'ip4': u'10.20.8.209/24', u'gw4': u'10.20.8.1'}) => {
    "changed": true,
    "invocation": {
        "module_args": {
            "ageingtime": "300",
            "arp_interval": null,
            "arp_ip_target": null,
            "autoconnect": null,
            "conn_name": "bond0",
            "dns4": null,
            "dns6": null,
            "downdelay": null,
            "egress": null,
            "flags": null,
            "forwarddelay": "15",
            "gw4": "10.20.8.1",
            "gw6": null,
            "hellotime": "2",
            "ifname": null,
            "ingress": null,
            "ip4": "10.20.8.209/24",
            "ip6": null,
            "mac": null,
            "master": null,
            "maxage": "20",
            "miimon": null,
            "mode": "active-backup",
            "mtu": null,
            "priority": "128",
            "slavepriority": "32",
            "state": "present",
            "stp": "yes",
            "type": "bond",
            "updelay": null,
            "vlandev": null,
            "vlanid": null
        },
        "module_name": "nmcli"
    },
    "item": {
        "conn_name": "bond0",
        "gw4": "10.20.8.1",
        "ip4": "10.20.8.209/24",
        "mode": "active-backup"
    }
}

```