### PR TITLE
archive: Fix check if archive is created in path to be removed (fixes #3537)

### DIFF
--- a/files/archive.py
+++ b/files/archive.py
@@ -194,8 +194,13 @@ def main():
             arcroot += os.sep
 
         # Don't allow archives to be created anywhere within paths to be removed
-        if remove and os.path.isdir(path) and dest.startswith(path):
-            module.fail_json(path=', '.join(paths), msg='Error, created archive can not be contained in source paths when remove=True')
+        if remove and os.path.isdir(path):
+            path_dir = path
+            if path[-1] != '/':
+                path_dir += '/'
+
+            if dest.startswith(path_dir):
+                module.fail_json(path=', '.join(paths), msg='Error, created archive can not be contained in source paths when remove=True')
 
         if os.path.lexists(path):
             archive_paths.append(path)


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
archive

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file =
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #3537 by appending '/' to `path`, to ensure that `dest` is truly contained in `path`
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```