### PR TITLE
 swdepot.py : filter swlist header

### DIFF
--- a/packaging/os/swdepot.py
+++ b/packaging/os/swdepot.py
@@ -89,9 +89,9 @@ def query_package(module, name, depot=None):
 
     cmd_list = '/usr/sbin/swlist -a revision -l product'
     if depot:
-        rc, stdout, stderr = module.run_command("%s -s %s %s | grep %s" % (cmd_list, pipes.quote(depot), pipes.quote(name), pipes.quote(name)), use_unsafe_shell=True)
+        rc, stdout, stderr = module.run_command("%s -s %s %s | grep -v \# | grep %s" % (cmd_list, pipes.quote(depot), pipes.quote(name), pipes.quote(name)), use_unsafe_shell=True)
     else:
-        rc, stdout, stderr = module.run_command("%s %s | grep %s" % (cmd_list, pipes.quote(name), pipes.quote(name)), use_unsafe_shell=True)
+        rc, stdout, stderr = module.run_command("%s %s | grep -v \# | grep %s" % (cmd_list, pipes.quote(name), pipes.quote(name)), use_unsafe_shell=True)
     if rc == 0:
         version = re.sub("\s\s+|\t" , " ", stdout).strip().split()[1]
     else:


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
packaging/os/swdepot.py 

##### ANSIBLE VERSION
```
ansible 2.2.0.0
```

##### SUMMARY
swlist add a header that could match package name.
Real example : "tar" that match "target"

```
$swlist -a revision -l product tar | grep tar
# Contacting target "yrvm08"...
  tar   1.29
```

So filtering it via "grep -v \#"
```
$ swlist -a revision -l product tar | grep -v \# |  grep tar
  tar   1.29
```
