### PR TITLE
Required and default are mutually exclusive

### DIFF
--- a/cloud/amazon/lambda_event.py
+++ b/cloud/amazon/lambda_event.py
@@ -386,7 +386,7 @@ def main():
         dict(
             state=dict(required=False, default='present', choices=['present', 'absent']),
             lambda_function_arn=dict(required=True, default=None, aliases=['function_name', 'function_arn']),
-            event_source=dict(required=True, default="stream", choices=source_choices),
+            event_source=dict(required=False, default="stream", choices=source_choices),
             source_params=dict(type='dict', required=True, default=None),
             alias=dict(required=False, default=None),
             version=dict(type='int', required=False, default=0),


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
cloud/amazon/lambda_event

##### ANSIBLE VERSION
```
ansible 2.2.0.0 (detached HEAD 44faad0593) last updated 2016/10/13 10:30:44 (GMT -500)
  lib/ansible/modules/core: (detached HEAD d66983b43e) last updated 2016/10/13 10:30:50 (GMT -500)
  lib/ansible/modules/extras: (detached HEAD 35132b892f) last updated 2016/10/13 10:30:50 (GMT -500)
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
Default values and required are mutually exclusive. A reasonable default was already provided so I choose to keep that and set required to False.

```
BEFORE:
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Module alias error: internal error: required and default are mutually exclusive for event_source"}

AFTER:
changed: [localhost]
```

