### PR TITLE
Add 'state=obtain' for consul_kv module

### DIFF
--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -199,11 +199,16 @@ def lock(module, state):
 
     changed = not existing or (existing and existing['Value'] != value)
     if changed and not module.check_mode:
-        changed = consul_api.kv.put(key, value,
-                                    cas=module.params.get('cas'),
-                                    release=session,
-                                    flags=module.params.get('flags'))
-
+        if state == 'acquire':
+            changed = consul_api.kv.put(key, value,
+                                        cas=module.params.get('cas'),
+                                        acquire=session,
+                                        flags=module.params.get('flags'))
+        else:
+            changed = consul_api.kv.put(key, value,
+                                        cas=module.params.get('cas'),
+                                        release=session,
+                                        flags=module.params.get('flags'))
     module.exit_json(changed=changed,
                      index=index,
                      key=key)

--- a/clustering/consul_kv.py
+++ b/clustering/consul_kv.py
@@ -180,7 +180,7 @@ def get_value(module):
                          value=data['Value'],
                          data=data)
     except Exception as e:
-        module.exit_json(msg="Key does not exist %s" % e)
+        module.fail_json(msg="Consul key does not exist. %s" % e)
 
 def lock(module, state):
 


### PR DESCRIPTION
##### ISSUE TYPE
 - New Module Pull Request

##### COMPONENT NAME
consul_kv

##### ANSIBLE VERSION
```
2.2.1.0
```

##### SUMMARY
There doesn't seem to be an easy way to grab existing values from Consul keys.  I have configurations that are added to consul via other sources and would like Ansible to grab those values to use for configurations or perhaps to run certain tasks or not.
```
- name: Get value from Consul key
  consul_kv:
    key: foo
    state: obtain
  register: key
- name: Output
  debug: msg="value={{ key.value }}"
```
