### PR TITLE
Avoid extending a class if it does not exists

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -164,22 +164,20 @@ import copy
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
 
+    # Extend the ZabbixAPI
+    # Since the zabbix-api python module too old (version 1.0, no higher version so far),
+    # it does not support the 'hostinterface' api calls,
+    # so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
+    class ZabbixAPIExtends(ZabbixAPI):
+        hostinterface = None
+
+        def __init__(self, server, timeout, user, passwd, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+            self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
+
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
-
-
-# Extend the ZabbixAPI
-# Since the zabbix-api python module too old (version 1.0, no higher version so far),
-# it does not support the 'hostinterface' api calls,
-# so we have to inherit the ZabbixAPI class to add 'hostinterface' support.
-class ZabbixAPIExtends(ZabbixAPI):
-    hostinterface = None
-
-    def __init__(self, server, timeout, user, passwd, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
-        self.hostinterface = ZabbixAPISubClass(self, dict({"prefix": "hostinterface"}, **kwargs))
-
 
 class Host(object):
     def __init__(self, module, zbx):

--- a/monitoring/zabbix_hostmacro.py
+++ b/monitoring/zabbix_hostmacro.py
@@ -103,16 +103,15 @@ import copy
 try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
 
+    # Extend the ZabbixAPI
+    # Since the zabbix-api python module too old (version 1.0, no higher version so far).
+    class ZabbixAPIExtends(ZabbixAPI):
+        def __init__(self, server, timeout, user, passwd, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
-
-
-# Extend the ZabbixAPI
-# Since the zabbix-api python module too old (version 1.0, no higher version so far).
-class ZabbixAPIExtends(ZabbixAPI):
-    def __init__(self, server, timeout, user, passwd, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
 
 
 class HostMacro(object):

--- a/monitoring/zabbix_screen.py
+++ b/monitoring/zabbix_screen.py
@@ -143,21 +143,20 @@ try:
     from zabbix_api import ZabbixAPI, ZabbixAPISubClass
     from zabbix_api import ZabbixAPIException
     from zabbix_api import Already_Exists
+
+    # Extend the ZabbixAPI
+    # Since the zabbix-api python module too old (version 1.0, and there's no higher version so far), it doesn't support the 'screenitem' api call,
+    # we have to inherit the ZabbixAPI class to add 'screenitem' support.
+    class ZabbixAPIExtends(ZabbixAPI):
+        screenitem = None
+
+        def __init__(self, server, timeout, user, passwd, **kwargs):
+            ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
+            self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
+
     HAS_ZABBIX_API = True
 except ImportError:
     HAS_ZABBIX_API = False
-
-
-# Extend the ZabbixAPI
-# Since the zabbix-api python module too old (version 1.0, and there's no higher version so far), it doesn't support the 'screenitem' api call,
-# we have to inherit the ZabbixAPI class to add 'screenitem' support.
-class ZabbixAPIExtends(ZabbixAPI):
-    screenitem = None
-
-    def __init__(self, server, timeout, user, passwd, **kwargs):
-        ZabbixAPI.__init__(self, server, timeout=timeout, user=user, passwd=passwd)
-        self.screenitem = ZabbixAPISubClass(self, dict({"prefix": "screenitem"}, **kwargs))
-
 
 class Screen(object):
     def __init__(self, module, zbx):


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
monitoring/zabbix_*

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
2.2
```

##### SUMMARY
Do not make python fail badly if the extended class is non existent

Otherwise the following error is thrown:
```
NameError: name 'ZabbixAPI' is not defined
```

