### PR TITLE
elasticsearch-plugin: fix local variable 'name' referenced before assignment

### DIFF
--- a/packaging/elasticsearch_plugin.py
+++ b/packaging/elasticsearch_plugin.py
@@ -129,7 +129,7 @@ def install_plugin(module, plugin_bin, plugin_name, version, url, proxy_host, pr
     cmd_args = [plugin_bin, PACKAGE_STATE_MAP["present"], plugin_name]
 
     if version:
-        name = name + '/' + version
+        plugin_name = plugin_name + '/' + version
 
     if proxy_host and proxy_port:
         cmd_args.append("-DproxyHost=%s -DproxyPort=%s" % (proxy_host, proxy_port))


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
packaging/elasticsearch_plugin

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
fatal: [elasticsearch-01]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Shared connection to 192.168.202.2 closed.\r\n", "module_stdout": "Traceback (most recent call last):\r\n  File \"/tmp/ansible_L2tLqc/ansible_module_elasticsearch_plugin.py\", line 208, in <module>\r\n    main()\r\n  File \"/tmp/ansible_L2tLqc/ansible_module_elasticsearch_plugin.py\", line 198, in main\r\n   changed, cmd, out, err = install_plugin(module, plugin_bin, name, version, url, proxy_host, proxy_port, timeout)\r\n  File \"/tmp/ansible_L2tLqc/ansible_module_elasticsearch_plugin.py\", line 132, in install_plugin\r\n    name = name + '/' + version\r\nUnboundLocalError: local variable 'name' referenced before assignment\r\n", "msg": "MODULE FAILURE"}
```