### PR TITLE
github_release module get asset_url for latest release or specfic release

### DIFF
--- a/source_control/github_release.py
+++ b/source_control/github_release.py
@@ -46,10 +46,12 @@ options:
         choices: [ 'latest_release', 'get_asset_url' ]
     release_version:
         required: False
+        version_added: "2.3"
         description:
             - You can specify and lock down a version of the release you want to target (used in combination with get_asset_url action)
     asset_regex:
         required: False
+        version_added: "2.3"
         description:
             - github opensource projects typically build multi assets per release, this regex will help target a specfic asset in that release
 author:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
github_releases

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This change adds a feature to the github_releases. I'm still working on this but thought I would open a pull request to ensure that the change is worth being merged upstream. 

Sometimes certain opensource applications that share their code on github do not have there packages available (or at all) in specfic operating system package manager repos (apt, yum, pacman) and sometimes the most reliable way to get the latest provide binaries, tars,  rpms are on github. Sometimes its hard to get updates, when you need them.

This change adds the feature of being to download the latest release without having to script out and expand it into multiple tasks. (get latest release version, wget tar)

It works by calling the releases api, find the latest release, and then finding all the associated assets for that specfic release.

I personally feel like this isn't a a clean way to express it within this task. (should be similar to a package manager action=install, state=latest) but a change like that requires me to edit the "API" which will probs break a few modules. I could also move this to new a module, or not contribute upstream at all :)

I'll cc the main contributor to this script so he can see  if it fits :)
\cc @adrianmoisey