### PR TITLE
Allow Datadog monitors to be retrieved by id instead of name.

### DIFF
--- a/monitoring/datadog_monitor.py
+++ b/monitoring/datadog_monitor.py
@@ -105,6 +105,11 @@ options:
         required: false
         default: null
         version_added: "2.3"
+    id:
+        description: ["The id of the alert. If set, will be used instead of the name to locate the alert."]
+        required: false
+        default: null
+        version_added: "2.3"
 '''
 
 EXAMPLES = '''
@@ -172,7 +177,8 @@ def main():
             thresholds=dict(required=False, type='dict', default=None),
             tags=dict(required=False, type='list', default=None),
             locked=dict(required=False, default=False, type='bool'),
-            require_full_window=dict(required=False, default=None, type='bool')
+            require_full_window=dict(required=False, default=None, type='bool'),
+            id=dict(required=False)
         )
     )
 
@@ -201,9 +207,16 @@ def _fix_template_vars(message):
 
 
 def _get_monitor(module):
-    for monitor in api.Monitor.get_all():
-        if monitor['name'] == module.params['name']:
-            return monitor
+    if module.params['id'] is not None:
+        monitor = api.Monitor.get(module.params['id'])
+        if 'errors' in monitor:
+            module.fail_json(msg="Failed to retrieve monitor with id %s, errors are %s" % (module.params['id'], str(monitor['errors'])))
+        return monitor
+    else:
+        monitors = api.Monitor.get_all()
+        for monitor in monitors:
+            if monitor['name'] == module.params['name']:
+                return monitor
     return {}
 
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
datadog_monitor

##### ANSIBLE VERSION
```
ansible --version
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
Allow the retrieval of Datadog alerts (monitors) by id instead of retrieving all monitors and then finding the monitor by name in-memory.
We needed to make this change due to performance reasons, our Datadog account has thousands of monitors and the client was starting to time out.
