### PR TITLE
Making yum_repository module compatible with Python 3

### DIFF
--- a/packaging/os/yum_repository.py
+++ b/packaging/os/yum_repository.py
@@ -19,10 +19,10 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 
-import ConfigParser
 import os
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.pycompat24 import get_exception
+from ansible.module_utils.six.moves import configparser
 
 
 DOCUMENTATION = '''
@@ -469,7 +469,7 @@ class YumRepo(object):
     module = None
     params = None
     section = None
-    repofile = ConfigParser.RawConfigParser()
+    repofile = configparser.RawConfigParser()
 
     # List of parameters which will be allowed in the repo file output
     allowed_params = [
@@ -576,7 +576,7 @@ class YumRepo(object):
         if len(self.repofile.sections()):
             # Write data into the file
             try:
-                fd = open(self.params['dest'], 'wb')
+                fd = open(self.params['dest'], 'w')
             except IOError:
                 e = get_exception()
                 self.module.fail_json(


### PR DESCRIPTION
##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

`yum_repository`

##### ANSIBLE VERSION

```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY

This PR is adding compatibility with Python 3. The results for both versions of python:

```
$ cat site.yaml
- name: Testing yumrepo module
  hosts: localhost
  gather_facts: no
  connection: local
  tasks:
    - name: yumrepo module test
      yum_repository:
        name: test
        description: Testing repo
        baseurl: http://test.server
        reposdir: /tmp
$ ansible-playbook -i localhost, --diff -e '{ ansible_python_interpreter: /usr/bin/python2 }' site.yaml

PLAY [Testing yumrepo module] ****************************************************

TASK [yumrepo module test] ****************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0   

$ rm -f /tmp/test.repo
$ ansible-playbook -i localhost, --diff -e '{ ansible_python_interpreter: /usr/bin/python3 }' site.yaml

PLAY [Testing yumrepo module] ****************************************************

TASK [yumrepo module test] ****************************************************
changed: [localhost]

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0
```