### PR TITLE
Get user SID in a way that works on Windows 2012 too (#2933)

### DIFF
--- a/windows/win_acl.ps1
+++ b/windows/win_acl.ps1
@@ -84,6 +84,7 @@ Function UserSearch
             return $apppoolobj.applicationPoolSid
         }
     }
+    Else
     {
         #Search by samaccountname
         $objUser = New-Object System.Security.Principal.NTAccount($accountName)

--- a/windows/win_owner.ps1
+++ b/windows/win_owner.ps1
@@ -48,7 +48,7 @@ Function UserSearch
 
     if ($searchDomain -eq $false)
     {
-        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
+        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
         $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $accountName}
         if ($localaccount)
         {
@@ -58,29 +58,11 @@ Function UserSearch
     Else
     {
         #Search by samaccountname
-        $Searcher = [adsisearcher]""
-
-        If ($searchDomainUPN -eq $false) {
-            $Searcher.Filter = "sAMAccountName=$($accountName)"
-        }
-        Else {
-            $Searcher.Filter = "userPrincipalName=$($accountName)"
-        }
-
-        $result = $Searcher.FindOne() 
-        if ($result)
-        {
-            $user = $result.GetDirectoryEntry()
-
-            # get binary SID from AD account
-            $binarySID = $user.ObjectSid.Value
-
-            # convert to string SID
-            return (New-Object System.Security.Principal.SecurityIdentifier($binarySID,0)).Value
-        }
+        $objUser = New-Object System.Security.Principal.NTAccount($accountName)
+        return $objUser.Translate([System.Security.Principal.SecurityIdentifier]).Value
     }
 }
- 
+
 $params = Parse-Args $args;
 
 $result = New-Object PSObject;

--- a/windows/win_share.ps1
+++ b/windows/win_share.ps1
@@ -48,7 +48,7 @@ Function UserSearch
 
     if ($searchDomain -eq $false)
     {
-        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
+        # do not use Win32_UserAccount, because e.g. SYSTEM (BUILTIN\SYSTEM or COMPUTERNAME\SYSTEM) will not be listed. on Win32_Account groups will be listed too
         $localaccount = get-wmiobject -class "Win32_Account" -namespace "root\CIMV2" -filter "(LocalAccount = True)" | where {$_.Caption -eq $accountName}
         if ($localaccount)
         {
@@ -58,26 +58,8 @@ Function UserSearch
     Else
     {
         #Search by samaccountname
-        $Searcher = [adsisearcher]""
-
-        If ($searchDomainUPN -eq $false) {
-            $Searcher.Filter = "sAMAccountName=$($accountName)"
-        }
-        Else {
-            $Searcher.Filter = "userPrincipalName=$($accountName)"
-        }
-
-        $result = $Searcher.FindOne() 
-        if ($result)
-        {
-            $user = $result.GetDirectoryEntry()
-
-            # get binary SID from AD account
-            $binarySID = $user.ObjectSid.Value
-
-            # convert to string SID
-            return (New-Object System.Security.Principal.SecurityIdentifier($binarySID,0)).Value
-        }
+        $objUser = New-Object System.Security.Principal.NTAccount($accountName)
+        return $objUser.Translate([System.Security.Principal.SecurityIdentifier]).Value
     }
 }
 Function NormalizeAccounts
@@ -224,7 +206,7 @@ Try {
                 }
             }
         }
-        
+
         # add missing permissions
         ForEach ($user in $permissionRead) {
             Grant-SmbShareAccess -Force -Name $name -AccountName $user -AccessRight "Read"


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
- win_acl
- win_owner
- win_share

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.3.0 (devel 43714f859a) last updated 2016/11/25 12:46:09 (GMT +200)
  lib/ansible/modules/core: (detached HEAD dedfe2becf) last updated 2016/11/25 12:46:38 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 43bb97bc37) last updated 2016/11/25 12:55:29 (GMT +200)
  config file = /home/jswetzen/vagrant/ansible.cfg
  configured module search path = Default w/o overrides
```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
ADSISearcher is not allowed to be used remotely on Windows Server 2012 R2, at least not without specific credentials. Hence, these components fail when trying to get the user SID. In the referenced issue #2933, @Vye proposed this way of getting the SID instead. It's shorter and works remotely.

I have verified that the SID is correctly identified in the different cases for $accountName:
- If the User Principal Name is used, user@domain
- If the account is specified as domain\user
- If the domain is the computer name (that case is not affected)
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
ansible 2.3.0 (devel 43714f859a) last updated 2016/11/25 12:46:09 (GMT +200)
  lib/ansible/modules/core: (detached HEAD dedfe2becf) last updated 2016/11/25 12:46:38 (GMT +200)
  lib/ansible/modules/extras: (detached HEAD 9d76271ef1) last updated 2016/11/25 12:56:36 (GMT +200)
  config file = /home/jswetzen/vagrant/ansible.cfg
  configured module search path = Default w/o overrides
```

