### PR TITLE
Correct BOTO3 detection in `ec2_group_facts`

### DIFF
--- a/cloud/amazon/ec2_group_facts.py
+++ b/cloud/amazon/ec2_group_facts.py
@@ -102,7 +102,7 @@ try:
     from botocore.exceptions import ClientError
     HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = Falsentry
+    HAS_BOTO3 = False
 
 import traceback
 


### PR DESCRIPTION
##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
`ec2_group_facts`

##### ANSIBLE VERSION
Head of `devel`

##### SUMMARY
Made the code actually work when `boto3` was not installed

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>