### PR TITLE
improve example for module ec2_vpc_subnet_facts

### DIFF
--- a/cloud/amazon/ec2_vpc_subnet_facts.py
+++ b/cloud/amazon/ec2_vpc_subnet_facts.py
@@ -65,6 +65,7 @@ EXAMPLES = '''
     - publicA
     - publicB
     - publicC
+  register: subnet_facts
 
 - set_fact:
     subnet_ids: "{{ subnet_facts.results|map(attribute='subnets.0.id')|list }}"


### PR DESCRIPTION
##### ISSUE TYPE
 - Docs Pull Request

##### COMPONENT NAME
ec2_vpc_subnet_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
>= 2.1 (this module is new in version 2.1).
```

##### SUMMARY

Fix the problem that I can't successfully run with exist example.
Improve the example for module ec2_vpc_subnet_facts.
