### PR TITLE
Fixes #3539 "win_robocopy does not return changed properly"

### DIFF
--- a/windows/win_robocopy.ps1
+++ b/windows/win_robocopy.ps1
@@ -22,10 +22,8 @@
 $params = Parse-Args $args;
 
 $result = New-Object psobject @{
-    win_robocopy = New-Object psobject @{
-        recurse         = $false
-        purge           = $false
-    }
+    recurse = $false
+    purge = $false
     changed = $false
 }
 
@@ -70,10 +68,10 @@ if (-Not (Test-Path $src)) {
 }
 
 $robocopy_opts += $src
-Set-Attr $result.win_robocopy "src" $src
+Set-Attr $result "src" $src
 
 $robocopy_opts += $dest
-Set-Attr $result.win_robocopy "dest" $dest
+Set-Attr $result "dest" $dest
 
 if ($flags -eq $null) {
     if ($purge) {
@@ -88,9 +86,9 @@ Else {
     $robocopy_opts += $flags
 }
 
-Set-Attr $result.win_robocopy "purge" $purge
-Set-Attr $result.win_robocopy "recurse" $recurse
-Set-Attr $result.win_robocopy "flags" $flags
+Set-Attr $result "purge" $purge
+Set-Attr $result "recurse" $recurse
+Set-Attr $result "flags" $flags
 
 $robocopy_output = ""
 $rc = 0
@@ -109,8 +107,8 @@ Else {
     }
 }
 
-Set-Attr $result.win_robocopy "return_code" $rc
-Set-Attr $result.win_robocopy "output" $robocopy_output
+Set-Attr $result "return_code" $rc
+Set-Attr $result "output" $robocopy_output
 
 $cmd_msg = "Success"
 If ($rc -eq 0) {
@@ -141,7 +139,7 @@ ElseIf ($rc -eq 16) {
     Fail-Json $result $error_msg
 }
 
-Set-Attr $result.win_robocopy "msg" $cmd_msg
-Set-Attr $result.win_robocopy "changed" $changed
+Set-Attr $result "msg" $cmd_msg
+Set-Attr $result "changed" $changed
 
 Exit-Json $result

--- a/windows/win_robocopy.py
+++ b/windows/win_robocopy.py
@@ -120,7 +120,7 @@ flags:
     returned: always
     type: string
     sample: "/e /purge"
-return_code:
+rc:
     description: The return code retuned by robocopy.
     returned: success
     type: int


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
win_robocopy

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.1.0
  config file = /ansible/ansible_config
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
Fixes #3539 "win_robocopy does not return changed properly":
Remove the win_robocopy object from $result. This brings the code in line with the documentation, and correctly sets the changed attribute.

<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE:
```
ok: [x.x.x.x] => (item=path/to/file.ext) => {
    "changed": false,
    ...
    "win_robocopy": {
        "changed": true
    },
    ...
```

AFTER:
```
changed: [x.x.x.x] => (item=path/to/file.ext) => {
    "changed": true,
    ...
```

I can't copy and paste from my ansible machine so I've manually typed a shortened output. It should still be enough to get the point though.

Also worth noting that this doesn't fix #3498, that will still need to be merged.