### PR TITLE
Added feature to allow ignoring extra network devices during the

### DIFF
--- a/cloud/lxd/lxd_container.py
+++ b/cloud/lxd/lxd_container.py
@@ -101,6 +101,11 @@ options:
             starting or restarting.
         required: false
         default: false
+    wait_for_ipv4_addresses_ignore_devices:
+        description:
+          - This will add additional devices to the ignore list which
+            currently only ignores the loopback device "lo".
+        required: false
     force_stop:
         description:
           - If this is true, the M(lxd_container) forces to stop the container
@@ -301,6 +306,7 @@ class LXDContainerManagement(object):
 
         self.timeout = self.module.params['timeout']
         self.wait_for_ipv4_addresses = self.module.params['wait_for_ipv4_addresses']
+        self.wait_for_ipv4_addresses_ignore_devices = self.module.params['wait_for_ipv4_addresses_ignore_devices']
         self.force_stop = self.module.params['force_stop']
         self.addresses = None
 
@@ -380,6 +386,8 @@ class LXDContainerManagement(object):
         self.actions.append('unfreez')
 
     def _container_ipv4_addresses(self, ignore_devices=['lo']):
+        if self.wait_for_ipv4_addresses_ignore_devices: 
+            ignore_devices = ['lo'] + self.wait_for_ipv4_addresses_ignore_devices
         resp_json = self._get_container_state_json()
         network = resp_json['metadata']['network'] or {}
         network = dict((k, v) for k, v in network.items() if k not in ignore_devices) or {}
@@ -582,6 +590,9 @@ def main():
             wait_for_ipv4_addresses=dict(
                 type='bool',
                 default=False
+            ),
+            wait_for_ipv4_addresses_ignore_devices=dict(
+                type='list',
             ),
             force_stop=dict(
                 type='bool',


### PR DESCRIPTION
optional wait period specified by "wait_for_ipv4_addresses"

# This repository is locked

Please open all new issues and pull requests in https://github.com/ansible/ansible

For more information please see http://docs.ansible.com/ansible/dev_guide/repomerge.html
