### PR TITLE
Performance improvement using in-operator for hash lookups

### DIFF
--- a/system/crypttab.py
+++ b/system/crypttab.py
@@ -312,7 +312,7 @@ class Options(dict):
     def add(self, opts_string):
         changed = False
         for k, v in Options(opts_string).items():
-            if self.has_key(k):
+            if k in self:
                 if self[k] != v:
                     changed = True
             else:
@@ -323,7 +323,7 @@ class Options(dict):
     def remove(self, opts_string):
         changed = False
         for k in Options(opts_string):
-            if self.has_key(k):
+            if k in self:
                 del self[k]
                 changed = True
         return changed, 'removed options'
@@ -341,7 +341,7 @@ class Options(dict):
         return iter(self.itemlist)
 
     def __setitem__(self, key, value):
-        if not self.has_key(key):
+        if key not in self:
             self.itemlist.append(key)
         super(Options, self).__setitem__(key, value)
 


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
Various components

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
v2.2

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

Just a small cleanup for the existing occurrences.

Using the in-operator for hash lookups is faster than using .has_key()
http://stackoverflow.com/questions/1323410/has-key-or-in

Fixes ansible/ansible#18505