### PR TITLE
nmcli: implement vlan connections

### DIFF
--- a/network/nmcli.py
+++ b/network/nmcli.py
@@ -988,6 +988,16 @@ class Nmcli(object):
             cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
+    def modify_connection_disable_ipv4(self):
+        cmd=[self.module.get_bin_path('nmcli', True)]
+        cmd.extend(['con', 'mod', self.conn_name, 'ipv4.method', 'disabled'])
+        return cmd
+
+    def modify_connection_disable_ipv6(self):
+        cmd=[self.module.get_bin_path('nmcli', True)]
+        cmd.extend(['con', 'mod', self.conn_name, 'ipv6.method', 'ignore'])
+        return cmd
+
     def create_connection_bridge(self):
         cmd=[self.module.get_bin_path('nmcli', True)]
         # format for creating bridge interface
@@ -1001,11 +1011,91 @@ class Nmcli(object):
     def create_connection_vlan(self):
         cmd=[self.module.get_bin_path('nmcli', True)]
         # format for creating ethernet interface
+        # To add a Vlan connection with static IP configuration, issue a command as follows
+        # - nmcli: name=add conn_name=my-vlan1 ifname=vlan1 vlandev=eth0 vlanid=1 type=vlan ip4=192.0.2.100/24 gw4=192.0.2.1 state=present
+        # nmcli con add con-name my-vlan1 ifname vlan1 type vlan dev eth0 id 1 ip4 192.0.2.100/24 gw4 192.0.2.1
+        cmd.append('con')
+        cmd.append('add')
+        cmd.append('type')
+        cmd.append('vlan')
+
+        cmd.append('con-name')
+        if self.conn_name is not None:
+            cmd.append(self.conn_name)
+        elif self.ifname is not None:
+            cmd.append(self.ifname)
+        else:
+            cmd.append("vlan%s" % self.vlanid)
+
+        cmd.append('ifname')
+        if self.ifname is not None:
+            cmd.append(self.ifname)
+        elif self.conn_name is not None:
+            cmd.append(self.conn_name)
+        else:
+            cmd.append("vlan%s" % self.vlanid)
+
+        assert self.vlandev, "vlandev required"
+        cmd.append('dev')
+        cmd.append(self.vlandev)
+
+        assert self.vlanid, "vlanid required"
+        cmd.append('id')
+        cmd.append(self.vlanid)
+
+        if self.ip4 is not None:
+            cmd.append('ip4')
+            cmd.append(self.ip4)
+        if self.gw4 is not None:
+            cmd.append('gw4')
+            cmd.append(self.gw4)
+        if self.ip6 is not None:
+            cmd.append('ip6')
+            cmd.append(self.ip6)
+        if self.gw6 is not None:
+            cmd.append('gw6')
+            cmd.append(self.gw6)
+        if self.autoconnect is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def modify_connection_vlan(self):
         cmd=[self.module.get_bin_path('nmcli', True)]
         # format for modifying ethernet interface
+        cmd.append('con')
+        cmd.append('mod')
+        cmd.append(self.conn_name)
+
+        if self.vlandev is not None:
+            cmd.append('vlan.parent')
+            cmd.append(self.vlandev)
+
+        if self.vlanid is not None:
+            cmd.append('vlan.id')
+            cmd.append(self.vlanid)
+
+        if self.ip4 is not None:
+            cmd.append('ipv4.address')
+            cmd.append(self.ip4)
+        if self.gw4 is not None:
+            cmd.append('ipv4.gateway')
+            cmd.append(self.gw4)
+        if self.dns4 is not None:
+            cmd.append('ipv4.dns')
+            cmd.append(self.dns4)
+        if self.ip6 is not None:
+            cmd.append('ipv6.address')
+            cmd.append(self.ip6)
+        if self.gw6 is not None:
+            cmd.append('ipv6.gateway')
+            cmd.append(self.gw6)
+        if self.dns6 is not None:
+            cmd.append('ipv6.dns')
+            cmd.append(self.dns6)
+        if self.autoconnect is not None:
+            cmd.append('autoconnect')
+            cmd.append(self.bool_to_string(self.autoconnect))
         return cmd
 
     def create_connection(self):
@@ -1061,6 +1151,15 @@ class Nmcli(object):
             cmd=self.create_connection_bridge()
         elif self.type=='vlan':
             cmd=self.create_connection_vlan()
+            # if no dns given, we assume that IPv4/IPv6 is not used
+            # on the interface and we need to disable protocol,
+            # otherwise the interface won't come up
+            if self.dns4 is None:
+                self.execute_command(cmd)
+                cmd = self.modify_connection_disable_ipv4()
+            if self.dns6 is None:
+                self.execute_command(cmd)
+                cmd = self.modify_connection_disable_ipv6()
         return self.execute_command(cmd)
 
     def remove_connection(self):


### PR DESCRIPTION
##### ISSUE TYPE
 - Feature Pull Request

##### COMPONENT NAME
<!--- Name of the plugin/module/task -->

nmcli

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```
ansible 2.2.0.0

```

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Fixes #2045 (at least partially) ... documentation of nmcli module states parameters for creating vlan interfaces but it hasn't been implemented yet.

TODO / still open: 

- repeated execution always reports "changed", and would apply `nmcli con mod ...` even if nothing needs to be changed

<!--- Paste verbatim command output below, e.g. before and after your change -->

