### PR TITLE
added vDS support for config spec and note/annotation support

### DIFF
--- a/cloud/vmware/vmware_guest.py
+++ b/cloud/vmware/vmware_guest.py
@@ -89,6 +89,11 @@ options:
         description:
             - The esxi hostname where the VM will run.
         required: True
+   annotation:
+        description:
+            - A note or annotation to include in the VM
+        required: False
+        version_added: "2.3"
    customize:
         description:
            - Should customization spec be run
@@ -723,17 +728,18 @@ class PyVmomiHelper(object):
         # lets try and assign a static ip addresss
         if self.params['customize'] is True:
             ip_settings = list()
-            if self.params['ips'] and self.params['network']:
+            if self.params['ips']:
                 for ip_string in self.params['ips']:
                     ip = IPAddress(self.params['ips'])
                     for network in self.params['networks']:
-                        if ip in IPNetwork(network):
-                            self.params['networks'][network]['ip'] = str(ip)
-                            ipnet = IPNetwork(network)
-                            self.params['networks'][network]['subnet_mask'] = str(
-                                ipnet.netmask
-                            )
-                            ip_settings.append(self.params['networks'][network])
+	                if network:
+                            if ip in IPNetwork(network):
+                                self.params['networks'][network]['ip'] = str(ip)
+                                ipnet = IPNetwork(network)
+                                self.params['networks'][network]['subnet_mask'] = str(
+                                  ipnet.netmask
+                                )
+                                ip_settings.append(self.params['networks'][network])
 
             key = 0
             network = get_obj(self.content, [vim.Network], ip_settings[key]['network'])
@@ -764,14 +770,27 @@ class PyVmomiHelper(object):
             nic.device.addressType = 'assigned'
             nic.device.deviceInfo = vim.Description()
             nic.device.deviceInfo.label = 'Network Adapter %s' % (key + 1)
-
             nic.device.deviceInfo.summary = ip_settings[key]['network']
-            nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
-            nic.device.backing.network = get_obj(self.content, [vim.Network], ip_settings[key]['network'])
+            
+            if hasattr(get_obj(self.content, [vim.Network], ip_settings[key]['network']), 'portKeys'):
+            # VDS switch
+                pg_obj = get_obj(self.content, [vim.dvs.DistributedVirtualPortgroup], ip_settings[key]['network'])
+                dvs_port_connection = vim.dvs.PortConnection()
+                dvs_port_connection.portgroupKey= pg_obj.key
+                dvs_port_connection.switchUuid= pg_obj.config.distributedVirtualSwitch.uuid
+                nic.device.backing = vim.vm.device.VirtualEthernetCard.DistributedVirtualPortBackingInfo()
+                nic.device.backing.port = dvs_port_connection 
 
-            nic.device.backing.deviceName = ip_settings[key]['network']
+            else: 
+            # vSwitch
+                nic.device.backing = vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+                nic.device.backing.network = get_obj(self.content, [vim.Network], ip_settings[key]['network'])
+                nic.device.backing.deviceName = ip_settings[key]['network']
+
             nic.device.connectable = vim.vm.device.VirtualDevice.ConnectInfo()
             nic.device.connectable.startConnected = True
+            nic.device.connectable.allowGuestControl = True
+            nic.device.connectable.connected = True
             nic.device.connectable.allowGuestControl = True
             devices.append(nic)
             
@@ -808,13 +827,12 @@ class PyVmomiHelper(object):
             ident.hostName.name = self.params['name']
 
             customspec = vim.vm.customization.Specification()
-            customspec.nicSettingMap = adaptermaps
-            customspec.globalIPSettings = globalip
-            customspec.identity = ident
+            clonespec_kwargs['customization'] = customspec
 
-            clonespec = vim.vm.CloneSpec(**clonespec_kwargs)
-            clonespec.customization = customspec
-
+            clonespec_kwargs['customization'].nicSettingMap = adaptermaps
+            clonespec_kwargs['customization'].globalIPSettings = globalip
+            clonespec_kwargs['customization'].identity = ident
+		
         clonespec = vim.vm.CloneSpec(**clonespec_kwargs)
         task = template.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
         self.wait_for_task(task)
@@ -825,7 +843,13 @@ class PyVmomiHelper(object):
             return ({'changed': False, 'failed': True, 'msg': task.info.error.msg})
         else:
 
+            # set annotation
             vm = task.info.result
+            if self.params['annotation']:
+                annotation_spec = vim.vm.ConfigSpec()
+                annotation_spec.annotation = str(self.params['annotation'])
+                task = vm.ReconfigVM_Task(annotation_spec)
+		self.wait_for_task(task)
             if wait_for_ip:
                 self.set_powerstate(vm, 'poweredon', force=False)
                 self.wait_for_vm_ip(vm)
@@ -1064,6 +1088,7 @@ def main():
                 default='present'),
             validate_certs=dict(required=False, type='bool', default=True),
             template_src=dict(required=False, type='str', aliases=['template']),
+            annotation=dict(required=False, type='str', aliases=['notes']),
             name=dict(required=True, type='str'),
             name_match=dict(required=False, type='str', default='first'),
             uuid=dict(required=False, type='str'),

--- a/cloud/vmware/vmware_guest.py
+++ b/cloud/vmware/vmware_guest.py
@@ -732,7 +732,7 @@ class PyVmomiHelper(object):
                 for ip_string in self.params['ips']:
                     ip = IPAddress(self.params['ips'])
                     for network in self.params['networks']:
-	                if network:
+                        if network:
                             if ip in IPNetwork(network):
                                 self.params['networks'][network]['ip'] = str(ip)
                                 ipnet = IPNetwork(network)
@@ -849,7 +849,7 @@ class PyVmomiHelper(object):
                 annotation_spec = vim.vm.ConfigSpec()
                 annotation_spec.annotation = str(self.params['annotation'])
                 task = vm.ReconfigVM_Task(annotation_spec)
-		self.wait_for_task(task)
+                self.wait_for_task(task)
             if wait_for_ip:
                 self.set_powerstate(vm, 'poweredon', force=False)
                 self.wait_for_vm_ip(vm)

--- a/cloud/vmware/vmware_guest.py
+++ b/cloud/vmware/vmware_guest.py
@@ -832,7 +832,7 @@ class PyVmomiHelper(object):
             clonespec_kwargs['customization'].nicSettingMap = adaptermaps
             clonespec_kwargs['customization'].globalIPSettings = globalip
             clonespec_kwargs['customization'].identity = ident
-		
+
         clonespec = vim.vm.CloneSpec(**clonespec_kwargs)
         task = template.Clone(folder=destfolder, name=self.params['name'], spec=clonespec)
         self.wait_for_task(task)
@@ -855,7 +855,6 @@ class PyVmomiHelper(object):
                 self.wait_for_vm_ip(vm)
             vm_facts = self.gather_facts(vm)
             return ({'changed': True, 'failed': False, 'instance': vm_facts})
-        
 
     def wait_for_task(self, task):
         # https://www.vmware.com/support/developer/vc-sdk/visdk25pubs/ReferenceGuide/vim.Task.html


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - Bugfix Pull Request

##### COMPONENT NAME
vmware_guest.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible --version
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Adds annotation support and extends customization by adding logic to switch between vDS and vSwitch. 
<!---
Adds annotation support and extends customization by adding logic to switch between vDS and vSwitch
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
changed: [localhost] => {
    "changed": true, 
    "failed": false, 
    "instance": {
        "hw_eth15": {
            "addresstype": "assigned", 
            "ipaddresses": [
                "10.19.114.254", 
                "fe80::250:56ff:fe97:76f1"
            ], 
            "label": "Network adapter 1", 
            "macaddress": "00:50:56:97:76:f1", 
            "macaddress_dash": "00-50-56-97-76-f1", 
            "summary": "VM Network"
        }, 
        "hw_guest_full_name": "Red Hat Enterprise Linux 7 (64-bit)", 
        "hw_guest_id": "rhel7_64Guest", 
        "hw_interfaces": [
            "eth15"
        ], 
        "hw_memtotal_mb": 4096, 
        "hw_name": "test02", 
        "hw_power_status": "poweredOn", 
        "hw_processor_count": 2, 
        "hw_product_uuid": "421711f2-933b-c3cd-cd50-69fa74236d54", 
        "ipv4": "10.19.114.254", 
        "ipv6": "fe80::250:56ff:fe97:76f1", 
        "module_hw": true
    }, 
    "invocation": {
        "module_args": {
            "annotation": "master", 
            "cluster": "devel", 
            "customize": true, 
            "datacenter": "Boston", 
            "disk": null, 
            "dns_servers": [
                "10.x.x.5", 
                "10.x.x.2"
            ], 
            "domain": "e2e.bos.redhat.com", 
            "esxi_hostname": null, 
            "folder": "/vm", 
            "force": false, 
            "hardware": {}, 
            "hostname": "test02", 
            "ips": "10.x.x.253", 
            "name": "test02", 
            "name_match": "first", 
            "networks": {
                "10.19.114.0/23": {
                    "gateway": "10.x.x.254", 
                    "ip": "10.x.x.253", 
                    "network": "VM Network", 
                    "subnet_mask": "255.255.254.0"
                }
            }, 
            "nic": null, 
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER", 
            "state": "present", 
            "template": "ansible-template", 
            "template_src": "ansible-template", 
            "username": "administrator@vsphere.local", 
            "uuid": null, 
            "validate_certs": false, 
            "wait_for_ip_address": true
        }, 
        "module_name": "vmware_guest"
    }
}

```

