### PR TITLE
Fixes #3498 "The variable '$changed' cannot be retrieved because it has not been set." Fixes #3346 Handle supported return codes

### DIFF
--- a/windows/win_robocopy.ps1
+++ b/windows/win_robocopy.ps1
@@ -113,6 +113,7 @@ Set-Attr $result.win_robocopy "return_code" $rc
 Set-Attr $result.win_robocopy "output" $robocopy_output
 
 $cmd_msg = "Success"
+$changed = $false
 If ($rc -eq 0) {
     $cmd_msg = "No files copied."
 }

--- a/windows/win_robocopy.ps1
+++ b/windows/win_robocopy.ps1
@@ -114,32 +114,51 @@ Set-Attr $result.win_robocopy "output" $robocopy_output
 
 $cmd_msg = "Success"
 $changed = $false
-If ($rc -eq 0) {
-    $cmd_msg = "No files copied."
-}
-ElseIf ($rc -eq 1) {
-    $cmd_msg = "Files copied successfully!"
-    $changed = $true
-}
-ElseIf ($rc -eq 2) {
-    $cmd_msg = "Extra files or directories were detected!"
-    $changed = $true
-}
-ElseIf ($rc -eq 4) {
-    $cmd_msg = "Some mismatched files or directories were detected!"
-    $changed = $true
-}
-ElseIf ($rc -eq 8) {
-    $error_msg = SearchForError $robocopy_output "Some files or directories could not be copied!"
-    Fail-Json $result $error_msg
-}
-ElseIf ($rc -eq 10) {
-    $error_msg = SearchForError $robocopy_output "Serious Error! No files were copied! Do you have permissions to access $src and $dest?"
-    Fail-Json $result $error_msg
-}
-ElseIf ($rc -eq 16) {
-    $error_msg = SearchForError $robocopy_output "Fatal Error!"
-    Fail-Json $result $error_msg
+switch ($rc)
+{
+    0 {
+        $cmd_msg = "No files copied."
+    }
+    1 {
+        $cmd_msg = "Files copied successfully!"
+        $changed = $true
+    }
+    2 {
+        $cmd_msg = "Some Extra files or directories were detected. No files were copied."
+        $changed = $true
+    }
+    3 {
+        $cmd_msg = "(2+1) Some files were copied. Additional files were present."
+        $changed = $true
+    }
+    4 {
+        $cmd_msg = "Some mismatched files or directories were detected. Housekeeping might be required!"
+        $changed = $true
+    }
+    5 {
+        $cmd_msg = "(4+1) Some files were copied. Some files were mismatched."
+        $changed = $true
+    }
+    6 {
+        $cmd_msg = "(4+2) Additional files and mismatched files exist. No files were copied."
+        $changed = $true
+    }
+    7 {
+        $cmd_msg = "(4+1+2) Files were copied, a file mismatch was present, and additional files were present."
+        $changed = $true
+    }
+    8 {
+        $error_msg = SearchForError $robocopy_output "Some files or directories could not be copied!"
+        Fail-Json $result $error_msg
+    }
+    { @(9, 10, 11, 12, 13, 14, 15) -contains $_ } {
+        $error_msg = SearchForError $robocopy_output "Fatal error. Check log message!"        
+        Fail-Json $result $error_msg
+    }
+    16 {
+        $error_msg = SearchForError $robocopy_output "Serious Error! No files were copied! Do you have permissions to access $src and $dest?"
+        Fail-Json $result $error_msg
+    }
 }
 
 Set-Attr $result.win_robocopy "msg" $cmd_msg


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
win_robocopy
##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /etc/ansible/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Solve "The variable '$changed' cannot be retrieved because it has not been set." error when I use win_robocopy on windows 2012 r2

Add supported return codes (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before
```
TASK [server : Backup files] ***********************************
task path: server/tasks/main.yml:2
Using module file /usr/lib/python2.7/dist-packages/ansible/modules/extras/windows/win_robocopy.ps1
<192.168.33.20> ESTABLISH WINRM CONNECTION FOR USER: vagrant on PORT 5986 TO 192.168.33.20
<192.168.33.20> EXEC Set-StrictMode -Version Latest
(New-Item -Type Directory -Path $env:temp -Name "ansible-tmp-1479487487.3-247510806404649").FullName | Write-Host -Separator '';
<192.168.33.20> PUT "/tmp/tmpAzBWvQ" TO "C:\Users\vagrant\AppData\Local\Temp\ansible-tmp-1479487487.3-247510806404649\win_robocopy.ps1"
<192.168.33.20> EXEC Set-StrictMode -Version Latest
Try
{
& 'C:\Users\vagrant\AppData\Local\Temp\ansible-tmp-1479487487.3-247510806404649\win_robocopy.ps1'
}
Catch
{
$_obj = @{ failed = $true }
If ($_.Exception.GetType)
{
$_obj.Add('msg', $_.Exception.Message)
}
Else
{
$_obj.Add('msg', $_.ToString())
}
If ($_.InvocationInfo.PositionMessage)
{
$_obj.Add('exception', $_.InvocationInfo.PositionMessage)
}
ElseIf ($_.ScriptStackTrace)
{
$_obj.Add('exception', $_.ScriptStackTrace)
}
Try
{
$_obj.Add('error_record', ($_ | ConvertTo-Json | ConvertFrom-Json))
}
Catch
{
}
Echo $_obj | ConvertTo-Json -Compress -Depth 99
Exit 1
}
Finally { Remove-Item "C:\Users\vagrant\AppData\Local\Temp\ansible-tmp-1479487487.3-247510806404649" -Force -Recurse -ErrorAction SilentlyContinue }
An exception occurred during task execution. The full traceback is:
At C:\Users\vagrant\AppData\Local\Temp\ansible-tmp-1479487487.3-247510806404649\win_robocopy.ps1:392 char:41
+ Set-Attr $result.win_robocopy "changed" $changed
+                                         ~~~~~~~~
fatal: [ids-server-local]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_name": "win_robocopy"
    },
```
After
```
-------------------------------------------------------------------------------
   ROBOCOPY     ::     Robust File Copy for Windows                              
-------------------------------------------------------------------------------

  Started : November 22, 2016 9:34:47 AM
   Source : C:\install
     Dest : C:\install.bak

    Files : *.*
	    
  Options : *.* /S /E /DCOPY:DA /COPY:DAT /PURGE /MIR /R:1000000 /W:30 

------------------------------------------------------------------------------

	                   1	C:\install\

------------------------------------------------------------------------------

               Total    Copied   Skipped  Mismatch    FAILED    Extras
    Dirs :         1         0         0         0         0         0
   Files :         1         0         0         0         0         0
   Bytes :    1.08 m         0    1.08 m         0         0         0
   Times :   0:00:00   0:00:00                       0:00:00   0:00:00
   Ended : November 22, 2016 9:34:47 AM
```

Add $changed = false default value to solve "The variable '$changed' cannot be retrieved because it has not been set." error

Add supported return codes (0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16)