### PR TITLE
Allow pymongo version 3.2 in combination with mongodb 3.2

### DIFF
--- a/database/misc/mongodb_user.py
+++ b/database/misc/mongodb_user.py
@@ -185,7 +185,7 @@ def check_compatibility(module, client):
     loose_srv_version = LooseVersion(client.server_info()['version'])
     loose_driver_version = LooseVersion(PyMongoVersion)
 
-    if loose_srv_version >= LooseVersion('3.2') and loose_driver_version <= LooseVersion('3.2'):
+    if loose_srv_version >= LooseVersion('3.2') and loose_driver_version < LooseVersion('3.2'):
         module.fail_json(msg=' (Note: you must use pymongo 3.2+ with MongoDB >= 3.2)')
 
     elif loose_srv_version >= LooseVersion('3.0') and loose_driver_version <= LooseVersion('2.8'):


### PR DESCRIPTION
##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
mongodb_user

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
Support using pymongo version 3.2 with mongodb version 3.2 (currently pymongo must be _greater_ than 3.2)
