### PR TITLE
yum_repository: use https:// for EPEL examples

### DIFF
--- a/packaging/os/yum_repository.py
+++ b/packaging/os/yum_repository.py
@@ -400,14 +400,14 @@ EXAMPLES = '''
   yum_repository:
     name: epel
     description: EPEL YUM repo
-    baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
 
 - name: Add multiple repositories into the same file (1/2)
   yum_repository:
     name: epel
     description: EPEL YUM repo
     file: external_repos
-    baseurl: http://download.fedoraproject.org/pub/epel/$releasever/$basearch/
+    baseurl: https://download.fedoraproject.org/pub/epel/$releasever/$basearch/
     gpgcheck: no
 - name: Add multiple repositories into the same file (2/2)
   yum_repository:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Docs Pull Request

##### COMPONENT NAME
yum_repository


This whole module is really lacking in security guidelines, but
downloading RPMs via plain `http://` without gpg is quite bad.  Let's
use `https://` for the EPEL examples for a start.