### PR TITLE
added quota management: os_compute_quotas, os_volume_quotas, os_netwo…

### DIFF
--- a/cloud/openstack/os_compute_quotas.py
+++ b/cloud/openstack/os_compute_quotas.py
@@ -1,0 +1,134 @@
+#!/usr/bin/python
+
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+from distutils.version import StrictVersion
+
+
+DOCUMENTATION = '''
+---
+module: os_compute_quotas
+short_description: Update/Delete compute quotas in a OpenStack tenant.
+extends_documentation_fragment: openstack
+author: "Ghe Rivero (@GheRivero)" and "Andrea Mercanti (@mercantiandrea)"
+version_added: "2.2"
+description:
+   - Update or delete compute quotas in a OpenStack tenant.
+options:
+  project:
+    description:
+      - The name or id of the project to which the quota should be assigned
+    required: true
+  state:
+    description:
+      - Should the resource be present or absent
+    choices: ['present', 'absent']
+    required: false
+    default: present
+  quota:
+    description:
+      - Dictionary containing the quotas and values you want to update
+    required: false
+
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Update the quota of the tenant 'demo'
+- os_compute_quotas:
+    cloud: mycloud
+    project: demo
+    state: present
+    quota:
+      instances: 33
+      cores: 33
+      ram: 33333
+      floating_ips: 33
+      fixed_ips: 33
+      metadata_items: 33
+      injected_files: 33
+      injected_file_content_bytes: 33333
+      injected_file_path_bytes: 333
+      key_pairs: 33
+      security_groups: 33
+      security_group_rules: 33
+      server_groups: 33
+      server_group_members: 33
+
+# Delete quotas for the tenant 'demo' and back to defaults
+- os_compute_quotas:
+    cloud: mycloud
+    project: demo
+    state: absent
+'''
+
+RETURN = '''
+quotas:
+    description: Dictionary listing all the compute quotas and their values for the project
+    returned: On success
+    type: dictionary
+
+'''
+
+
+def main():
+    argument_spec = openstack_full_argument_spec(
+        project = dict(required=False),
+        quota = dict(default=None, type='dict'),
+        state = dict(default='present', choices=['absent', 'present']),
+    )
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    if (StrictVersion(shade.__version__) < StrictVersion('1.8.0')):
+        module.fail_json(msg="To manage compute quotas, the installed version of"
+                             "the shade library MUST be >=1.8.0")
+
+    try:
+        cloud = shade.operator_cloud(**module.params)
+
+        old_quotas = cloud.get_compute_quotas(module.params['project'])
+
+        if module.params['state'] == 'present':
+            cloud.set_compute_quotas(module.params['project'],
+                                     **module.params['quota'])
+
+        elif module.params['state'] == 'absent':
+            cloud.delete_compute_quotas(module.params['project'])
+
+        new_quotas = cloud.get_compute_quotas(module.params['project'])
+
+        module.exit_json(changed=old_quotas != new_quotas, quotas=new_quotas)
+
+    except shade.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_compute_quotas.py
+++ b/cloud/openstack/os_compute_quotas.py
@@ -29,8 +29,8 @@ DOCUMENTATION = '''
 module: os_compute_quotas
 short_description: Update/Delete compute quotas in a OpenStack tenant.
 extends_documentation_fragment: openstack
-author: "Ghe Rivero (@GheRivero)" and "Andrea Mercanti (@mercantiandrea)"
-version_added: "2.2"
+author: "Ghe Rivero (@GheRivero) and Andrea Mercanti (@mercantiandrea)"
+version_added: "2.3"
 description:
    - Update or delete compute quotas in a OpenStack tenant.
 options:

--- a/cloud/openstack/os_network_quotas.py
+++ b/cloud/openstack/os_network_quotas.py
@@ -30,7 +30,7 @@ module: os_network_quotas
 short_description: Update/Delete network quotas in a OpenStack tenant.
 extends_documentation_fragment: openstack
 author: "Andrea Mercanti (@mercantiandrea)"
-version_added: "2.2"
+version_added: "2.3"
 description:
    - Update or delete network quotas in a OpenStack tenant.
 options:
@@ -60,7 +60,14 @@ EXAMPLES = '''
     state: present
     quota:
       floatingip: 33
+      healthmonitor: 33
+      ikepolicy: 33
+      ipsec_site_connection: 33
+      ipsecpolicy: 33
+      listener: 33
+      loadbalancer: 33
       network: 33
+      pool: 33
       port: 33
       rbac_policy: 33
       router: 33
@@ -68,6 +75,7 @@ EXAMPLES = '''
       security_group_rule: 33
       subnet: 33
       subnetpool: 33
+      vpnservice: 33
 
 # Delete quotas for the tenant 'demo' and back to defaults
 - os_network_quotas:

--- a/cloud/openstack/os_network_quotas.py
+++ b/cloud/openstack/os_network_quotas.py
@@ -1,0 +1,129 @@
+#!/usr/bin/python
+
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+from distutils.version import StrictVersion
+
+
+DOCUMENTATION = '''
+---
+module: os_network_quotas
+short_description: Update/Delete network quotas in a OpenStack tenant.
+extends_documentation_fragment: openstack
+author: "Andrea Mercanti (@mercantiandrea)"
+version_added: "2.2"
+description:
+   - Update or delete network quotas in a OpenStack tenant.
+options:
+  project:
+    description:
+      - The name or id of the project to which the quota should be assigned
+    required: true
+  state:
+    description:
+      - Should the resource be present or absent
+    choices: ['present', 'absent']
+    required: false
+    default: present
+  quota:
+    description:
+      - Dictionary containing the quotas and values you want to update
+    required: false
+
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Update the quota of the tenant 'demo'
+- os_network_quotas:
+    cloud: mycloud
+    project: demo
+    state: present
+    quota:
+      floatingip: 33
+      network: 33
+      port: 33
+      rbac_policy: 33
+      router: 33
+      security_group: 33
+      security_group_rule: 33
+      subnet: 33
+      subnetpool: 33
+
+# Delete quotas for the tenant 'demo' and back to defaults
+- os_network_quotas:
+    cloud: mycloud
+    project: demo
+    state: absent
+'''
+
+RETURN = '''
+quotas:
+    description: Dictionary listing all the network quotas and their values for the project
+    returned: On success
+    type: dictionary
+
+'''
+
+
+def main():
+    argument_spec = openstack_full_argument_spec(
+        project = dict(required=False),
+        quota = dict(default=None, type='dict'),
+        state = dict(default='present', choices=['absent', 'present']),
+    )
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    if (StrictVersion(shade.__version__) < StrictVersion('1.8.0')):
+        module.fail_json(msg="To manage network quotas, the installed version of"
+                             "the shade library MUST be >=1.8.0")
+
+    try:
+        cloud = shade.operator_cloud(**module.params)
+
+        old_quotas = cloud.get_network_quotas(module.params['project'])
+
+        if module.params['state'] == 'present':
+            cloud.set_network_quotas(module.params['project'],
+                                     **module.params['quota'])
+
+        elif module.params['state'] == 'absent':
+            cloud.delete_network_quotas(module.params['project'])
+
+        new_quotas = cloud.get_network_quotas(module.params['project'])
+
+        module.exit_json(changed=old_quotas != new_quotas, quotas=new_quotas)
+
+    except shade.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_volume_quotas.py
+++ b/cloud/openstack/os_volume_quotas.py
@@ -1,0 +1,126 @@
+#!/usr/bin/python
+
+# Copyright (c) 2015 Hewlett-Packard Development Company, L.P.
+#
+# This module is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this software.  If not, see <http://www.gnu.org/licenses/>.
+
+try:
+    import shade
+    HAS_SHADE = True
+except ImportError:
+    HAS_SHADE = False
+
+from distutils.version import StrictVersion
+
+
+DOCUMENTATION = '''
+---
+module: os_volume_quotas
+short_description: Update/Delete volume quotas in a OpenStack tenant.
+extends_documentation_fragment: openstack
+author: "Andrea Mercanti (@mercantiandrea)"
+version_added: "2.2"
+description:
+   - Update or delete volume quotas in a OpenStack tenant.
+options:
+  project:
+    description:
+      - The name or id of the project to which the quota should be assigned
+    required: true
+  state:
+    description:
+      - Should the resource be present or absent
+    choices: ['present', 'absent']
+    required: false
+    default: present
+  quota:
+    description:
+      - Dictionary containing the quotas and values you want to update
+    required: false
+
+requirements: ["shade"]
+'''
+
+EXAMPLES = '''
+# Update the quota of the tenant 'demo'
+- os_volume_quotas:
+    cloud: mycloud
+    project: demo
+    state: present
+    quota:
+      backup_gigabytes: 33333
+      backups: 33
+      gigabytes: 33333
+      per_volume_gigabytes: 33333
+      snapshots: 33
+      volumes: 33
+
+# Delete quotas for the tenant 'demo' and back to defaults
+- os_volume_quotas:
+    cloud: mycloud
+    project: demo
+    state: absent
+'''
+
+RETURN = '''
+quotas:
+    description: Dictionary listing all the volume quotas and their values for the project
+    returned: On success
+    type: dictionary
+
+'''
+
+
+def main():
+    argument_spec = openstack_full_argument_spec(
+        project = dict(required=False),
+        quota = dict(default=None, type='dict'),
+        state = dict(default='present', choices=['absent', 'present']),
+    )
+
+    module_kwargs = openstack_module_kwargs()
+    module = AnsibleModule(argument_spec, **module_kwargs)
+
+    if not HAS_SHADE:
+        module.fail_json(msg='shade is required for this module')
+
+    if (StrictVersion(shade.__version__) < StrictVersion('1.8.0')):
+        module.fail_json(msg="To manage volume quotas, the installed version of"
+                             "the shade library MUST be >=1.8.0")
+
+    try:
+        cloud = shade.operator_cloud(**module.params)
+
+        old_quotas = cloud.get_volume_quotas(module.params['project'])
+
+        if module.params['state'] == 'present':
+            cloud.set_volume_quotas(module.params['project'],
+                                     **module.params['quota'])
+
+        elif module.params['state'] == 'absent':
+            cloud.delete_volume_quotas(module.params['project'])
+
+        new_quotas = cloud.get_volume_quotas(module.params['project'])
+
+        module.exit_json(changed=old_quotas != new_quotas, quotas=new_quotas)
+
+    except shade.OpenStackCloudException as e:
+        module.fail_json(msg=str(e))
+
+
+from ansible.module_utils.basic import *
+from ansible.module_utils.openstack import *
+
+if __name__ == '__main__':
+    main()

--- a/cloud/openstack/os_volume_quotas.py
+++ b/cloud/openstack/os_volume_quotas.py
@@ -30,7 +30,7 @@ module: os_volume_quotas
 short_description: Update/Delete volume quotas in a OpenStack tenant.
 extends_documentation_fragment: openstack
 author: "Andrea Mercanti (@mercantiandrea)"
-version_added: "2.2"
+version_added: "2.3"
 description:
    - Update or delete volume quotas in a OpenStack tenant.
 options:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New Module Pull Request


##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
 - os_compute_quotas
 - os_volume_quotas
 - os_network_quotas

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Add new modules to manage all quota in OpenStack Tenant.
In particular there are three new module to modify tenant quota:
 - os_compute_quotas --> manage Nova quotas
 - os_volume_quotas --> manage Cinder quotas
 - os_network_quotas --> manage Neutron quotas

I have built these modules from this work:
  https://github.com/ansible/ansible-modules-extras/pull/1823
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE:
```
[bastion@bastion ~]$ nova quota-show
+-----------------------------+-------+
| Quota                       | Limit |
+-----------------------------+-------+
| instances                   | 10    |
| cores                       | 20    |
| ram                         | 51200 |
| floating_ips                | 10    |
| fixed_ips                   | -1    |
| metadata_items              | 128   |
| injected_files              | 5     |
| injected_file_content_bytes | 10240 |
| injected_file_path_bytes    | 255   |
| key_pairs                   | 100   |
| security_groups             | 10    |
| security_group_rules        | 20    |
| server_groups               | 10    |
| server_group_members        | 10    |
+-----------------------------+-------+

[bastion@bastion ~]$ neutron quota-show
+---------------------+-------+
| Field               | Value |
+---------------------+-------+
| floatingip          | 50    |
| network             | 10    |
| port                | 50    |
| rbac_policy         | 10    |
| router              | 10    |
| security_group      | 10    |
| security_group_rule | 100   |
| subnet              | 10    |
| subnetpool          | -1    |
+---------------------+-------+

[bastion@bastion ~]$ cinder quota-show 78bd3ce0b75e4b469e6cf3d1ef33ca86
+----------------------+-------+
| Property             | Value |
+----------------------+-------+
| backup_gigabytes     | 1000  |
| backups              | 10    |
| gigabytes            | 1000  |
| per_volume_gigabytes | -1    |
| snapshots            | 10    |
| volumes              | 10    |
+----------------------+-------+
```
AFTER
```
[bastion@bastion ~]$ nova quota-show
+-----------------------------+-------+
| Quota                       | Limit |
+-----------------------------+-------+
| instances                   | 33    |
| cores                       | 33    |
| ram                         | 33333 |
| floating_ips                | 33    |
| fixed_ips                   | 33    |
| metadata_items              | 33    |
| injected_files              | 33    |
| injected_file_content_bytes | 33333 |
| injected_file_path_bytes    | 333   |
| key_pairs                   | 33    |
| security_groups             | 33    |
| security_group_rules        | 33    |
| server_groups               | 33    |
| server_group_members        | 33    |
+-----------------------------+-------+

[bastion@bastion ~]$ neutron quota-show
+---------------------+-------+
| Field               | Value |
+---------------------+-------+
| floatingip          | 33    |
| network             | 33    |
| port                | 33    |
| rbac_policy         | 33    |
| router              | 33    |
| security_group      | 33    |
| security_group_rule | 33    |
| subnet              | 33    |
| subnetpool          | 33    |
+---------------------+-------+

[bastion@bastion ~]$ cinder quota-show 78bd3ce0b75e4b469e6cf3d1ef33ca86
+----------------------+-------+
| Property             | Value |
+----------------------+-------+
| backup_gigabytes     | 33333 |
| backups              | 33    |
| gigabytes            | 33333 |
| per_volume_gigabytes | 33333 |
| snapshots            | 33    |
| volumes              | 33    |
+----------------------+-------+

```
…rk_quotas