### PR TITLE
add tip for installing zabbix-api

### DIFF
--- a/monitoring/zabbix_host.py
+++ b/monitoring/zabbix_host.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
 module: zabbix_host
 short_description: Zabbix host creates/updates/deletes
 description:
-   - This module allows you to create, modify and delete Zabbix host entries and associated group and template data.
+   - This module allows you to create, modify and delete Zabbix host entries and associated group and template data. You need to install zabbix-api :  sudo apt install python-pip; pip install zabbix-api 
 version_added: "2.0"
 author:
     - "(@cove)"


### PR DESCRIPTION
hello,
it was difficult to find how to install zabbix api

I add a tip in the doc for that. I do not know if it is the best place.

Tested on ubuntu 16.10:

sudo apt install python-pip 

pip install zabbix-api

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html
