### PR TITLE
[ovirt_disks] Check if value provided for  vm_id and vm_name instead of checking for key

### DIFF
--- a/cloud/ovirt/ovirt_disks.py
+++ b/cloud/ovirt/ovirt_disks.py
@@ -280,7 +280,7 @@ def main():
             ret = disks_module.remove()
 
         # If VM was passed attach/detach disks to/from the VM:
-        if 'vm_id' in module.params or 'vm_name' in module.params and state != 'absent':
+        if module.params.get('vm_id') is not None or module.params.get('vm_name') is not None and state != 'absent':
             vms_service = connection.system_service().vms_service()
 
             # If `vm_id` isn't specified, find VM by name:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ovirt_disks

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0
  config file = /home/fabian/code/redhat/rhci/ansible-ovirt/ansible.cfg
  configured module search path = Default w/o overrides

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
I wanted to create disks that were unattached from a VM, so I used a configuration like this: 
```
- name: create disk
      ovirt_disks:
        name: my_disk
        state: present
        format: cow
        size: 15GiB
        auth: '{{ ovirt_auth }}'
        storage_domain: 'my_data_storage'
        interface: virtio
        wait: true
```
but this threw an error saying that the VM could not be found. I looked into the code and noticed that the check for whether or not vm information was provided was this:
```
'vm_id' in module.params or 'vm_name' in module.params and state != 'absent'
```
which would only check the keys of `module.params`, which will always have `vm_id` and `vm_name` in it. Simplified example of the issue below:
```python
my_dict = {'a': None}
'a' in my_dict  # True
'a' in my_dict.keys()  # True, equivalent to above
```
I replaced the `'vm_id' in module.params` with `module.params.get('vm_id') is not None`, which should be `False` when vm_id is not provided by the user. I used `is not None` rather than relying on python false-iness because I wasn't sure if disk names like `0` or empty string should count as the user not providing them.
<!---
If you are fixing an existing issue, please include "Fixes #nnnn" in your commit
message and your description; but you should still explain what the change does.
-->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```
ansible-playbook -i 'x1.example.org,' disk_test.yml --private-key=`s vagrant`                                   git:master

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [x1.example.org]

TASK [do the ovirt auth thing] *************************************************
ok: [x1.example.org]

TASK [create disk] *************************************************************
fatal: [x1.example.org]: FAILED! => {"changed": false, "failed": true, "msg": "VM don't exists, please create it first."}
        to retry, use: --limit @/home/fabian/code/redhat/rhci/ansible-ovirt/disk_test.retry

PLAY RECAP *********************************************************************
x1.example.org             : ok=2    changed=0    unreachable=0    failed=1

```


After:
```
ansible-playbook -i 'x1.example.org,' disk_test.yml --private-key=`s vagrant`                                   git:master

PLAY [all] *********************************************************************

TASK [setup] *******************************************************************
ok: [x1.example.org]

TASK [do the ovirt auth thing] *************************************************
ok: [x1.example.org]

TASK [create disk] *************************************************************
changed: [x1.example.org]

PLAY RECAP *********************************************************************
x1.example.org             : ok=3    changed=1    unreachable=0    failed=0
```
