### PR TITLE
Fix the usage of map since converting to using python six package

### DIFF
--- a/network/f5/bigip_virtual_server.py
+++ b/network/f5/bigip_virtual_server.py
@@ -250,7 +250,7 @@ def set_rules(api, name, rules_list):
         return False
     rules_list = list(enumerate(rules_list))
     try:
-        current_rules = map(lambda x: (x['priority'], x['rule_name']), get_rules(api, name))
+        current_rules = list(map(lambda x: (x['priority'], x['rule_name']), get_rules(api, name)))
         to_add_rules = []
         for i, x in rules_list:
             if (i, x) not in current_rules:


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->
network/f5/bigip_virtual_server.py

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 1.9.2
  configured module search path = None
```

##### SUMMARY
six changed the map function to return an iterable. So we need to
send that through the list method to get the value we need