### PR TITLE
Removed whitespace from 'mb' disk size

### DIFF
--- a/cloud/vmware/vmware_guest.py
+++ b/cloud/vmware/vmware_guest.py
@@ -771,7 +771,7 @@ class PyVmomiHelper(object):
                     kb = expected * 1024 * 1024 * 1024
                 elif unit == 'gb':
                     kb = expected * 1024 * 1024
-                elif unit ==' mb':
+                elif unit =='mb':
                     kb = expected * 1024
                 elif unit == 'kb':
                     kb = expected


### PR DESCRIPTION
current upstream fails when a disk spec contains 'size_mb' as it's actually looking for ' mb' when processing the disk specification  - this commit fixes that
