### PR TITLE
Katello module support for repository_sets without a releasever

### DIFF
--- a/infrastructure/foreman/katello.py
+++ b/infrastructure/foreman/katello.py
@@ -241,7 +241,7 @@ class NailGun(object):
             e = get_exception()
             
             if "Import is the same as existing data" in e.message:
-                return True
+                return False
             else:
                 self._module.fail_json(msg="Manifest import failed with %s" % e)
 
@@ -304,7 +304,7 @@ class NailGun(object):
             formatted_name = [params['name'].replace('(', '').replace(')', '')]
             formatted_name.append(params['basearch'])
 
-            if params['releasever']:
+            if 'releasever' in params:
                 formatted_name.append(params['releasever'])
 
             formatted_name = ' '.join(formatted_name)
@@ -315,7 +315,10 @@ class NailGun(object):
             repository = repository.search()
 
             if len(repository) == 0:
-                reposet.enable(data={'basearch': params['basearch'], 'releasever': params['releasever']})
+                if 'releasever' in params:
+                     reposet.enable(data={'basearch': params['basearch'], 'releasever': params['releasever']})
+                else:
+                    reposet.enable(data={'basearch': params['basearch']})
 
         return True
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
katello

##### ANSIBLE VERSION
```
ansible 2.3.0
```

##### SUMMARY
The existing logic will fail to add a katello/satellite repository set if that repository set does not have a release version. Some repository sets, like the satellite tools set, do not have a release version. By adding some conditionals we can also support these types of repository sets.

```
"WARNING:nailgun.client:Received HTTP 422 response: {\"displayMessage\":\"[\\\"releasever\\\"] cannot be specified for Red Hat Satellite Tools 6.2 (for RHEL 6 Server) (RPMs) as that information is not substituable
```

- Allow support of repository_sets that do not have a releasever, like the
Red Hat Satellite Tools 6.2 for RHEL 7 Server RPMs x86_64 set.