### PR TITLE
correct a tipo where defaul= should be default= and causes error like…

### DIFF
--- a/cloud/ovirt/ovirt_vms.py
+++ b/cloud/ovirt/ovirt_vms.py
@@ -766,7 +766,7 @@ def main():
         force=dict(type='bool', default=False),
         nics=dict(default=[], type='list'),
         cloud_init=dict(type='dict'),
-        cloud_init_nics=dict(defaul=[], type='list'),
+        cloud_init_nics=dict(default=[], type='list'),
         sysprep=dict(type='dict'),
         host=dict(default=None),
         clone=dict(type='bool', default=False),


### PR DESCRIPTION
# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html

… 'NoneType' object has no attribute 'append';