### PR TITLE
Fix name/package parameter convert when passed list of values using with_items

### DIFF
--- a/packaging/os/portage.py
+++ b/packaging/os/portage.py
@@ -434,7 +434,7 @@ portage_absent_states = ['absent', 'unmerged', 'removed']
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            package=dict(default=None, aliases=['name']),
+            package=dict(default=None, aliases=['name'], type='list'),
             state=dict(
                 default=portage_present_states[0],
                 choices=portage_present_states + portage_absent_states,
@@ -475,7 +475,7 @@ def main():
 
     packages = []
     if p['package']:
-        packages.extend(p['package'].split(','))
+        packages.extend(p['package'])
 
     if p['depclean']:
         if packages and p['state'] not in portage_absent_states:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
Packaging plugin for gentoo: packaging/os/portage.py

##### ANSIBLE VERSION
```
ansible 2.2.0.0
  config file = 
  configured module search path = Default w/o overrides
```

##### SUMMARY
task file:

```
% cat roles/mysql/tasks/main.yml 
---
- name: check mysql packages
  package: name={{ item }} state=present
  with_items:
      - "{{ mysql_server_package }}"
      - "{{ mysql_python_package }}"
```

Ansible output:
```
failed: [servername] (item=[u'mysql', u'mysql-python']) => {
    "cmd": [
        "/usr/bin/emerge",
        "--ask=n",
        "['mysql'",
        " 'mysql-python']"
    ],
    "failed": true,
    "invocation": {
        "module_args": {
            "changed_use": false,
            "deep": false,
            "depclean": false,
            "getbinpkg": false,
            "name": [                                                                                                                                      
                "mysql", 
                "mysql-python"
            ], 
            "newuse": false, 
            "nodeps": false, 
            "noreplace": false, 
            "oneshot": false, 
            "onlydeps": false, 
            "package": "['mysql', 'mysql-python']", 
            "quiet": false, 
            "state": "present", 
            "sync": null, 
            "update": false, 
            "usepkg": false, 
            "usepkgonly": false, 
            "verbose": false
        }
    }, 
    "item": [
        "mysql", 
        "mysql-python"
    ], 
    "msg": "Packages not installed.", 
    "rc": 1, 
    "stderr": "!!! '['mysql'' is not a valid package atom.\n!!! Please check ebuild(5) for full details.\n", 
    "stdout": "", 
    "stdout_lines": []
}
```

List parameter is converted to string and then split by ',', so we get list with values "['mysql'" and "'mysql-python']". In fix I've just set explicit parameter type to 'list' and remove split by ',' because in case of explicit type it will be always a list.

Now output looks like:
```
ok: [servername] => (item=[u'mysql', u'mysql-python']) => {
    "changed": false,
    "invocation": {
        "module_args": {
            "changed_use": false,        
            "deep": false,
            "depclean": false,
            "getbinpkg": false,
            "name": [
                "mysql",
                "mysql-python"
            ],
            "newuse": false,
            "nodeps": false,
            "noreplace": false,
            "oneshot": false,
            "onlydeps": false,
            "package": [           
                "mysql",
                "mysql-python"      
            ],                       
            "quiet": false,
            "state": "present",
            "sync": null, 
            "update": false, 
            "usepkg": false, 
            "usepkgonly": false, 
            "verbose": false
        }
    }, 
    "item": [
        "mysql", 
        "mysql-python"
    ], 
    "msg": "Packages already present."
}
```