### PR TITLE
ec2_snapshot_facts.py - fix: convert owner_ids to a list of strings

### DIFF
--- a/cloud/amazon/ec2_snapshot_facts.py
+++ b/cloud/amazon/ec2_snapshot_facts.py
@@ -172,7 +172,7 @@ from ansible.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
 def list_ec2_snapshots(connection, module):
 
     snapshot_ids = module.params.get("snapshot_ids")
-    owner_ids = module.params.get("owner_ids")
+    owner_ids = map(str, module.params.get("owner_ids"))
     restorable_by_user_ids = module.params.get("restorable_by_user_ids")
     filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-modules-extras/cloud/amazon/ec2_snapshot_facts.py

##### ANSIBLE VERSION
ansible 2.3.0

##### SUMMARY
Fix for the issue #3473 


```
  - name: Get snapshot details
    ec2_snapshot_facts:
      region: eu-west-1
      owner_ids:
        - 740680212471
        - 397995763618
```

Output:
```
ok: [localhost] => {
    "snapshot_facts": {
        "changed": false,
        "snapshots": [
            {
                "description": "Created by CreateImage(i-0xxxxxxxxxxxx) for ami-xxxxxxxxx from vol-xxxxxxx",
                "encrypted": false,
                "owner_id": "740680212471",
                "progress": "100%",
                "snapshot_id": "snap-xxxxxxxx",
                "start_time": "2016-09-28T11:43:02+00:00",
                "state": "completed",
                "volume_id": "vol-xxxxxxxx",
                "volume_size": 8
            },
            {
                "description": "",
                "encrypted": false,
                "owner_id": "397995763618",
                "progress": "100%",
                "snapshot_id": "snap-xxxxxxxx",
                "start_time": "2016-10-26T14:26:48+00:00",
                "state": "completed",
                "tags": {
                    "Name": "Snap1"
                },
                "volume_id": "vol-xxxxxxxx",
                "volume_size": 8
            }
        ]
    }
}
```

