### PR TITLE
ec2_elb_facts module broken when no names are provided (fixes #3514)

### DIFF
--- a/cloud/amazon/ec2_elb_facts.py
+++ b/cloud/amazon/ec2_elb_facts.py
@@ -207,7 +207,7 @@ class ElbInformation(object):
         if all_elbs:
             if self.names:
                 for existing_lb in all_elbs:
-                    if existing_lb.name in self.names:
+                    if self.names is None or existing_lb.name in self.names:
                         elb_array.append(existing_lb)
             else:
                 elb_array = all_elbs


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
ec2_elb_facts

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

This PR Fixes [#3514](https://github.com/ansible/ansible-modules-extras/issues/3514)

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->

```
# Ansible Task
- name: Gather facts about ELBs
  local_action: ec2_elb_facts
  args:
    aws_access_key: 'YourAccessKey.'
    aws_secret_key: 'YourSecretKey'
    region: 'us-east-1'
```

```
### Before
TASK [myrole : Gather facts about ELBs] *****************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: argument of type 'NoneType' is not iterable
fatal: [localhost -> localhost]: FAILED! => {"changed": false, "failed": true, "module_stderr": "Traceback (most recent call last):\n  File \"/tmp/ansible_GfqFBy/ansible_module_ec2_elb_facts.py\", line 245, in <module>\n    main()\n  File \"/tmp/ansible_GfqFBy/ansible_module_ec2_elb_facts.py\", line 237, in main\n    elbs=elb_information.list_elbs())\n  File \"/tmp/ansible_GfqFBy/ansible_module_ec2_elb_facts.py\", line 209, in list_elbs\n    if existing_lb.name in self.names:\nTypeError: argument of type 'NoneType' is not iterable\n", "module_stdout": "", "msg": "MODULE FAILURE"}
```

```
### After
TASK [myrole : Gather facts about ELBs] *****************************
ok: [localhost -> localhost]
```