### PR TITLE
Performance improvement using in-operator on dicts

### DIFF
--- a/cloud/misc/rhevm.py
+++ b/cloud/misc/rhevm.py
@@ -715,22 +715,22 @@ class RHEVConn(object):
                 for iface in ifaces:
                     try:
                         setMsg('creating host interface ' + iface['name'])
-                        if 'management' in iface.keys():
+                        if 'management' in iface:
                             manageip = iface['ip']
-                        if 'boot_protocol' not in iface.keys():
-                            if 'ip' in iface.keys():
+                        if 'boot_protocol' not in iface:
+                            if 'ip' in iface:
                                 iface['boot_protocol'] = 'static'
                             else:
                                 iface['boot_protocol'] = 'none'
-                        if 'ip' not in iface.keys():
+                        if 'ip' not in iface:
                             iface['ip'] = ''
-                        if 'netmask' not in iface.keys():
+                        if 'netmask' not in iface:
                             iface['netmask'] = ''
-                        if 'gateway' not in iface.keys():
+                        if 'gateway' not in iface:
                             iface['gateway'] = ''
 
-                        if 'network' in iface.keys():
-                            if 'bond' in iface.keys():
+                        if 'network' in iface:
+                            if 'bond' in iface:
                                 bond = []
                                 for slave in iface['bond']:
                                     bond.append(ifacelist[slave])

--- a/network/haproxy.py
+++ b/network/haproxy.py
@@ -196,10 +196,10 @@ class HAProxy(object):
         """
         Capture the output for a command
         """
-        if not 'command' in self.command_results.keys():
+        if 'command' not in self.command_results:
             self.command_results['command'] = []
         self.command_results['command'].append(cmd)
-        if not 'output' in self.command_results.keys():
+        if 'output' not in self.command_results:
             self.command_results['output'] = []
         self.command_results['output'].append(output)
 

--- a/network/snmp_facts.py
+++ b/network/snmp_facts.py
@@ -153,7 +153,7 @@ def lookup_adminstatus(int_adminstatus):
                             2: 'down',
                             3: 'testing'
                           }
-    if int_adminstatus in adminstatus_options.keys():
+    if int_adminstatus in adminstatus_options:
         return adminstatus_options[int_adminstatus]
     else:
         return ""
@@ -168,7 +168,7 @@ def lookup_operstatus(int_operstatus):
                            6: 'notPresent',
                            7: 'lowerLayerDown'
                          }
-    if int_operstatus in operstatus_options.keys():
+    if int_operstatus in operstatus_options:
         return operstatus_options[int_operstatus]
     else:
         return ""


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Various components

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Just a small cleanup for the existing occurrences.

Using the in-operator for hash lookups is faster than using .keys()
http://stackoverflow.com/questions/29314269/why-do-key-in-dict-and-key-in-dict-keys-have-the-same-output