### PR TITLE
Use dbus only if it is present

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -520,7 +520,8 @@ class Nmcli(object):
 
     platform='Generic'
     distribution=None
-    bus=dbus.SystemBus()
+    if HAVE_DBUS:
+        bus=dbus.SystemBus()
     # The following is going to be used in dbus code
     DEVTYPES={1: "Ethernet",
                    2: "Wi-Fi",


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
network/nmcli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2
```

##### SUMMARY
Call dbus subfunction only if the dbus library is present, otherwise the following error appears:

```
NameError: name 'dbus' is not defined
```