### PR TITLE
Fix issue in adding RAW disk in block storage domain

### DIFF
--- a/cloud/ovirt/ovirt_disks.py
+++ b/cloud/ovirt/ovirt_disks.py
@@ -65,7 +65,10 @@ options:
         default: 'virtio'
     format:
         description:
-            - "Format of the disk. Either copy-on-write or raw."
+            - Specify format of the disk.
+            - If (cow) format is used, disk will by created as sparse, so space will be allocated for the volume as needed, also known as I(thin provision).
+            - If (raw) format is used, disk storage will be allocated right away, also known as I(preallocated).
+            - Note that this option isn't idempotent as it's not currently possible to change format of the disk via API.
         choices: ['raw', 'cow']
     storage_domain:
         description:
@@ -168,6 +171,7 @@ class DisksModule(BaseModule):
             format=otypes.DiskFormat(
                 self._module.params.get('format')
             ) if self._module.params.get('format') else None,
+            sparse=False if self._module.params.get('format') == 'raw' else True,
             provisioned_size=convert_to_bytes(
                 self._module.params.get('size')
             ),
@@ -198,7 +202,6 @@ class DisksModule(BaseModule):
         return (
             equal(self._module.params.get('description'), entity.description) and
             equal(convert_to_bytes(self._module.params.get('size')), entity.provisioned_size) and
-            equal(self._module.params.get('format'), str(entity.format)) and
             equal(self._module.params.get('shareable'), entity.shareable)
         )
 
@@ -234,7 +237,6 @@ def main():
         vm_id=dict(default=None),
         size=dict(default=None),
         interface=dict(default=None,),
-        allocation_policy=dict(default=None),
         storage_domain=dict(default=None),
         profile=dict(default=None),
         format=dict(default=None, choices=['raw', 'cow']),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Ovirt

##### ANSIBLE VERSION

```
ansible 2.3.0 (devel)
```

##### SUMMARY
Ovirt won't allow to add RAW sparse disk in block storage domain and is only available in file based storage domain. By default, sparse option is true in ovirt. So currently the raw disk creation using this module in a block storage domain will fail with error "Disk configuration (RAW Sparse) is incompatible with the storage domain type". 

The commit adds sparse option where user can pass it as "True/False". So while creating RAW disk in block storage domain, we can pass "sparse = False" to make it work.