### PR TITLE
Add force param to Katello promote action

### DIFF
--- a/infrastructure/foreman/katello.py
+++ b/infrastructure/foreman/katello.py
@@ -414,6 +414,10 @@ class NailGun(object):
         version = self.find_content_view_version(params['name'], params['organization'], params['from_environment'])
 
         data = {'environment_id': to_environment.id}
+
+        if 'force' in params.keys():
+            data['force'] = params['force']
+
         return version.promote(data=data)
 
     def lifecycle_environment(self, params):


### PR DESCRIPTION
##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request

##### COMPONENT NAME
infrastructure/foreman/katello

##### SUMMARY
Adds the force parameter for promoting a content view in Katello across environments that are not sequential.
